### PR TITLE
🎨 fix(outline): improve label contrast for EVIDENCE/VISUAL/NOTES

### DIFF
--- a/web-ui/src/components/deck/OutlineView.tsx
+++ b/web-ui/src/components/deck/OutlineView.tsx
@@ -114,7 +114,7 @@ function DetailPanel({ subItems, state }: { subItems: OutlineSubItem[]; state: S
                   strokeWidth={1.5}
                 />
                 <div className="min-w-0 flex-1">
-                  <span className="text-[10px] uppercase tracking-[0.08em] text-foreground-muted/60 font-medium">
+                  <span className="text-[10px] uppercase tracking-[0.08em] text-foreground-secondary/70 font-medium">
                     {label}
                   </span>
                   <p className="text-[12.5px] text-foreground/80 leading-relaxed mt-0.5">


### PR DESCRIPTION
## What

Outline view の sub-item ラベル（EVIDENCE / VISUAL / NOTES）のコントラストを改善。

## Why

`text-foreground-muted/60` (oklch 0.40 × 60%) ではダーク背景上でほぼ読めなかった。

## Change

`text-foreground-secondary/70` (oklch 0.65 × 70%) に変更。本文より控えめだが十分読める明度。