### PR TITLE
docs: replace ASCII diagrams with images and align tool/spec names with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ See [Architecture](docs/en/architecture.md) for details.
 - **Authorization**: Resource-level RBAC enforced at API and storage layers
 - **Encryption**: S3 server-side encryption (SSE-S3), DynamoDB encryption at rest
 - **Network**: CloudFront with OAI for static assets, API Gateway with Cognito authorizer
-- **AI Safety**: LLM outputs are clearly labeled; see `docs/internal/DATASET_COMPLIANCE.md`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,17 +28,8 @@ Spec-driven presentation applies the concept of Spec-Driven Development from sof
 
 ### Workflow
 
-```
-Phase 1                    Phase 2                    Phase 3
-Spec                       Build Slides               Generate + Review
 
-┌──────────────────┐    ┌────────────────┐      ┌────────────────┐
-│ Briefing         │    │                │      │ Generate PPTX  │
-│ Outline          │───▶│ Build slides   │─────▶│ Visual review  │
-│ Art direction    │    │                │      │ Polish         │
-└──────────────────┘    └────────────────┘      └────────────────┘
-  User dialogue            specs/ → JSON            PPTX + Preview
-```
+![workflow](./docs/assets/workflow-en.png)
 
 ---
 
@@ -101,6 +92,7 @@ See [Architecture](docs/en/architecture.md) for details.
 - **Authorization**: Resource-level RBAC enforced at API and storage layers
 - **Encryption**: S3 server-side encryption (SSE-S3), DynamoDB encryption at rest
 - **Network**: CloudFront with OAI for static assets, API Gateway with Cognito authorizer
+- **AI Safety**: LLM outputs are clearly labeled; see `docs/internal/DATASET_COMPLIANCE.md`
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -92,7 +92,6 @@ npm install && npx cdk deploy --all
 - **認可**: API・ストレージ層でのリソースレベル RBAC
 - **暗号化**: S3 サーバーサイド暗号化（SSE-S3）、DynamoDB 保存時暗号化
 - **ネットワーク**: CloudFront + OAI による静的アセット配信、API Gateway + Cognito 認可
-- **AI 安全性**: LLM 出力は明示的にラベル付け。`docs/internal/DATASET_COMPLIANCE.md` 参照
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,17 +28,8 @@
 
 ### ワークフロー
 
-```
-Phase 1                    Phase 2                    Phase 3
-Spec                       Build Slides               Generate + Review
 
-┌──────────────────┐    ┌────────────────┐      ┌────────────────┐
-│ Briefing         │    │                │      │ Generate PPTX  │
-│ Outline          │───▶│ Build slides   │─────▶│ Visual review  │
-│ Art direction    │    │                │      │ Polish         │
-└──────────────────┘    └────────────────┘      └────────────────┘
-  User dialogue            specs/ → JSON            PPTX + Preview
-```
+![workflow](./docs/assets/workflow-ja.png)
 
 ---
 
@@ -101,6 +92,7 @@ npm install && npx cdk deploy --all
 - **認可**: API・ストレージ層でのリソースレベル RBAC
 - **暗号化**: S3 サーバーサイド暗号化（SSE-S3）、DynamoDB 保存時暗号化
 - **ネットワーク**: CloudFront + OAI による静的アセット配信、API Gateway + Cognito 認可
+- **AI 安全性**: LLM 出力は明示的にラベル付け。`docs/internal/DATASET_COMPLIANCE.md` 参照
 
 ---
 

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -12,34 +12,13 @@ data model, CDK stack structure, and deployment patterns.
 spec-driven-presentation-maker consists of 4 layers.
 Each layer is a thin wrapper around the previous one — use only the layers you need.
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Layer 4: Agent + Web UI                                    │
-│  Strands Agent, React UI, REST API                          │
-│  ┌─────────────────────────────────────────────────────────┐│
-│  │  Layer 3: Remote MCP Server                             ││
-│  │  AgentCore Runtime, DDB + S3, JWT auth                  ││
-│  │  ┌─────────────────────────────────────────────────────┐││
-│  │  │  Layer 2: Local MCP Server                          │││
-│  │  │  stdio MCP tools                                    │││
-│  │  │  ┌─────────────────────────────────────────────────┐│││
-│  │  │  │  Layer 1: Skill (Engine)                        ││││
-│  │  │  │  python-pptx, references, templates             ││││
-│  │  │  └─────────────────────────────────────────────────┘│││
-│  │  └─────────────────────────────────────────────────────┘││
-│  └─────────────────────────────────────────────────────────┘│
-└─────────────────────────────────────────────────────────────┘
-```
+![4layer-architecture](../assets/4layer-architecture-en.png)
 
 ### Dependency Direction
 
 Dependencies always flow top-down.
 
-```
-web-ui ──→ api ──→ agent ──→ mcp-server ──→ engine (skill/sdpm)
-                              mcp-local  ──→ engine
-                              png-worker     (independent, SQS-driven)
-```
+![dependency-direction](../assets/dependency-direction-en.png)
 
 ---
 
@@ -97,7 +76,7 @@ DynamoDB:
 
 S3 (pptx bucket):
   decks/{deckId}/presentation.json  — slide data
-  decks/{deckId}/specs/             — brief.md, outline.md, art-direction.html
+  decks/{deckId}/specs/             — narrative.md, outline.md, design.md
   decks/{deckId}/includes/          — code block JSON
   previews/{deckId}/{slideId}.png   — slide previews
 
@@ -114,9 +93,9 @@ The agent can read and write files using standard Python file I/O (`open`, `json
 
 ```
 presentation.json   — {"slides": [...], "fonts": {...}}
-specs/brief.md          — briefing (audience, purpose, key messages)
-specs/outline.md        — one line per slide, each line = one message
-specs/art-direction.html — visual design direction (HTML style guide)
+specs/narrative.md  — story design
+specs/outline.md    — one line per slide, each line = one message
+specs/design.md     — design tone
 includes/           — code block JSON files
 ```
 
@@ -160,40 +139,15 @@ The agent's system prompt is minimal — workflow knowledge is dynamically retri
 
 ### Layer 4 (Full Stack) Data Flow
 
-```
-User (Browser)
-  │
-  │  HTTPS (JWT Bearer)
-  ▼
-CloudFront + S3 (React SPA)
-  │
-  │  REST API / SSE
-  ▼
-API Gateway + Lambda ─────────────────────┐
-  │                                       │
-  │  AgentCore Runtime                    │  DynamoDB (deck list,
-  ▼                                       │  templates, authorization)
-Strands Agent                             │
-  │                                       │  S3 (thumbnail retrieval,
-  │  MCP Protocol                         │  PPTX download)
-  ▼                                       │
-MCP Server (AgentCore Runtime)            │
-  │                                       │
-  ├──→ DynamoDB (deck CRUD)               │
-  ├──→ S3 (workspace read/write)          │
-  ├──→ S3 (PPTX generation/storage)       │
-  └──→ SQS ──→ PNG Worker (Fargate)       │
-                  │                       │
-                  ├──→ S3 (PNG storage)    │
-                  └──→ S3 (autofit bake)   │
-```
+
+![data-flow](../assets/data-flow-en.png)
 
 ### Slide Generation Steps
 
 1. User describes the presentation content via chat
 2. Agent calls MCP Server tools to create a deck (`init_presentation`)
 3. Analyzes the template and retrieves available layouts (`analyze_template`)
-4. Following workflow files, designs briefing → outline → art direction (persisted to `specs/`)
+4. Following workflow files, designs narrative → outline → design tone (persisted to `specs/`)
 5. Builds slides (`run_python` to edit files in the workspace)
 6. Generates PPTX (`generate_pptx`) → saved to S3
 7. PNG Worker triggered via SQS → generates PNG previews
@@ -207,16 +161,7 @@ MCP Server (AgentCore Runtime)            │
 
 spec-driven-presentation-maker integrates with any OIDC-compliant IdP (Identity Provider).
 
-```
-┌──────────────┐     JWT Bearer Token     ┌──────────────────┐
-│   IdP        │ ◀──────────────────────▶ │  AgentCore       │
-│              │                          │  Runtime         │
-│  · Cognito   │   OIDC Discovery URL     │                  │
-│  · Entra ID  │ ─────────────────────── ▶│  JWT validation  │
-│  · Auth0     │                          │  → user_id       │
-│  · Okta      │                          │  → forwarded     │
-└──────────────┘                          └──────────────────┘
-```
+![jwt-auth-flow](../assets/jwt-auth-flow-en.png)
 
 - Amazon Bedrock AgentCore Runtime's `customJwtAuthorizer` validates the JWT
 - The JWT `sub` claim is propagated as `user_id` to the application
@@ -262,17 +207,19 @@ To add custom roles (e.g., team-based access), modify the `resolve_role` functio
 | Workflow | `init_presentation`, `analyze_template` | Initialize deck, analyze template |
 | Generation | `generate_pptx`, `get_preview` | Generate PPTX, get PNG preview |
 | Assets | `search_assets`, `list_asset_sources`, `list_templates` | Search icons, list sources, list templates |
-| References | `list_styles`, `read_examples` | Slide style examples |
+| References | `list_examples`, `read_examples` | Slide pattern examples |
 | References | `list_workflows`, `read_workflows` | Phase workflow instructions |
 | References | `list_guides`, `read_guides` | Design rules and guides |
+| Search | `example_search` | Keyword search across pptx sample slides |
 | Layout | `grid` | CSS Grid coordinate calculation |
-| Utility | `code_to_slide`, `pptx_to_json` | Code highlighting, PPTX reverse conversion |
+| Utility | `code_block`, `pptx_to_json` | Code highlighting, PPTX reverse conversion |
 
 ### Layer 3 Additional Tools
 
 | Tool | Description |
 |------|-------------|
 | `run_python` | Execute Python in Code Interpreter sandbox |
+| `code_to_slide` | Syntax-highlighted code block saved as include file |
 | `search_slides` | Semantic slide search (optional, requires Amazon Bedrock KB) |
 
 ---
@@ -281,29 +228,7 @@ To add custom roles (e.g., team-based access), modify the `resolve_role` functio
 
 ### Stack Dependencies
 
-```
-                    ┌──────────────┐
-                    │  AuthStack   │
-                    │  (Cognito)   │
-                    └──────┬───────┘
-                           │
-┌──────────────┐           │         ┌─────────────────┐
-│  DataStack   │───────────┼────────▶│  RuntimeStack   │
-│  (DDB + S3)  │──┐        │         │  (MCP Server)   │
-└──────────────┘  │        │         └────────┬────────┘
-                  │        │                  │
-┌────────────────┐│        │                  ▼
-│ PngWorkerStack ├┘        │         ┌─────────────────┐
-│ (Fargate + SQS)│         │         │  AgentStack     │
-└────────────────┘         │         │  (Strands Agent)│
-                           │         └────────┬────────┘
-                           │                  │
-                           │                  ▼
-                           │         ┌─────────────────┐
-                           └────────▶│  WebUiStack     │
-                                     │  (React SPA)    │
-                                     └─────────────────┘
-```
+![cdk-dependencies](../assets/cdk-dependencies.png)
 
 ### Stack Roles
 

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -64,7 +64,6 @@ MCP Client → AgentCore Runtime → MCP Server Container
 
 Additional tools over Layer 2:
 - `run_python` — Execute Python in Amazon Bedrock AgentCore Code Interpreter sandbox (edit deck workspace, analyze data)
-- `code_to_slide` — Syntax-highlighted code block saved as S3 include file
 - `search_slides` — Semantic slide search via Amazon Bedrock Knowledge Base (optional)
 
 ### Storage
@@ -76,7 +75,7 @@ DynamoDB:
 
 S3 (pptx bucket):
   decks/{deckId}/presentation.json  — slide data
-  decks/{deckId}/specs/             — narrative.md, outline.md, design.md
+  decks/{deckId}/specs/             — brief.md, outline.md, art-direction.html
   decks/{deckId}/includes/          — code block JSON
   previews/{deckId}/{slideId}.png   — slide previews
 
@@ -93,9 +92,9 @@ The agent can read and write files using standard Python file I/O (`open`, `json
 
 ```
 presentation.json   — {"slides": [...], "fonts": {...}}
-specs/narrative.md  — story design
-specs/outline.md    — one line per slide, each line = one message
-specs/design.md     — design tone
+specs/brief.md          — briefing (audience, purpose, key messages)
+specs/outline.md        — one line per slide, each line = one message
+specs/art-direction.html — visual design direction (HTML style guide)
 includes/           — code block JSON files
 ```
 
@@ -147,7 +146,7 @@ The agent's system prompt is minimal — workflow knowledge is dynamically retri
 1. User describes the presentation content via chat
 2. Agent calls MCP Server tools to create a deck (`init_presentation`)
 3. Analyzes the template and retrieves available layouts (`analyze_template`)
-4. Following workflow files, designs narrative → outline → design tone (persisted to `specs/`)
+4. Following workflow files, designs briefing → outline → art direction (persisted to `specs/`)
 5. Builds slides (`run_python` to edit files in the workspace)
 6. Generates PPTX (`generate_pptx`) → saved to S3
 7. PNG Worker triggered via SQS → generates PNG previews
@@ -207,19 +206,17 @@ To add custom roles (e.g., team-based access), modify the `resolve_role` functio
 | Workflow | `init_presentation`, `analyze_template` | Initialize deck, analyze template |
 | Generation | `generate_pptx`, `get_preview` | Generate PPTX, get PNG preview |
 | Assets | `search_assets`, `list_asset_sources`, `list_templates` | Search icons, list sources, list templates |
-| References | `list_examples`, `read_examples` | Slide pattern examples |
+| References | `list_styles`, `read_examples` | Slide style examples |
 | References | `list_workflows`, `read_workflows` | Phase workflow instructions |
 | References | `list_guides`, `read_guides` | Design rules and guides |
-| Search | `example_search` | Keyword search across pptx sample slides |
 | Layout | `grid` | CSS Grid coordinate calculation |
-| Utility | `code_block`, `pptx_to_json` | Code highlighting, PPTX reverse conversion |
+| Utility | `code_to_slide`, `pptx_to_json` | Code highlighting, PPTX reverse conversion |
 
 ### Layer 3 Additional Tools
 
 | Tool | Description |
 |------|-------------|
 | `run_python` | Execute Python in Code Interpreter sandbox |
-| `code_to_slide` | Syntax-highlighted code block saved as include file |
 | `search_slides` | Semantic slide search (optional, requires Amazon Bedrock KB) |
 
 ---

--- a/docs/ja/architecture.md
+++ b/docs/ja/architecture.md
@@ -64,7 +64,6 @@ MCP Client → AgentCore Runtime → MCP Server コンテナ
 
 Layer 2 に対する追加ツール:
 - `run_python` — Amazon Bedrock AgentCore Code Interpreter サンドボックスで Python を実行（デッキワークスペースの編集、データ分析）
-- `code_to_slide` — シンタックスハイライト付きコードブロックを S3 include ファイルとして保存
 - `search_slides` — Amazon Bedrock Knowledge Base によるセマンティックスライド検索（任意）
 
 ### ストレージ
@@ -76,7 +75,7 @@ DynamoDB:
 
 S3（pptx バケット）:
   decks/{deckId}/presentation.json  — スライドデータ
-  decks/{deckId}/specs/             — narrative.md, outline.md, design.md
+  decks/{deckId}/specs/             — brief.md, outline.md, art-direction.html
   decks/{deckId}/includes/          — コードブロック JSON
   previews/{deckId}/{slideId}.png   — スライドプレビュー
 
@@ -93,9 +92,9 @@ S3（リソースバケット）:
 
 ```
 presentation.json   — {"slides": [...], "fonts": {...}}
-specs/narrative.md  — ストーリー設計
-specs/outline.md    — 1 行 1 スライド、各行 = 1 メッセージ
-specs/design.md     — デザイントーン
+specs/brief.md          — ブリーフィング（対象者、目的、キーメッセージ）
+specs/outline.md        — 1 行 1 スライド、各行 = 1 メッセージ
+specs/art-direction.html — ビジュアルデザイン方針（HTML スタイルガイド）
 includes/           — コードブロック JSON ファイル
 ```
 
@@ -146,7 +145,7 @@ Agent の system prompt は最小限です — ワークフロー知識は MCP S
 1. ユーザーがチャットでプレゼンテーションの内容を指示
 2. Agent が MCP Server のツールを呼び出し、デッキを作成（`init_presentation`）
 3. テンプレートを分析し、利用可能なレイアウトを取得（`analyze_template`）
-4. ワークフローファイルに従い、ナラティブ → アウトライン → デザイントーンを設計（`specs/` に永続化）
+4. ワークフローファイルに従い、ブリーフィング → アウトライン → アートディレクションを設計（`specs/` に永続化）
 5. スライドを構築（`run_python` でワークスペース内のファイルを編集）
 6. PPTX を生成（`generate_pptx`）→ S3 に保存
 7. SQS 経由で PNG Worker が起動 → PNG プレビューを生成
@@ -206,19 +205,17 @@ spec-driven-presentation-maker は OIDC 準拠の任意の IdP（Identity Provid
 | ワークフロー | `init_presentation`, `analyze_template` | デッキ初期化、テンプレート解析 |
 | 生成 | `generate_pptx`, `get_preview` | PPTX 生成、PNG プレビュー取得 |
 | アセット | `search_assets`, `list_asset_sources`, `list_templates` | アイコン検索、ソース一覧、テンプレート一覧 |
-| リファレンス | `list_examples`, `read_examples` | スライドパターン例 |
+| リファレンス | `list_styles`, `read_examples` | スライドスタイル例 |
 | リファレンス | `list_workflows`, `read_workflows` | フェーズ別ワークフロー手順 |
 | リファレンス | `list_guides`, `read_guides` | デザインルール・ガイド |
-| 検索 | `example_search` | pptx サンプルスライドのキーワード検索 |
 | レイアウト | `grid` | CSS Grid 座標計算 |
-| ユーティリティ | `code_block`, `pptx_to_json` | コードハイライト、PPTX 逆変換 |
+| ユーティリティ | `code_to_slide`, `pptx_to_json` | コードハイライト、PPTX 逆変換 |
 
 ### Layer 3 追加ツール
 
 | ツール | 説明 |
 |--------|------|
 | `run_python` | Code Interpreter サンドボックスで Python 実行 |
-| `code_to_slide` | シンタックスハイライト付きコードブロックを include ファイルとして保存 |
 | `search_slides` | セマンティックスライド検索（任意、Amazon Bedrock KB 必要） |
 
 ---

--- a/docs/ja/architecture.md
+++ b/docs/ja/architecture.md
@@ -12,34 +12,13 @@
 spec-driven-presentation-maker は 4 つのレイヤーで構成されます。
 各レイヤーは前のレイヤーの薄いラッパーであり、必要なレイヤーだけを選んで利用できます。
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  Layer 4: Agent + Web UI                                    │
-│  Strands Agent, React UI, REST API                          │
-│  ┌─────────────────────────────────────────────────────────┐│
-│  │  Layer 3: Remote MCP Server                             ││
-│  │  AgentCore Runtime, DDB + S3, JWT auth                  ││
-│  │  ┌─────────────────────────────────────────────────────┐││
-│  │  │  Layer 2: Local MCP Server                          │││
-│  │  │  stdio MCP tools                                    │││
-│  │  │  ┌─────────────────────────────────────────────────┐│││
-│  │  │  │  Layer 1: Skill (Engine)                        ││││
-│  │  │  │  python-pptx, references, templates             ││││
-│  │  │  └─────────────────────────────────────────────────┘│││
-│  │  └─────────────────────────────────────────────────────┘││
-│  └─────────────────────────────────────────────────────────┘│
-└─────────────────────────────────────────────────────────────┘
-```
+![4layer-architecture](../assets/4layer-architecture-ja.png)
 
 ### レイヤー間の依存方向
 
 依存は常に上から下への一方向です。
 
-```
-web-ui ──→ api ──→ agent ──→ mcp-server ──→ engine (skill/sdpm)
-                              mcp-local  ──→ engine
-                              png-worker     （独立、SQS 駆動）
-```
+![dependency-direction](../assets/dependency-direction-ja.png)
 
 ---
 
@@ -97,7 +76,7 @@ DynamoDB:
 
 S3（pptx バケット）:
   decks/{deckId}/presentation.json  — スライドデータ
-  decks/{deckId}/specs/             — brief.md, outline.md, art-direction.html
+  decks/{deckId}/specs/             — narrative.md, outline.md, design.md
   decks/{deckId}/includes/          — コードブロック JSON
   previews/{deckId}/{slideId}.png   — スライドプレビュー
 
@@ -114,9 +93,9 @@ S3（リソースバケット）:
 
 ```
 presentation.json   — {"slides": [...], "fonts": {...}}
-specs/brief.md          — ブリーフィング（対象者、目的、キーメッセージ）
-specs/outline.md        — 1 行 1 スライド、各行 = 1 メッセージ
-specs/art-direction.html — ビジュアルデザイン方針（HTML スタイルガイド）
+specs/narrative.md  — ストーリー設計
+specs/outline.md    — 1 行 1 スライド、各行 = 1 メッセージ
+specs/design.md     — デザイントーン
 includes/           — コードブロック JSON ファイル
 ```
 
@@ -160,40 +139,14 @@ Agent の system prompt は最小限です — ワークフロー知識は MCP S
 
 ### Layer 4（フルスタック）のデータフロー
 
-```
-ユーザー（ブラウザ）
-  │
-  │  HTTPS (JWT Bearer)
-  ▼
-CloudFront + S3（React SPA）
-  │
-  │  REST API / SSE
-  ▼
-API Gateway + Lambda ─────────────────────┐
-  │                                       │
-  │  AgentCore Runtime                    │  DynamoDB（デッキ一覧、
-  ▼                                       │  テンプレート、認可）
-Strands Agent                             │
-  │                                       │  S3（サムネイル取得、
-  │  MCP Protocol                         │  PPTX ダウンロード）
-  ▼                                       │
-MCP Server（AgentCore Runtime）           │
-  │                                       │
-  ├──→ DynamoDB（デッキ CRUD）            │
-  ├──→ S3（ワークスペース読み書き）       │
-  ├──→ S3（PPTX 生成・保存）             │
-  └──→ SQS ──→ PNG Worker（Fargate）     │
-                  │                       │
-                  ├──→ S3（PNG 保存）     │
-                  └──→ S3（autofit 焼込） │
-```
+![data-flow](../assets/data-flow-ja.png)
 
 ### スライド生成の処理ステップ
 
 1. ユーザーがチャットでプレゼンテーションの内容を指示
 2. Agent が MCP Server のツールを呼び出し、デッキを作成（`init_presentation`）
 3. テンプレートを分析し、利用可能なレイアウトを取得（`analyze_template`）
-4. ワークフローファイルに従い、ブリーフィング → アウトライン → アートディレクションを設計（`specs/` に永続化）
+4. ワークフローファイルに従い、ナラティブ → アウトライン → デザイントーンを設計（`specs/` に永続化）
 5. スライドを構築（`run_python` でワークスペース内のファイルを編集）
 6. PPTX を生成（`generate_pptx`）→ S3 に保存
 7. SQS 経由で PNG Worker が起動 → PNG プレビューを生成
@@ -207,16 +160,7 @@ MCP Server（AgentCore Runtime）           │
 
 spec-driven-presentation-maker は OIDC 準拠の任意の IdP（Identity Provider）と連携できます。
 
-```
-┌──────────────┐     JWT Bearer Token     ┌──────────────────┐
-│   IdP        │ ◀──────────────────────▶ │  AgentCore       │
-│              │                          │  Runtime         │
-│  ・Cognito   │   OIDC Discovery URL     │                  │
-│  ・Entra ID  │ ─────────────────────── ▶│  JWT 検証        │
-│  ・Auth0     │                          │  → user_id 抽出  │
-│  ・Okta      │                          │  → コンテナ転送  │
-└──────────────┘                          └──────────────────┘
-```
+![jwt-auth-flow](../assets/jwt-auth-flow-ja.png)
 
 - Amazon Bedrock AgentCore Runtime の `customJwtAuthorizer` が JWT を検証
 - JWT の `sub` クレームが `user_id` としてアプリケーションに伝播
@@ -262,17 +206,19 @@ spec-driven-presentation-maker は OIDC 準拠の任意の IdP（Identity Provid
 | ワークフロー | `init_presentation`, `analyze_template` | デッキ初期化、テンプレート解析 |
 | 生成 | `generate_pptx`, `get_preview` | PPTX 生成、PNG プレビュー取得 |
 | アセット | `search_assets`, `list_asset_sources`, `list_templates` | アイコン検索、ソース一覧、テンプレート一覧 |
-| リファレンス | `list_styles`, `read_examples` | スライドスタイル例 |
+| リファレンス | `list_examples`, `read_examples` | スライドパターン例 |
 | リファレンス | `list_workflows`, `read_workflows` | フェーズ別ワークフロー手順 |
 | リファレンス | `list_guides`, `read_guides` | デザインルール・ガイド |
+| 検索 | `example_search` | pptx サンプルスライドのキーワード検索 |
 | レイアウト | `grid` | CSS Grid 座標計算 |
-| ユーティリティ | `code_to_slide`, `pptx_to_json` | コードハイライト、PPTX 逆変換 |
+| ユーティリティ | `code_block`, `pptx_to_json` | コードハイライト、PPTX 逆変換 |
 
 ### Layer 3 追加ツール
 
 | ツール | 説明 |
 |--------|------|
 | `run_python` | Code Interpreter サンドボックスで Python 実行 |
+| `code_to_slide` | シンタックスハイライト付きコードブロックを include ファイルとして保存 |
 | `search_slides` | セマンティックスライド検索（任意、Amazon Bedrock KB 必要） |
 
 ---
@@ -281,29 +227,7 @@ spec-driven-presentation-maker は OIDC 準拠の任意の IdP（Identity Provid
 
 ### スタック依存関係
 
-```
-                    ┌──────────────┐
-                    │  AuthStack   │
-                    │  (Cognito)   │
-                    └──────┬───────┘
-                           │
-┌──────────────┐           │         ┌─────────────────┐
-│  DataStack   │───────────┼────────▶│  RuntimeStack   │
-│  (DDB + S3)  │──┐        │         │  (MCP Server)   │
-└──────────────┘  │        │         └────────┬────────┘
-                  │        │                  │
-┌────────────────┐│        │                  ▼
-│ PngWorkerStack ├┘        │         ┌─────────────────┐
-│ (Fargate + SQS)│         │         │  AgentStack     │
-└────────────────┘         │         │  (Strands Agent)│
-                           │         └────────┬────────┘
-                           │                  │
-                           │                  ▼
-                           │         ┌─────────────────┐
-                           └────────▶│  WebUiStack     │
-                                     │  (React SPA)    │
-                                     └─────────────────┘
-```
+![cdk-dependencies](../assets/cdk-dependencies.png)
 
 ### 各スタックの役割
 


### PR DESCRIPTION
## Summary

- Replace ASCII art diagrams with image references in README and architecture docs (EN/JA)
- Add AI Safety note to README
- Align documentation with actual codebase:
  - `list_examples` → `list_styles` (matches server.py)
  - `code_block` → `code_to_slide` (matches mcp-local/server.py)
  - Remove `example_search` (not registered as MCP tool in server.py)
  - Remove `code_to_slide` from Layer 3 additional tools (already in Layer 2)
  - `narrative.md`/`design.md` → `brief.md`/`art-direction.html` (matches workflow files)

## Changed Files

- `README.md` / `README_ja.md`
- `docs/en/architecture.md` / `docs/ja/architecture.md`