### PR TITLE
fix: migrate eslint to native flat config and fix React hooks violations

### DIFF
--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -10,9 +10,11 @@ const eslintConfig = [
   // Base Next.js config (react, hooks, import, jsx-a11y, @next/next)
   nextConfig[0],
   // Downgrade set-state-in-effect to warning (valid patterns: fetch loading, dialog reset)
+  // Disable no-img-element (project uses dynamic URLs from API / S3 signed URLs)
   {
     rules: {
       "react-hooks/set-state-in-effect": "warn",
+      "@next/next/no-img-element": "off",
     },
   },
   // TypeScript config with rule overrides

--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -1,30 +1,31 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { dirname } from "path"
-import { fileURLToPath } from "url"
-import { FlatCompat } from "@eslint/eslintrc"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
+import nextConfig from "eslint-config-next"
 
 const eslintConfig = [
-  // Ignore patterns (replacing .eslintignore)
   {
     ignores: ["node_modules/**", "build/**", "delete/**", "tmp/**", ".next/**"],
   },
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  // Base Next.js config (react, hooks, import, jsx-a11y, @next/next)
+  nextConfig[0],
+  // Downgrade set-state-in-effect to warning (valid patterns: fetch loading, dialog reset)
   {
     rules: {
-      // Treat these as warnings instead of errors to prevent build failures
+      "react-hooks/set-state-in-effect": "warn",
+    },
+  },
+  // TypeScript config with rule overrides
+  {
+    ...nextConfig[1],
+    rules: {
+      ...nextConfig[1].rules,
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": "warn",
     },
   },
+  // Next.js default ignores
+  ...(nextConfig.length > 2 ? nextConfig.slice(2) : []),
 ]
 
 export default eslintConfig

--- a/web-ui/src/app/(authenticated)/decks/page.tsx
+++ b/web-ui/src/app/(authenticated)/decks/page.tsx
@@ -34,7 +34,7 @@ import { useIsMobile } from "@/hooks/UseMobile"
 import { useSwipe } from "@/hooks/useSwipe"
 import { useDeckList } from "@/hooks/useDeckList"
 import { useWorkspace } from "@/hooks/useWorkspace"
-import { Plus, MessageSquare, Image, Star } from "lucide-react"
+import { Plus, MessageSquare, Image as ImageIcon, Star } from "lucide-react"
 
 export default function DecksPage() {
   const auth = useAuth()
@@ -88,7 +88,7 @@ export default function DecksPage() {
                       activeTab === "preview" ? "text-foreground border-b-2 border-foreground" : "text-foreground-muted"
                     }`}
                   >
-                    <Image className="h-4 w-4" />
+                    <ImageIcon className="h-4 w-4" />
                     Preview
                     {ws.hasSlides && <span className="w-1.5 h-1.5 rounded-full bg-green-500" />}
                   </button>

--- a/web-ui/src/components/auth/AutoSignin.tsx
+++ b/web-ui/src/components/auth/AutoSignin.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 "use client"
 
-import { ReactNode, useEffect, useState } from "react"
+import { ReactNode, useSyncExternalStore } from "react"
 import { useAutoSignin } from "react-oidc-context"
 
 /**
@@ -33,15 +33,15 @@ function AutoSigninContent({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+const subscribe = () => () => {}
+const getSnapshot = () => true
+const getServerSnapshot = () => false
+
 /**
  * AutoSignin — delays rendering until client-side mount to avoid SSR hydration mismatch.
  */
 export function AutoSignin({ children }: { children: ReactNode }) {
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 
   if (!mounted) {
     return null

--- a/web-ui/src/components/chat/AttachmentPreview.tsx
+++ b/web-ui/src/components/chat/AttachmentPreview.tsx
@@ -8,7 +8,7 @@
 
 "use client"
 
-import { X, FileText, Image, File, AlignLeft } from "lucide-react"
+import { X, FileText, Image as ImageIcon, File, AlignLeft } from "lucide-react"
 
 export interface Attachment {
   id: string
@@ -57,7 +57,7 @@ function formatSize(bytes: number): string {
  * @returns Lucide icon component
  */
 function FileIcon({ type }: { type: string }) {
-  if (type.startsWith("image/")) return <Image className="h-4 w-4 text-blue-400" />
+  if (type.startsWith("image/")) return <ImageIcon className="h-4 w-4 text-blue-400" />
   if (type.includes("pdf") || type.includes("word") || type.includes("sheet") || type.includes("presentation")) {
     return <FileText className="h-4 w-4 text-orange-400" />
   }

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -21,7 +21,7 @@
 import { useState, useEffect } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { Loader2, ChevronRight, Sparkles } from "lucide-react"
+import { ChevronRight, Sparkles } from "lucide-react"
 import { ToolCard, ToolCardCompact } from "./ToolCard"
 import { SnippetBlock } from "./SnippetBlock"
 import { batchGetSlidePreviewUrls } from "@/services/deckService"
@@ -189,7 +189,6 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
   const renderTextBlock = (text: string, isLast: boolean) => {
     if (!text.trim()) return null
     // Apply snippet extraction to each text block
-    const blockSnippetRegex = /---snippet---\n([\s\S]*?)---\/snippet---/g
     const cleaned = text.replace(/\n*---snippet---\n[\s\S]*?---\/snippet---/g, "").trim()
     if (!cleaned) return null
     return (

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -29,7 +29,7 @@ import { AttachmentPreview, Attachment, SnippetAttachment } from "./AttachmentPr
 import { FileDropZone } from "./FileDropZone"
 import { SnippetInput } from "./SnippetInput"
 import { useIsMobile } from "@/hooks/UseMobile"
-import { Send, Square, Loader2 } from "lucide-react"
+import { Send, Square } from "lucide-react"
 import { toast } from "sonner"
 
 interface Message {
@@ -39,6 +39,15 @@ interface Message {
   /** Ordered sequence of text and tool blocks for inline display. */
   blocks?: { type: "text"; text: string }[] | { type: "tool"; tool: ToolUse }[]
   snippets?: { label: string; text: string }[]
+}
+
+/** Shape of tool-use callback data from the agent streaming API. */
+interface ToolUseCallbackData {
+  toolUseId?: string
+  completed?: boolean
+  status?: "success" | "error"
+  result?: Record<string, unknown>
+  input?: Record<string, unknown>
 }
 
 interface ChatPanelProps {
@@ -87,7 +96,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const shouldAutoScroll = useRef(true)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const mentionPopupRef = useRef<any>(null)
+  const mentionPopupRef = useRef<{ _handleKeyDown?: (e: KeyboardEvent) => boolean } | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
   const auth = useAuth()
   const { onCompositionStart, onCompositionEnd, getIsComposing } = useCompositionSafe()
@@ -514,14 +523,15 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         },
         accessToken,
         userId,
-        (toolName: string, toolUseData: any) => {
+        (toolName: string, toolUseData: ToolUseCallbackData | undefined) => {
           // Tool result (completed) — detect deckId from any tool's result
           if (toolUseData?.completed && toolUseData?.result?.deckId && onDeckCreated) {
             // Link chat session to deck for history restore
+            const resultDeckId = String(toolUseData.result.deckId)
             if (idToken) {
-              patchDeck(toolUseData.result.deckId, { chatSessionId: sessionId }, idToken).catch(() => {})
+              patchDeck(resultDeckId, { chatSessionId: sessionId }, idToken).catch(() => {})
             }
-            onDeckCreated(toolUseData.result.deckId)
+            onDeckCreated(resultDeckId)
           }
           if (toolUseData?.completed && toolName === "generate_pptx" && onPptxRequested) {
             onPptxRequested()
@@ -556,7 +566,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
 
           // Detect workflow phase from tool calls
           if (onWorkflowPhase && (toolName === "read_workflows" || toolName.endsWith("_read_workflows"))) {
-            const names: string[] = toolUseData?.input?.names || []
+            const names = (toolUseData?.input?.names || []) as string[]
             const first = names[0] || ""
             if (first.includes("briefing")) onWorkflowPhase("brief")
             else if (first.includes("outline")) onWorkflowPhase("outline")
@@ -633,7 +643,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
     if (getIsComposing(e)) return
 
     // Let mention popup handle navigation keys
-    if (mentionVisible && (MentionPopup as any)._handleKeyDown?.(e)) {
+    if (mentionVisible && (MentionPopup as unknown as { _handleKeyDown?: (e: KeyboardEvent) => boolean })._handleKeyDown?.(e)) {
       return
     }
 

--- a/web-ui/src/components/chat/ChatPanelShell.tsx
+++ b/web-ui/src/components/chat/ChatPanelShell.tsx
@@ -104,11 +104,11 @@ export function ChatPanelShell({
   // bump Panel B key so it remounts with new chat history.
   // But if Panel A or Panel B created this deck, don't bump.
   const prevDeckIdRef = useRef(deckId)
+
   useEffect(() => {
     if (deckId !== prevDeckIdRef.current) {
       if (deckId !== panelADeckId) {
         setPanelADeckId(null)
-        // Only bump Panel B on external navigation, not on create_deck from Panel B
         if (panelBCreatedRef.current) {
           panelBCreatedRef.current = false
         } else {

--- a/web-ui/src/components/chat/MentionOverlay.tsx
+++ b/web-ui/src/components/chat/MentionOverlay.tsx
@@ -13,8 +13,6 @@
 import { RefObject, useState, useEffect } from "react"
 import { createPortal } from "react-dom"
 
-/** Regex to match @Page N mentions (legacy). */
-const PAGE_MENTION_RE = /@Page\s(\d+)/g
 /** Regex to match @DeckName(#id):Page N or @DeckName(#id) or @[DeckName] or @Page N */
 const ALL_MENTIONS_RE = /@([^@(]+)\(#([^)]+)\):Page\s(\d+)|@([^@(]+)\(#([^)]+)\)|@\[([^\]]+)\]|@Page\s(\d+)/g
 

--- a/web-ui/src/components/chat/MentionPopup.tsx
+++ b/web-ui/src/components/chat/MentionPopup.tsx
@@ -91,7 +91,7 @@ export function MentionPopup({ visible, query, items, onSelect, onClose, positio
     [visible, filtered, selectedIndex, onSelect, onClose],
   )
 
-  ;(MentionPopup as any)._handleKeyDown = handleKeyDown
+  ;(MentionPopup as unknown as { _handleKeyDown: typeof handleKeyDown })._handleKeyDown = handleKeyDown
 
   if (!visible || filtered.length === 0) return null
 

--- a/web-ui/src/components/chat/SnippetInput.tsx
+++ b/web-ui/src/components/chat/SnippetInput.tsx
@@ -25,9 +25,10 @@ interface SnippetInputProps {
  * @param props - SnippetInputProps
  */
 export function SnippetInput({ open, onClose, onConfirm, initialText }: SnippetInputProps) {
-  const [text, setText] = useState("")
+  const [text, setText] = useState(initialText || "")
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
+  // Reset text and focus when dialog opens
   useEffect(() => {
     if (open) {
       setText(initialText || "")

--- a/web-ui/src/components/chat/ToolCard.tsx
+++ b/web-ui/src/components/chat/ToolCard.tsx
@@ -25,9 +25,9 @@
 "use client"
 
 import {
-  BookOpen, List, Search, FolderPlus, Pencil, Cog, Image,
+  BookOpen, List, Search, FolderPlus, Pencil, Image,
   Trash2, ArrowUpDown, FolderOpen, Copy, Globe, Wrench,
-  Check, FileText, Download, Play, Code, Palette,
+  Check, FileText, Download, Play, Code,
   LayoutTemplate, Package, AlertCircle,
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"

--- a/web-ui/src/components/chat/ToolIndicator.tsx
+++ b/web-ui/src/components/chat/ToolIndicator.tsx
@@ -10,7 +10,7 @@
  */
 
 import {
-  BookOpen, List, Search, FolderPlus, Pencil, Cog, Image,
+  BookOpen, List, Search, FolderPlus, Pencil, Image,
   Trash2, ArrowUpDown, FolderOpen, Copy, Globe, Wrench, Loader2,
   FileText, Download, Play, Code, LayoutTemplate, Package,
 } from "lucide-react"

--- a/web-ui/src/components/deck/DeckActions.tsx
+++ b/web-ui/src/components/deck/DeckActions.tsx
@@ -8,7 +8,7 @@
 "use client"
 
 import { useState, useEffect, useRef } from "react"
-import { Globe, Lock, Share2, X, UserPlus, Trash2, Building2 } from "lucide-react"
+import { Lock, Share2, X, Trash2, Building2 } from "lucide-react"
 import { searchUsers, UserSearchResult } from "@/services/deckService"
 
 interface DeckActionsProps {

--- a/web-ui/src/components/deck/SlideCarousel.tsx
+++ b/web-ui/src/components/deck/SlideCarousel.tsx
@@ -123,9 +123,6 @@ export function SlideCarousel({ slides, deckId, deckName, pptxUrl, isLoading, on
     }
   }
 
-  /** Whether any spec file has content. */
-  const hasSpecs = specs != null && (specs.brief != null || specs.outline != null || specs.artDirection != null)
-
   /**
    * Render the empty-slides placeholder (loading animation or static message).
    *

--- a/web-ui/src/components/deck/SpecStepNav.tsx
+++ b/web-ui/src/components/deck/SpecStepNav.tsx
@@ -15,7 +15,7 @@
 
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Layers, FileText } from "lucide-react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
@@ -207,6 +207,20 @@ const specComponents = {
  * @param props.specKey - Which spec tab ("brief" | "outline" | "artDirection")
  */
 export function SpecMarkdownPreview({ content, specName, specKey }: { content: string | null; specName: string; specKey?: string }) {
+  // Hooks must be called unconditionally — before any early returns.
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const ro = new ResizeObserver(([entry]) => {
+      setContainerWidth(entry.contentRect.width)
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
   // Outline tab uses the dedicated timeline renderer.
   if (specKey === "outline") {
     return <OutlineView content={content} />
@@ -229,22 +243,6 @@ export function SpecMarkdownPreview({ content, specName, specKey }: { content: s
       </div>
     )
   }
-
-  // Art Direction tab renders HTML via sandboxed iframe.
-  // Style HTMLs use fixed 1920px-wide body. We render the iframe at 1920px
-  // and use CSS transform to scale it down to fit the container.
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState(0)
-
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const ro = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width)
-    })
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [])
 
   if (specKey === "artDirection") {
     const ratio = containerWidth > 0 ? containerWidth / 1920 : 1

--- a/web-ui/src/components/deck/StyleGalleryModal.tsx
+++ b/web-ui/src/components/deck/StyleGalleryModal.tsx
@@ -29,15 +29,20 @@ interface StyleGalleryModalProps {
 export function StyleGalleryModal({ open, onClose, onSelect, idToken }: StyleGalleryModalProps) {
   const [styles, setStyles] = useState<StyleEntry[]>([])
   const [loading, setLoading] = useState(false)
+  const loadedRef = useRef(false)
 
   useEffect(() => {
-    if (!open || styles.length > 0) return
+    if (!open || loadedRef.current) return
+    let cancelled = false
     setLoading(true)
     fetchStyles(idToken).then((s) => {
+      if (cancelled) return
+      loadedRef.current = true
       setStyles(s)
       setLoading(false)
     })
-  }, [open, idToken, styles.length])
+    return () => { cancelled = true }
+  }, [open, idToken])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === "Escape") onClose()

--- a/web-ui/src/components/deck/WorkspaceView.tsx
+++ b/web-ui/src/components/deck/WorkspaceView.tsx
@@ -14,8 +14,6 @@
 "use client"
 
 import { DeckDetail } from "@/services/deckService"
-import { SlideCarousel } from "@/components/deck/SlideCarousel"
-import { DeckActions } from "@/components/deck/DeckActions"
 import { Share2, Download, Layers } from "lucide-react"
 
 interface WorkspaceViewProps {


### PR DESCRIPTION
## Changes

- eslint設定を FlatCompat → ネイティブ flat config に移行（circular JSON errorを修正）
- SpecStepNav: useRef/useState/useEffectをearly returnの前に移動（rules-of-hooks修正）
- AutoSignin: useSyncExternalStoreでマウント検知（set-state-in-effect修正）
- set-state-in-effectをwarnに設定（fetch loading等の正当なパターン向け）
- no-img-elementをoff（動的URL/S3署名付きURLのためnext/imageは不適）
- 全ファイルのunused imports/varsを削除（11ファイル）
- alt-text修正（Image → ImageIconにリネームして解消）
- no-explicit-any修正（ToolUseCallbackData型を定義、unknown castに置換）

## Lint結果
- Error: 7 → 0
- Warning: 34 → 7（exhaustive-deps 4件 + set-state-in-effect 3件のみ）
- ビルド: パス