### PR TITLE
feat: show endpoints after deploy and add show_endpoints.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ skill/assets/config.json
 .ash/
 ?/
 skill/sdpm/.cache/
+
+# Temporary workspace
+tmp/

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -241,6 +241,16 @@ To use your own IdP (Entra ID, Auth0, Okta, etc.):
 2. Set `oidcDiscoveryUrl` and `allowedClients` in `config.yaml`
 3. The Runtime's `customJwtAuthorizer` validates JWTs from any OIDC-compliant issuer
 
+### Checking Endpoints After Deployment
+
+If the deploy script's log monitoring was interrupted, or you need to check the endpoints later, run:
+
+```bash
+bash scripts/show_endpoints.sh
+```
+
+This displays the CloudFront URL and Cognito sign-up URL from the deployed CloudFormation stacks.
+
 ### Updating the Web UI
 
 To update the Web UI without a full CDK deployment:

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -241,6 +241,16 @@ npx cdk deploy --all
 2. `config.yaml` に `oidcDiscoveryUrl` と `allowedClients` を設定
 3. Runtime の `customJwtAuthorizer` が OIDC 準拠の任意の発行者からの JWT を検証
 
+### デプロイ後のエンドポイント確認
+
+デプロイスクリプトのログ監視が途中で中断した場合や、後からエンドポイントを確認したい場合は以下を実行してください。
+
+```bash
+bash scripts/show_endpoints.sh
+```
+
+デプロイ済みの CloudFormation スタックから CloudFront URL と Cognito サインアップ URL を表示します。
+
 ### Web UI の更新
 
 Web UI のコードを変更した場合、フル CDK デプロイなしで更新できます。

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -337,7 +337,34 @@ print(data.get('nextForwardToken', ''))
 
     if [ "${BUILD_STATUS}" = "SUCCEEDED" ]; then
       echo ""
-      echo "Deployment complete. Check CloudFormation outputs above for endpoints."
+      echo "Deployment complete!"
+      echo ""
+
+      # Fetch and display key endpoints from CloudFormation outputs
+      SITE_URL=$(aws cloudformation describe-stacks \
+        --stack-name SdpmWebUi ${AWS_OPTS} \
+        --query 'Stacks[0].Outputs[?OutputKey==`SiteUrl`].OutputValue' \
+        --output text 2>/dev/null || echo "")
+
+      USER_POOL_ID=$(aws cloudformation describe-stacks \
+        --stack-name SdpmAuth ${AWS_OPTS} \
+        --query 'Stacks[0].Outputs[?OutputKey==`UserPoolId`].OutputValue' \
+        --output text 2>/dev/null || echo "")
+
+      if [ -n "${SITE_URL}" ]; then
+        COGNITO_CONSOLE_URL="https://${REGION}.console.aws.amazon.com/cognito/v2/idp/user-pools/${USER_POOL_ID}/users?region=${REGION}"
+
+        echo "========================================="
+        echo "  CloudFront URL      : ${SITE_URL}"
+        echo "  Cognito User Pool   : ${COGNITO_CONSOLE_URL}"
+        echo "========================================="
+        echo ""
+        echo "1. Open the Cognito User Pool console to create a user"
+        echo "2. Open the CloudFront URL to access the Web UI"
+      else
+        echo "Check CloudFormation outputs for endpoints."
+      fi
+
       exit 0
     else
       echo ""

--- a/scripts/show_endpoints.sh
+++ b/scripts/show_endpoints.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# show_endpoints.sh — Display CloudFront URL and Cognito User Pool console URL
+#                     from deployed CloudFormation stacks.
+#
+# Usage:
+#   ./scripts/show_endpoints.sh
+#   ./scripts/show_endpoints.sh --region us-west-2
+#   ./scripts/show_endpoints.sh --profile my-profile
+
+set -euo pipefail
+
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+PROFILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)  REGION="$2"; shift 2 ;;
+    --profile) PROFILE="$2"; shift 2 ;;
+    *)         echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+AWS_OPTS="--region ${REGION}"
+if [ -n "$PROFILE" ]; then
+  AWS_OPTS="${AWS_OPTS} --profile ${PROFILE}"
+fi
+
+# --- Fetch CloudFormation outputs ---
+SITE_URL=$(aws cloudformation describe-stacks \
+  --stack-name SdpmWebUi ${AWS_OPTS} \
+  --query 'Stacks[0].Outputs[?OutputKey==`SiteUrl`].OutputValue' \
+  --output text 2>/dev/null || echo "")
+
+USER_POOL_ID=$(aws cloudformation describe-stacks \
+  --stack-name SdpmAuth ${AWS_OPTS} \
+  --query 'Stacks[0].Outputs[?OutputKey==`UserPoolId`].OutputValue' \
+  --output text 2>/dev/null || echo "")
+
+if [ -z "${SITE_URL}" ]; then
+  echo "Error: SdpmWebUi stack not found or has no SiteUrl output."
+  echo "Make sure Layer 4 (--layer4) has been deployed in region ${REGION}."
+  exit 1
+fi
+
+COGNITO_CONSOLE_URL="https://${REGION}.console.aws.amazon.com/cognito/v2/idp/user-pools/${USER_POOL_ID}/users?region=${REGION}"
+
+echo ""
+echo "========================================="
+echo "  CloudFront URL      : ${SITE_URL}"
+echo "  Cognito User Pool   : ${COGNITO_CONSOLE_URL}"
+echo "========================================="
+echo ""
+echo "1. Open the Cognito User Pool console to create a user"
+echo "2. Open the CloudFront URL to access the Web UI"


### PR DESCRIPTION
## What

- `deploy.sh`: Display CloudFront URL and Cognito console URL after successful deployment
- Add `scripts/show_endpoints.sh` for checking endpoints post-deploy
- Document `show_endpoints.sh` in getting-started (EN/JA)
- `.gitignore`: add `tmp/`

## Why

After a full Layer 4 deployment, users had to manually dig through CloudFormation outputs to find the CloudFront URL and Cognito User Pool. Now the deploy script shows them automatically, and `show_endpoints.sh` lets you check them anytime.
