### PR TITLE
fix: Style Gallery CORS error and blank preview

### DIFF
--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -187,7 +187,9 @@ export class WebUiStack extends cdk.Stack {
     api.root.addResource("chat").addResource("{session_id}").addMethod("GET", integration, auth);
     const slides = api.root.addResource("slides");
     slides.addResource("search").addMethod("GET", integration, auth);
-    api.root.addResource("styles").addMethod("GET", integration, auth);
+    const styles = api.root.addResource("styles");
+    styles.addMethod("GET", integration, auth);
+    styles.addResource("{name}").addMethod("GET", integration, auth);
 
     // --- Deploy web-ui static files to S3 ---
     const deployment = new s3deploy.BucketDeployment(this, "DeploySite", {

--- a/web-ui/src/components/deck/StyleGalleryModal.tsx
+++ b/web-ui/src/components/deck/StyleGalleryModal.tsx
@@ -146,14 +146,23 @@ function StylePreview({ html, loading }: { html: string; loading: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState(0)
 
-  useEffect(() => {
-    const el = containerRef.current
-    if (!el) return
-    const ro = new ResizeObserver(([entry]) => {
-      setContainerWidth(entry.contentRect.width)
-    })
-    ro.observe(el)
-    return () => ro.disconnect()
+  // Use callback ref to handle DOM element changes (e.g. after loading→content transition)
+  const roRef = useRef<ResizeObserver | null>(null)
+  const measuredRef = useCallback((node: HTMLDivElement | null) => {
+    if (roRef.current) {
+      roRef.current.disconnect()
+      roRef.current = null
+    }
+    if (node) {
+      // Immediately measure
+      const w = node.getBoundingClientRect().width
+      if (w > 0) setContainerWidth(w)
+      // Observe future resizes
+      roRef.current = new ResizeObserver(([entry]) => {
+        setContainerWidth(entry.contentRect.width)
+      })
+      roRef.current.observe(node)
+    }
   }, [])
 
   if (loading || !html) {
@@ -164,23 +173,30 @@ function StylePreview({ html, loading }: { html: string; loading: boolean }) {
     )
   }
 
-  const ratio = containerWidth > 0 ? containerWidth / 1920 : 1
+  const ratio = containerWidth > 0 ? containerWidth / 1920 : 0
+  const slideCount = (html.match(/class="slide"/g) || []).length || 5
 
   return (
-    <div ref={containerRef} className="overflow-x-hidden">
-      <div style={{ width: containerWidth, height: 1080 * ratio * 10, overflow: "hidden" }}>
-        <iframe
-          srcDoc={html}
-          sandbox="allow-same-origin"
-          title="Style Preview"
-          style={{
-            width: 1920,
-            height: 10800,
-            border: "none",
-            transformOrigin: "top left",
-            transform: `scale(${ratio})`,
-          }}
-        />
+    <div ref={measuredRef} className="w-full overflow-x-hidden">
+      <div style={{ width: "100%", height: ratio > 0 ? 1080 * ratio * slideCount : 400, overflow: "hidden" }}>
+        {ratio > 0 ? (
+          <iframe
+            srcDoc={html}
+            sandbox="allow-same-origin"
+            title="Style Preview"
+            style={{
+              width: 1920,
+              height: 1080 * slideCount,
+              border: "none",
+              transformOrigin: "top left",
+              transform: `scale(${ratio})`,
+            }}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full">
+            <div className="w-6 h-6 border-2 border-brand-teal/30 border-t-brand-teal rounded-full animate-spin" />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web-ui/src/services/deckService.ts
+++ b/web-ui/src/services/deckService.ts
@@ -404,7 +404,7 @@ export interface StyleEntry {
  */
 export async function fetchStyles(idToken: string): Promise<StyleEntry[]> {
   const base = await getApiBaseUrl()
-  const res = await fetch(`${base}/styles`, {
+  const res = await fetch(`${base}styles`, {
     headers: { Authorization: `Bearer ${idToken}` },
   })
   if (!res.ok) return []
@@ -421,7 +421,7 @@ export async function fetchStyles(idToken: string): Promise<StyleEntry[]> {
  */
 export async function fetchStyleHtml(name: string, idToken: string): Promise<string> {
   const base = await getApiBaseUrl()
-  const res = await fetch(`${base}/styles/${encodeURIComponent(name)}`, {
+  const res = await fetch(`${base}styles/${encodeURIComponent(name)}`, {
     headers: { Authorization: `Bearer ${idToken}` },
   })
   if (!res.ok) return ""


### PR DESCRIPTION
## Problem

Style Gallery modal had two issues:

1. **CORS error on `/styles/{name}`** — Clicking a style card to preview triggered `net::ERR_FAILED` because the API Gateway resource for `/styles/{name}` was missing. The OPTIONS preflight returned 403 (`MissingAuthenticationTokenException`), causing the browser to block the actual GET request.

2. **Blank preview (black screen)** — Even after fixing CORS, the preview iframe never rendered. The `StylePreview` component used `useEffect([], ...)` with an early return for loading state, so when `html` arrived and the container div mounted, the `ResizeObserver` was never re-attached → `containerWidth` stayed 0 → iframe was never rendered.

## Changes

| File | Change |
|------|--------|
| `infra/lib/web-ui-stack.ts` | Add `/styles/{name}` GET resource with Cognito auth + CORS preflight |
| `web-ui/.../S
Style Gallery modal had two issues:

1. **CORS error on `/styles/{name}`** — Clicking a style card to preview triggered `net::ERt slides fo
1. **CORS error on `/styles/{namui/
2. **Blank preview (black screen)** — Even after fixing CORS, the preview iframe never rendered. The `StylePreview` component used `useEffect([], ...)` with an early return for loading state, so when `html` arrived and the container div mounted, the `ResizeObserver` was never re-attached → \onT
## Changes

| File | Change |
|------|--------|
| `infra/lib/web-ui-stack.ts` | Add `/styles/{name}` GET resource with Cognito auth + CORS preflight |
| `web-ui/.../S
Style Gallery modal had two issues:

1. **CORS error on `/styles/{name}`** — Clicking a style card to preview triggered `net::ERt slides fo
1. **C