### PR TITLE
fix: add path traversal validation to style name parameters

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -245,6 +245,8 @@ def get_style(name: str) -> Dict[str, Any]:
     """
     if not RESOURCE_BUCKET:
         return {"error": f"Style not found: {name}"}, 404
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", name):
+        return {"error": "Invalid style name"}, 400
     key = f"references/examples/styles/{name}.html"
     try:
         body = s3_client.get_object(Bucket=RESOURCE_BUCKET, Key=key)["Body"].read().decode("utf-8")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -15,6 +15,7 @@ To use a custom backend, replace AwsStorage with your Storage ABC implementation
 import json
 import logging
 import os
+import re
 import sys
 from contextvars import ContextVar
 from pathlib import Path
@@ -359,6 +360,8 @@ def apply_style(deck_id: str, style: str) -> str:
         JSON confirmation.
     """
     _check_deck_access(deck_id)
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", style):
+        raise ValueError("Invalid style name")
     html_key = f"references/examples/styles/{style}.html"
     html_bytes = _storage.download_file(key=html_key)
     dest_key = f"decks/{deck_id}/specs/art-direction.html"


### PR DESCRIPTION
## Changes

PR #6で追加された`get_style`エンドポイントと`apply_style`ツールに、スタイル名のバリデーションを追加。

`../`等を含むパストラバーサル攻撃を防止するため、スタイル名を`[a-zA-Z0-9_-]+`に制限。

- `api/index.py`: 不正な名前に400を返す
- `mcp-server/server.py`: 不正な名前にValueErrorをraise