### PR TITLE
chore: bump actions/upload-artifact from v4 to v5 for Node.js 24 support

### DIFF
--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run ASH scan
         run: ash --mode local --fail-on-findings
       - name: Upload scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: ash-results


### PR DESCRIPTION
## Summary

`actions/upload-artifact@v4` runs on Node.js 20, which is deprecated and will be forced to Node.js 24 starting June 2nd, 2026.

This PR bumps to `actions/upload-artifact@v5`, which runs on Node.js 24 natively.

## Changes

- `.github/workflows/ash.yml`: `actions/upload-artifact@v4` → `@v5`

## Reference

- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/