### PR TITLE
🐛 Fix slide preview PNG re-downloading on every poll

### DIFF
--- a/web-ui/src/hooks/useWorkspace.ts
+++ b/web-ui/src/hooks/useWorkspace.ts
@@ -70,7 +70,10 @@ export function useWorkspace(
 
   // Clear URL cache when generate_pptx is triggered so new PNGs are picked up
   useEffect(() => {
-    if (pptxRequested) stablePreviewUrls.current.clear()
+    if (pptxRequested) {
+      stablePreviewUrls.current.clear()
+      prevSlideKeyRef.current = ""
+    }
   }, [pptxRequested])
 
   useEffect(() => {
@@ -174,13 +177,14 @@ export function useWorkspace(
   const waitingForPng = pptxRequested
 
   // Reset flag once PNGs change after generate_pptx
-  const prevSlideCountRef = useRef(0)
+  const prevPngKeyRef = useRef<string>("")
   useEffect(() => {
-    const count = deck?.slides.filter((s) => s.previewUrl).length ?? 0
-    if (pptxRequested && count > 0 && count !== prevSlideCountRef.current) {
+    if (!pptxRequested || !deck?.slides) return
+    const pngKey = deck.slides.map((s) => `${s.slideId}:${s.previewUrl || ""}`).join("|")
+    if (prevPngKeyRef.current && pngKey !== prevPngKeyRef.current) {
       setPptxRequested(false)
     }
-    prevSlideCountRef.current = count
+    prevPngKeyRef.current = pngKey
   }, [pptxRequested, deck?.slides])
 
   return {

--- a/web-ui/src/hooks/useWorkspace.ts
+++ b/web-ui/src/hooks/useWorkspace.ts
@@ -35,6 +35,7 @@ export function useWorkspace(
   const [deck, setDeck] = useState<DeckDetail | null>(null)
   const [createdDeckId, setCreatedDeckId] = useState<string | null>(null)
   const [pptxRequested, setPptxRequested] = useState(false)
+  const pptxRequestedRef = useRef(false)
   const [chatOpen, setChatOpen] = useState(false)
   const [chatTab, setChatTab] = useState<ChatTabKey>("new")
   const [scrollToSlide, setScrollToSlide] = useState<string>("")
@@ -70,6 +71,7 @@ export function useWorkspace(
 
   // Clear URL cache when generate_pptx is triggered so new PNGs are picked up
   useEffect(() => {
+    pptxRequestedRef.current = pptxRequested
     if (pptxRequested) {
       stablePreviewUrls.current.clear()
       prevSlideKeyRef.current = ""
@@ -112,13 +114,16 @@ export function useWorkspace(
           prevSlideKeyRef.current = slideKey
           step = 0 // reset to fast polling on change
         }
-        // Stabilise presigned URLs to prevent unnecessary image re-downloads
-        for (const s of data.slides) {
-          if (s.previewUrl && !stablePreviewUrls.current.has(s.slideId)) {
-            stablePreviewUrls.current.set(s.slideId, s.previewUrl)
-          }
-          if (stablePreviewUrls.current.has(s.slideId)) {
-            s.previewUrl = stablePreviewUrls.current.get(s.slideId)!
+        // Stabilise presigned URLs to prevent unnecessary image re-downloads.
+        // Skip cache while waiting for new PNGs after generate_pptx.
+        if (!pptxRequestedRef.current) {
+          for (const s of data.slides) {
+            if (s.previewUrl && !stablePreviewUrls.current.has(s.slideId)) {
+              stablePreviewUrls.current.set(s.slideId, s.previewUrl)
+            }
+            if (stablePreviewUrls.current.has(s.slideId)) {
+              s.previewUrl = stablePreviewUrls.current.get(s.slideId)!
+            }
           }
         }
         setDeck(data)

--- a/web-ui/src/hooks/useWorkspace.ts
+++ b/web-ui/src/hooks/useWorkspace.ts
@@ -66,6 +66,12 @@ export function useWorkspace(
   /* ── Data loading: workspace polling with exponential backoff ── */
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const prevSlideKeyRef = useRef<string>("")
+  const stablePreviewUrls = useRef<Map<string, string>>(new Map())
+
+  // Clear URL cache when generate_pptx is triggered so new PNGs are picked up
+  useEffect(() => {
+    if (pptxRequested) stablePreviewUrls.current.clear()
+  }, [pptxRequested])
 
   useEffect(() => {
     // Clear stale deck when switching to a different deck or entering "new" mode
@@ -97,11 +103,20 @@ export function useWorkspace(
       }
       try {
         const data = await getDeck(deckIdToLoad, idToken)
-        // Detect slide changes (new slides or new PNGs) → reset backoff
-        const slideKey = data.slides.map((s) => `${s.slideId}:${s.previewUrl || ""}`).join("|")
+        // Detect slide changes (added/removed/PNG generated) — exclude presigned URL from comparison
+        const slideKey = data.slides.map((s) => `${s.slideId}:${!!s.previewUrl}`).join("|")
         if (slideKey !== prevSlideKeyRef.current) {
           prevSlideKeyRef.current = slideKey
           step = 0 // reset to fast polling on change
+        }
+        // Stabilise presigned URLs to prevent unnecessary image re-downloads
+        for (const s of data.slides) {
+          if (s.previewUrl && !stablePreviewUrls.current.has(s.slideId)) {
+            stablePreviewUrls.current.set(s.slideId, s.previewUrl)
+          }
+          if (stablePreviewUrls.current.has(s.slideId)) {
+            s.previewUrl = stablePreviewUrls.current.get(s.slideId)!
+          }
         }
         setDeck(data)
       } catch {
@@ -118,6 +133,7 @@ export function useWorkspace(
 
     if (isAuthenticated) {
       prevSlideKeyRef.current = ""
+      stablePreviewUrls.current.clear()
       poll() // immediate first fetch
     }
 


### PR DESCRIPTION
## Problem

Slide preview PNGs were being re-downloaded every ~1 second in the WebUI. The exponential backoff in useWorkspace never stabilized because slideKey included
presigned URLs, which change on every API response even when the underlying PNG hasn't changed.

This caused:
- Backoff reset to 1s on every poll (presigned URL always differs → "change detected")
- <img> elements re-rendering with new URLs → browser re-downloading identical images
- Unnecessary API and network load

## Root Cause

typescript
// Before: presigned URL included — always differs
const slideKey = data.slides.map((s) => `${s.slideId}:${s.previewUrl || ""}`).join("|")


## Solution

Three changes to useWorkspace.ts:

1. slideKey comparison: Exclude presigned URL, use !!s.previewUrl (boolean presence only)
2. URL stabilisation cache (stablePreviewUrls ref): Reuse first-fetched presigned URL per slide to prevent <img> re-renders
3. Cache bypass during pptxRequested: Skip URL cache while waiting for new PNGs after generate_pptx, ensuring updated slides are picked up. Uses
pptxRequestedRef to access latest value inside the polling closure.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Idle polling | 1s loop, PNG re-download every poll | 6s stable, no re-download |
| After generate_pptx | Same 1s loop | Fast poll → detect new PNG → cache new URL → stabilize |
| Slide add/remove | Same 1s loop | Backoff reset → detect change → stabilize |

## Changed Files

- web-ui/src/hooks/useWorkspace.ts