### PR TITLE
fix: add missing Palette import and CI undefined-reference check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Lint
         run: npm run lint
         working-directory: web-ui
+      - name: Check for undefined references
+        run: |
+          # Catch "Cannot find name" errors that cause runtime crashes
+          # Full tsc --noEmit is not yet clean; this targets the most critical class
+          ERRORS=$(npx tsc --noEmit 2>&1 | grep "Cannot find name" || true)
+          if [ -n "$ERRORS" ]; then
+            echo "$ERRORS"
+            echo "::error::Undefined references found — these will crash at runtime"
+            exit 1
+          fi
+        working-directory: web-ui
       - name: Build
         run: npm run build
         working-directory: web-ui

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -54,7 +54,7 @@ function renderInlinePreviews(text: string, urls: Record<string, string>): strin
  * @param text - Raw text that may contain mentions or color codes
  * @returns Array of string and JSX elements with mentions/colors highlighted
  */
-function highlightMentions(text: string): (string | JSX.Element)[] {
+function highlightMentions(text: string): (string | React.JSX.Element)[] {
   // Combined regex: mentions OR hex color codes
   const COMBINED_RE = /(@Page\s\d+|@\[[^\]]+\]|#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{3})\b)/g
   const parts = text.split(COMBINED_RE)

--- a/web-ui/src/components/chat/ToolCard.tsx
+++ b/web-ui/src/components/chat/ToolCard.tsx
@@ -27,7 +27,7 @@
 import {
   BookOpen, List, Search, FolderPlus, Pencil, Image,
   Trash2, ArrowUpDown, FolderOpen, Copy, Globe, Wrench,
-  Check, FileText, Download, Play, Code,
+  Check, FileText, Download, Play, Code, Palette,
   LayoutTemplate, Package, AlertCircle,
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"


### PR DESCRIPTION
## Problem

The /decks/ page crashed at runtime with:

    Uncaught ReferenceError: Palette is not defined

This was not caught by CI because:
1. next.config.ts has ignoreBuildErrors:true so npm run build skips type checking
2. ESLint no-undef is disabled for TypeScript files by design
3. No tsc --noEmit step existed in the web-ui CI job

## Changes

### Bug fixes
- web-ui/src/components/chat/ToolCard.tsx: Add missing Palette import from lucide-react
- web-ui/src/components/chat/ChatMessage.tsx: JSX.Element -> React.JSX.Element (React 19)

### CI improvement
- .github/workflows/ci.yml: Add "Cannot find name" check to web-ui job. Full tsc has 29 pre-existing errors, so a targeted grep catches the most critical class (undefined references that crash at runtime) without blocking on unrelated type noise.

## Already deployed
The fix has been built and deployed to CloudFront via deploy_webui.sh.
