### PR TITLE
fix: correct broken link in add-to-gateway.md

### DIFF
--- a/docs/en/add-to-gateway.md
+++ b/docs/en/add-to-gateway.md
@@ -41,7 +41,7 @@ For multi-user deployments, connect through Amazon Bedrock AgentCore Gateway. Th
 
 ### Prerequisites
 
-- Layer 3 deployed via CDK (see [Deployment Guide](deploy.md))
+- Layer 3 deployed via CDK (see [Getting Started — Layer 3](getting-started.md#layer-3-remote-mcp-server-aws))
 - Amazon Bedrock AgentCore Gateway configured in your AWS account
 
 ### Register as a Gateway Target


### PR DESCRIPTION
## Summary

`docs/en/add-to-gateway.md` contained a link to non-existent `deploy.md`. Corrected to `getting-started.md#layer-3-remote-mcp-server-aws`.

## Changes

- `docs/en/add-to-gateway.md`: Fixed broken link in Prerequisites section

Found during docs/README audit — the Japanese version (`docs/ja/add-to-gateway.md`) already had the correct link.