### PR TITLE
ci: add CI workflow for python, web-ui, infra, and PR guards

### DIFF
--- a/.ash.yaml
+++ b/.ash.yaml
@@ -1,6 +1,7 @@
 project_name: sample-spec-driven-presentation-maker
 
 global_settings:
+  severity_threshold: HIGH
   ignore_paths:
     - path: "infra/node_modules/**"
       reason: "CDK bundled code — not our source code"

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install ASH
         run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.2.4
       - name: Run ASH scan
-        run: ash --mode local --fail-on-findings --severity-threshold HIGH
+        run: ash --mode local --fail-on-findings
       - name: Upload scan results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install ASH
         run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.2.4
       - name: Run ASH scan
-        run: ash --mode local --no-fail-on-findings
+        run: ash --mode local --fail-on-findings --severity-threshold HIGH
       - name: Upload scan results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -10,8 +10,8 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install ASH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.changed_files, 0) == false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v4
+      - name: Lint
+        run: uv run ruff check skill/ mcp-local/ mcp-server/ shared/ api/
+      - name: Test
+        run: uv run pytest tests/ -v
+
+  web-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web-ui/package-lock.json
+      - name: Install
+        run: npm ci
+        working-directory: web-ui
+      - name: Lint
+        run: npm run lint
+        working-directory: web-ui
+      - name: Build
+        run: npm run build
+        working-directory: web-ui
+
+  infra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: infra/package-lock.json
+      - name: Install
+        run: npm ci
+        working-directory: infra
+      - name: Type check
+        run: npx tsc --noEmit
+        working-directory: infra
+
+  guard:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deny cdk.context.json
+        run: |
+          if [ -f "infra/cdk.context.json" ]; then
+            echo "::error::infra/cdk.context.json must not be committed"
+            exit 1
+          fi
+      - name: Deny .env files
+        run: |
+          if compgen -G "**/.env" > /dev/null || compgen -G "**/.env.*" > /dev/null; then
+            echo "::error::.env files must not be committed"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8.0.0
       - name: Lint
         run: uv run ruff check skill/ mcp-local/ mcp-server/ shared/ api/
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   python:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.changed_files, 0) == false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v4
@@ -26,8 +26,8 @@ jobs:
   web-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -45,8 +45,8 @@ jobs:
   infra:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Deny cdk.context.json
         run: |
           if [ -f "infra/cdk.context.json" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,6 @@ import sys
 from pathlib import Path
 
 _root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_root))
 sys.path.insert(0, str(_root / "mcp-server"))
 sys.path.insert(0, str(_root / "skill"))


### PR DESCRIPTION
## Changes

- Add GitHub Actions CI workflow with 4 parallel jobs:
  - **python**: ruff lint + pytest
  - **web-ui**: npm ci + eslint + next build
  - **infra**: npm ci + tsc type check
  - **guard**: deny cdk.context.json and .env files in PRs

Triggered on push to main and PRs to main.