### PR TITLE
Extract high-level APIs from CLI, make mcp-local a thin wrapper

### DIFF
--- a/.ash.yaml
+++ b/.ash.yaml
@@ -79,6 +79,14 @@ global_settings:
       expiration: "2027-03-29"
 
     - rule_id: "B108"
+      path: "skill/sdpm/api.py"
+      reason: >
+        High-level API uses /tmp for transient PPTX preview files.
+        Extracted from pptx_builder.py (Layer 1). Runs on developer's machine,
+        not in a shared server environment.
+      expiration: "2027-03-29"
+
+    - rule_id: "B108"
       path: "skill/sdpm/analyzer/__init__.py"
       reason: >
         Template analyzer reads preview PNGs from /tmp. Local CLI tool (Layer 1),

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,10 @@ web-ui/.next/
 web-ui/public/aws-exports.json
 
 # Kiro / Q-SPEC (local steering, specs, settings)
-.kiro/
+.kiro/*
+!.kiro/steering/
+.kiro/steering/*
+!.kiro/steering/principles.md
 
 # Config (contains secrets)
 infra/config.yaml

--- a/.kiro/steering/principles.md
+++ b/.kiro/steering/principles.md
@@ -1,0 +1,65 @@
+# Principles
+
+## Architecture: 3-Layer Structure
+
+```
+Layer 1: CLI (skill/scripts/pptx_builder.py)
+  ↓ uses
+Skill Engine (skill/sdpm/)          ← Core business logic
+  ↑ uses                ↑ uses
+Layer 2: MCP Local      Layer 3: MCP Remote
+(mcp-local/)            (mcp-server/)
+```
+
+## Engine (`skill/sdpm/`)
+
+PPTX生成エンジン。ビジネスロジックの唯一の実装場所。
+
+- `sdpm.builder` — PPTX構築（スライド生成、テンプレート処理）
+- `sdpm.preview` — プレビュー（PDF/PNG変換、autofit、レイアウト検証）
+- `sdpm.reference` — リファレンスドキュメントアクセス
+- `sdpm.api` — 高レベルAPI（generate, preview, init, code_block）
+- `sdpm.analyzer`, `sdpm.converter`, `sdpm.layout`, `sdpm.utils` — 各種ユーティリティ
+
+## Skill (`skill/`)
+
+Engine + CLI + リファレンスドキュメント + テンプレートを含むパッケージ。
+`sdpm-skill` としてインストールされ、Layer 2/3 から依存される。
+
+## MCP Local (`mcp-local/`) — Layer 2
+
+ローカル環境で動作するMCPサーバー。**薄いラッパー**であること。
+
+- 入力: MCPプロトコルのJSON params → Engine APIの引数に変換
+- 処理: Engine API (`sdpm.api.*`, `sdpm.reference.*`) を呼ぶ
+- 出力: 結果をJSON文字列に変換して返す
+- 独自ロジックを持たない（Engine APIに存在しないロジックを書かない）
+
+## MCP Remote (`mcp-server/`) — Layer 3
+
+AWS上で動作するMCPサーバー。S3/DynamoDB依存がある。
+
+- S3 Storage経由のファイルアクセスなど、インフラ依存の処理は独自実装が許容される
+- ただし、Engine内に同等のロジックがある場合はそちらを使う
+
+## ロジック共通化の原則
+
+### CLIが正本
+CLIの現行動作が仕様の源泉。Engine APIはCLIの挙動を正確に再現する。
+
+### 共通化の判断基準
+
+共通化する:
+- データ取得・変換のロジック（ファイル走査、frontmatter strip、pptxノート取得など）
+- ビジネスルール（テンプレート解決、icon検証、autofit、imbalance check）
+- 計算ロジック（grid計算、コードハイライト、レイアウト）
+
+共通化しない:
+- I/O形式の違い（CLI: print/stdin、MCP Local: JSON、MCP Remote: S3/DynamoDB）
+- 環境固有の処理（MCP RemoteのS3 Storage、CLIのargparse）
+- UI層の処理（エラーメッセージのフォーマット、ブラウザ起動の有無）
+
+### 迷ったときの判断フロー
+1. そのロジックはCLIにあるか？ → あればEngine APIに切り出して共通化
+2. インフラ依存か？ → S3/DynamoDB等に依存するならMCP Remote独自実装を許容
+3. 表示・出力の違いだけか？ → Engine APIでデータを返し、各層で出力を制御

--- a/.kiro/steering/principles.md
+++ b/.kiro/steering/principles.md
@@ -5,7 +5,7 @@
 ```
 Layer 1: CLI (skill/scripts/pptx_builder.py)
   ↓ uses
-Skill Engine (skill/sdpm/)          ← Core business logic
+Skill Engine (skill/sdpm/)          ← Single source of business logic
   ↑ uses                ↑ uses
 Layer 2: MCP Local      Layer 3: MCP Remote
 (mcp-local/)            (mcp-server/)
@@ -13,53 +13,53 @@ Layer 2: MCP Local      Layer 3: MCP Remote
 
 ## Engine (`skill/sdpm/`)
 
-PPTX生成エンジン。ビジネスロジックの唯一の実装場所。
+The PPTX generation engine. The single source of truth for all business logic.
 
-- `sdpm.builder` — PPTX構築（スライド生成、テンプレート処理）
-- `sdpm.preview` — プレビュー（PDF/PNG変換、autofit、レイアウト検証）
-- `sdpm.reference` — リファレンスドキュメントアクセス
-- `sdpm.api` — 高レベルAPI（generate, preview, init, code_block）
-- `sdpm.analyzer`, `sdpm.converter`, `sdpm.layout`, `sdpm.utils` — 各種ユーティリティ
+- `sdpm.builder` — PPTX construction (slide generation, template processing)
+- `sdpm.preview` — Preview (PDF/PNG conversion, autofit, layout validation)
+- `sdpm.reference` — Reference document access
+- `sdpm.api` — High-level API (generate, preview, init, code_block)
+- `sdpm.analyzer`, `sdpm.converter`, `sdpm.layout`, `sdpm.utils` — Utilities
 
 ## Skill (`skill/`)
 
-Engine + CLI + リファレンスドキュメント + テンプレートを含むパッケージ。
-`sdpm-skill` としてインストールされ、Layer 2/3 から依存される。
+Package containing Engine + CLI + reference documents + templates.
+Installed as `sdpm-skill` and consumed by Layer 2 and Layer 3.
 
 ## MCP Local (`mcp-local/`) — Layer 2
 
-ローカル環境で動作するMCPサーバー。**薄いラッパー**であること。
+MCP server for local environments. Must be a **thin wrapper**.
 
-- 入力: MCPプロトコルのJSON params → Engine APIの引数に変換
-- 処理: Engine API (`sdpm.api.*`, `sdpm.reference.*`) を呼ぶ
-- 出力: 結果をJSON文字列に変換して返す
-- 独自ロジックを持たない（Engine APIに存在しないロジックを書かない）
+- Input: Convert MCP JSON params to Engine API arguments
+- Processing: Call Engine API (`sdpm.api.*`, `sdpm.reference.*`)
+- Output: Convert results to JSON strings
+- No independent logic (do not implement logic that doesn't exist in Engine API)
 
 ## MCP Remote (`mcp-server/`) — Layer 3
 
-AWS上で動作するMCPサーバー。S3/DynamoDB依存がある。
+MCP server running on AWS with S3/DynamoDB dependencies.
 
-- S3 Storage経由のファイルアクセスなど、インフラ依存の処理は独自実装が許容される
-- ただし、Engine内に同等のロジックがある場合はそちらを使う
+- Infrastructure-dependent operations (S3 Storage file access, etc.) may have independent implementations
+- However, use Engine logic when equivalent functionality exists
 
-## ロジック共通化の原則
+## Logic Sharing Principles
 
-### CLIが正本
-CLIの現行動作が仕様の源泉。Engine APIはCLIの挙動を正確に再現する。
+### Engine is the source of truth
+The Engine API is the canonical implementation. CLI, MCP Local, and MCP Remote are consumers.
 
-### 共通化の判断基準
+### What to share
 
-共通化する:
-- データ取得・変換のロジック（ファイル走査、frontmatter strip、pptxノート取得など）
-- ビジネスルール（テンプレート解決、icon検証、autofit、imbalance check）
-- 計算ロジック（grid計算、コードハイライト、レイアウト）
+Share:
+- Data retrieval and transformation logic (file scanning, frontmatter stripping, pptx notes extraction)
+- Business rules (template resolution, icon validation, autofit, imbalance check)
+- Computation logic (grid calculation, code highlighting, layout)
 
-共通化しない:
-- I/O形式の違い（CLI: print/stdin、MCP Local: JSON、MCP Remote: S3/DynamoDB）
-- 環境固有の処理（MCP RemoteのS3 Storage、CLIのargparse）
-- UI層の処理（エラーメッセージのフォーマット、ブラウザ起動の有無）
+Do not share:
+- I/O format differences (CLI: print/stdin, MCP Local: JSON, MCP Remote: S3/DynamoDB)
+- Environment-specific processing (MCP Remote S3 Storage, CLI argparse)
+- UI layer concerns (error message formatting, browser launch behavior)
 
-### 迷ったときの判断フロー
-1. そのロジックはCLIにあるか？ → あればEngine APIに切り出して共通化
-2. インフラ依存か？ → S3/DynamoDB等に依存するならMCP Remote独自実装を許容
-3. 表示・出力の違いだけか？ → Engine APIでデータを返し、各層で出力を制御
+### Decision flow when uncertain
+1. Does the logic exist in the Engine? → Use it
+2. Is it infrastructure-dependent? → S3/DynamoDB dependencies allow MCP Remote independent implementation
+3. Is the difference only in presentation/output? → Engine API returns data, each layer controls output

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -10,7 +10,6 @@ No AWS dependencies. No deck management (that's Layer 3).
 """
 
 import re
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -113,12 +112,11 @@ def analyze_template(
     if not path.exists():
         raise FileNotFoundError(f"Template not found: {template_path}")
 
-    output_dir = Path(tempfile.gettempdir()) / "sdpm" / "templates" / path.stem
-    result = _analyze(path, output_dir)
+    result = _analyze(path)
 
     if layout:
-        from sdpm.analyzer import get_layout_detail
-        detail = get_layout_detail(output_dir, layout)
+        from sdpm.analyzer import get_layout_placeholders
+        detail = get_layout_placeholders(path, layout)
         if detail:
             result["layout_detail"] = detail
         else:
@@ -715,39 +713,36 @@ def code_block(
     from sdpm.builder.constants import CODE_COLORS
 
     colors = CODE_COLORS.get(theme, CODE_COLORS["dark"])
+    bg = colors["background"]
+    inverse_theme = "light" if theme == "dark" else "dark"
+    inverse_bg = CODE_COLORS[inverse_theme]["background"]
+    label_fg = "000000" if theme == "dark" else "FFFFFF"
     label_height = 22
 
-    # Background
-    elements = [
-        {
-            "type": "shape",
-            "shape_type": "rectangle",
-            "x": x, "y": y, "width": width, "height": height,
-            "fill": colors["bg"],
-            "corner_radius": 8,
-        },
-        {
-            "type": "shape",
-            "shape_type": "rectangle",
-            "x": x, "y": y, "width": width, "height": label_height,
-            "fill": colors["label_bg"],
-            "corner_radius": 8,
-        },
+    label_map = {"typescript": "TypeScript", "javascript": "JavaScript", "csharp": "C#", "cpp": "C++"}
+    label_text = label_map.get(language, language.capitalize())
+
+    elements: list[dict[str, Any]] = [
         {
             "type": "textbox",
-            "x": x + 8, "y": y + 2,
-            "width": width - 16, "height": label_height - 4,
-            "text": [{"text": language, "font_size": 9, "color": colors["label_fg"]}],
+            "x": x, "y": y, "width": width, "height": label_height,
+            "fontSize": 8, "align": "left",
+            "fill": inverse_bg,
+            "text": f"{{{{#{label_fg}:{label_text}}}}}",
+            "marginLeft": 50000, "marginTop": 0, "marginRight": 0, "marginBottom": 0,
+            "autoWidth": True,
         },
     ]
 
-    # Highlighted code
     spans = highlight_code(code, language, theme)
     elements.append({
         "type": "textbox",
-        "x": x + 12, "y": y + label_height + 4,
-        "width": width - 24, "height": height - label_height - 8,
+        "x": x, "y": y + label_height,
+        "width": width, "height": height - label_height,
+        "fill": bg,
         "text": spans,
+        "fontSize": 11, "fontFamily": "Courier New",
+        "marginLeft": 50000, "marginTop": 30000, "marginRight": 50000, "marginBottom": 30000,
     })
 
     return elements

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -5,109 +5,30 @@
 Security: AWS manages infrastructure security. You manage access control,
 data classification, and IAM policies. See SECURITY.md for details.
 
-Each tool wraps the skill/ engine for local filesystem usage.
+Thin wrappers around sdpm high-level APIs for local filesystem usage.
 No AWS dependencies. No deck management (that's Layer 3).
 """
 
-import re
-from datetime import datetime
+import json
 from pathlib import Path
 from typing import Any
 
-import json
+
+def init_presentation(name: str, template: str, skill_dir: Path) -> dict[str, Any]:
+    """Create a presentation workspace."""
+    from sdpm.api import init
+    return init(name=name, template=template or None)
 
 
-def _get_output_base_dir() -> Path:
-    """Return output base directory from config, with tilde expansion."""
-    try:
-        from sdpm.config import get_output_dir
-        return get_output_dir()
-    except Exception:
-        return Path.home() / "Documents" / "SDPM-Presentations"
-
-
-def init_presentation(
-    name: str,
-    template: str,
-    skill_dir: Path,
-) -> dict[str, Any]:
-    """Create a presentation workspace with empty JSON, specs/, and optional template.
-
-    Args:
-        name: Presentation name (used in directory name).
-        skill_dir: Path to the skill/ directory.
-        template: Template name (from list-templates) or full path. Required.
-
-    Returns:
-        Dict with output_dir, json_path, template info, and workspace file list.
-    """
-    from datetime import datetime as _dt
-
-    ts = _dt.now().strftime("%Y%m%d-%H%M")
-    dir_name = f"{ts}-{name}" if name else ts
-    out_dir = _get_output_base_dir() / dir_name
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    pres_data: dict[str, Any] = {"fonts": {"fullwidth": None, "halfwidth": None}, "slides": []}
-
-    if template:
-        templates_dir = skill_dir / "templates"
-        template_src = Path(template).expanduser()
-        if not template_src.exists() and "/" not in template and "\\" not in template:
-            candidate = templates_dir / (template if template.endswith(".pptx") else template + ".pptx")
-            if candidate.exists():
-                template_src = candidate
-        template_src = template_src.resolve()
-        if template_src.exists():
-            pres_data["template"] = template_src.name
-            from sdpm.analyzer import extract_fonts
-            pres_data["fonts"] = extract_fonts(template_src)
-
-    json_path = out_dir / "presentation.json"
-    import json
-    json_path.write_text(json.dumps(pres_data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-    # Create specs/ directory with empty spec files
-    specs_dir = out_dir / "specs"
-    specs_dir.mkdir(exist_ok=True)
-    spec_files = ("brief.md", "outline.md")
-    for spec_name in spec_files:
-        (specs_dir / spec_name).touch()
-
-    workspace = ["presentation.json"] + [f"specs/{s}" for s in spec_files]
-
-    return {
-        "output_dir": str(out_dir),
-        "json_path": str(json_path),
-        "template": pres_data.get("template", ""),
-        "fonts": pres_data.get("fonts", {}),
-        "workspace": workspace,
-    }
-
-
-def analyze_template(
-    template_path: str,
-    skill_dir: Path,
-    layout: str = "",
-) -> dict[str, Any]:
-    """Analyze a PPTX template to extract layouts, colors, fonts.
-
-    Args:
-        template_path: Path to .pptx file or template name.
-        skill_dir: Path to the skill/ directory.
-        layout: Optional layout name or index for detailed placeholder info.
-
-    Returns:
-        Dict with layouts, theme_colors, and fonts. If layout specified, includes placeholder details.
-    """
-    from sdpm.analyzer import analyze_template as _analyze
+def analyze_template(template_path: str, skill_dir: Path, layout: str = "") -> dict[str, Any]:
+    """Analyze a PPTX template to extract layouts, colors, fonts."""
+    from sdpm.analyzer import analyze_template as _analyze, get_layout_placeholders
 
     if not template_path:
-        raise FileNotFoundError("template_path is required. Use start_presentation to see available templates.")
+        raise FileNotFoundError("template_path is required.")
 
     path = Path(template_path)
     if not path.exists():
-        # Try as template name in templates/ directory
         path = skill_dir / "templates" / f"{template_path}.pptx"
     if not path.exists():
         raise FileNotFoundError(f"Template not found: {template_path}")
@@ -115,7 +36,6 @@ def analyze_template(
     result = _analyze(path)
 
     if layout:
-        from sdpm.analyzer import get_layout_placeholders
         detail = get_layout_placeholders(path, layout)
         if detail:
             result["layout_detail"] = detail
@@ -126,643 +46,103 @@ def analyze_template(
 
 
 def generate_pptx(
-    slides_json_path: str,
-    skill_dir: Path,
-    template: str = "",
-    output_path: str = "",
+    slides_json_path: str, skill_dir: Path,
+    template: str = "", output_path: str = "",
 ) -> dict[str, Any]:
-    """Generate PPTX from a JSON file.
-
-    Args:
-        slides_json_path: Path to slides JSON file.
-        skill_dir: Path to the skill/ directory.
-        template: Template name or path. Empty uses default.
-        output_path: Output path. Auto-generated if empty.
-
-    Returns:
-        Dict with output_path and slide summary.
-    """
-    from sdpm.builder import PPTXBuilder, resolve_override, validate_icons_in_json
-    from sdpm.utils.io import read_json
-
-    input_path = Path(slides_json_path)
-    if not input_path.exists():
-        raise FileNotFoundError(f"Slides JSON not found: {slides_json_path}")
-
-    try:
-        data = read_json(input_path)
-    except (json.JSONDecodeError, ValueError) as e:
-        return {"error": f"Invalid JSON in {slides_json_path}: {e}"}
-    templates_dir = skill_dir / "templates"
-
-    # Resolve template
-    template_file = None
-    custom_template = False
-    if template:
-        p = Path(template)
-        if p.exists():
-            template_file = p
-            custom_template = True
-        else:
-            named = templates_dir / f"{template}.pptx"
-            if named.exists():
-                template_file = named
-                custom_template = True
-            else:
-                raise FileNotFoundError(f"Template not found: {template}")
-    elif data.get("template"):
-        t = input_path.parent / data["template"]
-        if t.exists():
-            template_file = t
-            custom_template = True
-
-    if not template_file:
-        template_file = templates_dir / "default.pptx"
-        if not template_file.exists():
-            raise FileNotFoundError(f"Default template not found: {template_file}")
-
-    # Validate icons
-    missing = validate_icons_in_json(data)
-    if missing:
-        return {"error": f"Missing icons ({len(missing)}): {', '.join(sorted(missing)[:10])}"}
-
-    # Build
-    fonts = data.get("fonts")
-    builder = PPTXBuilder(
-        template_file, custom_template=custom_template, fonts=fonts,
-        base_dir=input_path.parent,
-        default_text_color=data.get("defaultTextColor"),
+    """Generate PPTX from a JSON file with full post-processing."""
+    from sdpm.api import generate
+    return generate(
+        json_path=slides_json_path,
+        template=template or None,
+        output_path=output_path or None,
     )
-    slides = data.get("slides", [])
-
-    id_map = {}
-    for s in slides:
-        if "id" in s:
-            id_map[s["id"]] = s
-
-    for s in slides:
-        builder.add_slide(resolve_override(s, id_map))
-
-    # Output path
-    if not output_path:
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        p = input_path.with_suffix(".pptx")
-        out = p.with_stem(f"{p.stem}_{ts}")
-    else:
-        out = Path(output_path)
-
-    builder.save(out)
-
-    summary = []
-    for i, s in enumerate(slides, 1):
-        title = s.get("title", "(no title)")
-        if isinstance(title, dict):
-            title = title.get("text", "(no title)")
-        summary.append(f"page{i:02d} - {title}")
-
-    return {
-        "output_path": str(out),
-        "slide_count": len(slides),
-        "slides": summary,
-    }
 
 
-def preview(
-    pptx_path: str,
-    pages: str = "",
-) -> dict[str, Any]:
-    """Generate PNG previews of a PPTX file.
-
-    Args:
-        pptx_path: Path to .pptx file.
-        pages: Comma-separated page numbers. Empty for all.
-
-    Returns:
-        Dict with generated PNG paths.
-    """
-    import platform
+def preview(pptx_path: str, pages: str = "") -> dict[str, Any]:
+    """Generate PNG previews of a PPTX file."""
+    from sdpm.api import preview as _preview
 
     path = Path(pptx_path).resolve()
     if not path.exists():
         raise FileNotFoundError(f"PPTX not found: {pptx_path}")
 
-    os_name = platform.system()
-    if os_name == "Darwin":
-        return _preview_macos(path, pages)
-    elif os_name == "Windows" or _is_wsl():
-        return _preview_windows(path, pages)
-    else:
-        return {
-            "error": "Preview requires Microsoft PowerPoint. "
-                     "On macOS: install Microsoft PowerPoint. "
-                     "On Windows/WSL: PowerPoint must be installed. "
-                     "Alternatively, open the generated PPTX file directly."
-        }
-
-
-def _is_wsl() -> bool:
-    """Check if running under Windows Subsystem for Linux."""
-    proc_version = Path("/proc/version")
-    return proc_version.exists() and "microsoft" in proc_version.read_text().lower()
-
-
-def _preview_macos(pptx_path: Path, pages: str) -> dict[str, Any]:
-    """Generate PNG previews on macOS via PowerPoint + AppleScript.
-
-    Args:
-        pptx_path: Resolved path to .pptx file.
-        pages: Comma-separated page numbers.
-
-    Returns:
-        Dict with generated PNG paths.
-    """
-    import subprocess
-    import glob
-
-    from pptx import Presentation
-    from sdpm.preview.backend import _mac_open_pptx_background, _mac_restore_pptx_focus_async
-
-    output_dir = Path("/tmp/pptx-preview")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    pdf_path = output_dir / "slides.pdf"
-
-    # Open in PowerPoint background, export PDF
-    pptx_name = pptx_path.name
-    restore_info = _mac_open_pptx_background(pptx_path)
-    _mac_restore_pptx_focus_async(restore_info)
-
-    import time
-    time.sleep(2)
-
-    script = f'''
-    tell application "Microsoft PowerPoint"
-        set theDoc to presentation "{pptx_name}"
-        set outPath to (POSIX file "{pdf_path}") as text
-        save theDoc in outPath as save as PDF
-        close theDoc saving no
-    end tell
-    '''
-    result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-    if result.returncode != 0 or not pdf_path.exists():
-        return {"error": f"PDF export failed. Is Microsoft PowerPoint installed? Error: {result.stderr}"}
-
-    # PDF → PNG via pdftoppm
-    cmd = ["pdftoppm", "-png", str(pdf_path), str(output_dir / "page")]
-    result = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-    if result.returncode != 0:
-        return {"error": f"PNG conversion failed. Is poppler (pdftoppm) installed? Error: {result.stderr}"}
-
-    # Parse pages filter
-    pages_set = None
-    if pages:
-        pages_set = set(int(p.strip()) for p in pages.split(","))
-
-    # Rename with slide titles
-    prs = Presentation(str(pptx_path))
-    titles = {}
-    for i, slide in enumerate(prs.slides, 1):
-        title = ""
-        if slide.shapes.title:
-            title = slide.shapes.title.text.strip().replace("\n", " ")[:30]
-        title = re.sub(r'[\\/:*?"<>|]', '', title)
-        titles[i] = title or "notitle"
-
-    generated = []
-    for png in sorted(glob.glob(str(output_dir / "page-*.png"))):
-        match = re.match(r'page-(\d+)\.png', Path(png).name)
-        if match:
-            num = int(match.group(1))
-            if pages_set and num not in pages_set:
-                Path(png).unlink()
-                continue
-            new_name = f"page{num:02d}-{titles.get(num, 'notitle')}.png"
-            new_path = output_dir / new_name
-            Path(png).rename(new_path)
-            generated.append(str(new_path))
-
-    pdf_path.unlink(missing_ok=True)
-
-    return {"preview_dir": str(output_dir), "files": generated}
-
-
-def _preview_windows(pptx_path: Path, pages: str) -> dict[str, Any]:
-    """Generate PNG previews on Windows/WSL via PowerShell COM.
-
-    Args:
-        pptx_path: Resolved path to .pptx file.
-        pages: Comma-separated page numbers.
-
-    Returns:
-        Dict with generated PNG paths.
-    """
-    import subprocess
-    import glob
-
-    from pptx import Presentation
-
-    output_dir = pptx_path.parent / "preview"
-    output_dir.mkdir(parents=True, exist_ok=True)
-    png_dir = output_dir / "ppt_png"
-    png_dir.mkdir(parents=True, exist_ok=True)
-
-    if _is_wsl():
-        win_pptx = subprocess.run(["wslpath", "-w", str(pptx_path)], capture_output=True, text=True).stdout.strip()  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-        win_png = subprocess.run(["wslpath", "-w", str(png_dir)], capture_output=True, text=True).stdout.strip()  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-        ps_cmd = (
-            f"$app = New-Object -ComObject PowerPoint.Application; "
-            f"$prs = $app.Presentations.Open('{win_pptx}', "
-            f"[Microsoft.Office.Core.MsoTriState]::msoTrue, "
-            f"[Microsoft.Office.Core.MsoTriState]::msoFalse, "
-            f"[Microsoft.Office.Core.MsoTriState]::msoFalse); "
-            f"$prs.SaveAs('{win_png}', 18); "
-            f"$prs.Close(); $app.Quit()"
-        )
-        shell = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
-    else:
-        ps_cmd = (
-            f"$app = New-Object -ComObject PowerPoint.Application; "
-            f"$prs = $app.Presentations.Open('{pptx_path}', "
-            f"[Microsoft.Office.Core.MsoTriState]::msoTrue, "
-            f"[Microsoft.Office.Core.MsoTriState]::msoFalse, "
-            f"[Microsoft.Office.Core.MsoTriState]::msoFalse); "
-            f"$prs.SaveAs('{png_dir}', 18); "
-            f"$prs.Close(); $app.Quit()"
-        )
-        shell = "powershell.exe"
-
-    result = subprocess.run([shell, "-Command", ps_cmd], capture_output=True, timeout=60)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-    if result.returncode != 0:
-        stderr = result.stderr.decode("cp932", errors="replace") if result.stderr else ""
-        return {"error": f"PNG export failed: {stderr}"}
-
-    pages_set = None
-    if pages:
-        pages_set = set(int(p.strip()) for p in pages.split(","))
-
-    prs = Presentation(str(pptx_path))
-    titles = {}
-    for i, slide in enumerate(prs.slides, 1):
-        title = ""
-        if slide.shapes.title:
-            title = slide.shapes.title.text.strip().replace("\n", " ")[:30]
-        title = re.sub(r'[\\/:*?"<>|]', '', title)
-        titles[i] = title or "notitle"
-
-    png_files = sorted(glob.glob(str(png_dir / "**" / "*.png"), recursive=True))
-    if not png_files:
-        png_files = sorted(glob.glob(str(png_dir / "**" / "*.PNG"), recursive=True))
-
-    generated = []
-    for idx, png in enumerate(png_files, 1):
-        if pages_set and idx not in pages_set:
-            Path(png).unlink()
-            continue
-        new_name = f"page{idx:02d}-{titles.get(idx, 'notitle')}.png"
-        new_path = output_dir / new_name
-        Path(png).rename(new_path)
-        generated.append(str(new_path))
-
-    import shutil
-    shutil.rmtree(png_dir, ignore_errors=True)
-
-    return {"preview_dir": str(output_dir), "files": generated}
+    pages_list = [int(p.strip()) for p in pages.split(",") if p.strip()] if pages else None
+    return _preview(pptx_path=path, pages=pages_list)
 
 
 def search_assets(
-    query: str,
-    skill_dir: Path,
-    limit: int = 20,
-    source_filter: str = "",
-    type_filter: str = "",
-    theme_filter: str = "",
+    query: str, skill_dir: Path, limit: int = 20,
+    source_filter: str = "", type_filter: str = "", theme_filter: str = "",
 ) -> dict[str, Any]:
-    """Search assets (icons, images, etc.) by keyword using local manifests.
-
-    Args:
-        query: Search keyword.
-        skill_dir: Path to the skill/ directory.
-        limit: Maximum results.
-        source_filter: Filter by source name (e.g. "aws", "material").
-        type_filter: Filter by asset type.
-        theme_filter: Filter by theme.
-
-    Returns:
-        Dict with matching assets.
-    """
+    """Search assets by keyword."""
     from sdpm.assets import search_assets as _search
-
     return {
         "query": query,
         "results": _search(
-            query, limit=limit, source_filter=source_filter or None,
-            type_filter=type_filter or None, theme_filter=theme_filter or None,
+            query, limit=limit,
+            source_filter=source_filter or None,
+            type_filter=type_filter or None,
+            theme_filter=theme_filter or None,
         ),
     }
 
 
 def list_asset_sources(skill_dir: Path) -> dict[str, Any]:
-    """List available asset sources with counts and descriptions.
-
-    Args:
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with list of sources.
-    """
+    """List available asset sources."""
     from sdpm.assets import list_sources
-
     return {"sources": list_sources()}
 
 
-def _list_category(category_dir: Path) -> list[dict[str, str]]:
-    """List all .md, .pptx, and .html files in a category directory with descriptions.
-
-    For .md files, extracts description from frontmatter.
-    For .pptx files, extracts description from first slide's speaker notes.
-    For .html files, extracts description from <title> tag.
-    Recurses into subdirectories (e.g. styles/).
-
-    Args:
-        category_dir: Path to the category directory.
-
-    Returns:
-        List of dicts with name, description, and path.
-    """
-    from sdpm.reference import _get_description
-
-    if not category_dir.exists():
-        return []
-    items = []
-    seen: set[str] = set()
-    for f in sorted(category_dir.rglob("*")):
-        if f.suffix not in (".md", ".pptx", ".html"):
-            continue
-        # Use relative path from category_dir as the unique key
-        rel = f.relative_to(category_dir)
-        stem_key = str(rel.with_suffix(""))
-        if stem_key in seen:
-            continue
-        seen.add(stem_key)
-        desc = _get_description(f)
-        items.append({
-            "name": stem_key,
-            "description": desc,
-            "path": f"{category_dir.name}/{rel}",
-        })
-    return items
-
-
-def _read_docs(category_dir: Path, names: list[str]) -> list[dict[str, Any]]:
-    """Read one or more documents from a category directory.
-
-    Supports .md (returned as text), .pptx (rendered via get_pptx_notes),
-    and .html (returned as text).
-    Names can include page specifiers for pptx: "common/patterns/3" or "common/patterns/all".
-
-    Args:
-        category_dir: Path to the category directory.
-        names: List of document names. Supports "name", "name/page", "name/all".
-
-    Returns:
-        List of dicts with name, path, and content.
-    """
-    results = []
-    for name in names:
-        # Parse page specifier from name (e.g. "common/patterns/3" → file="common/patterns", pages=[3])
-        pages = None
-        has_page_specifier = False
-        parts = name.rsplit("/", 1)
-        file_name = name
-        if len(parts) == 2 and (parts[1].isdigit() or parts[1] == "all"):
-            file_name = parts[0]
-            has_page_specifier = True
-            pages = None if parts[1] == "all" else [int(parts[1])]
-
-        # Try .md first, then .pptx, then .html
-        md_path = category_dir / f"{file_name}.md"
-        pptx_path = category_dir / f"{file_name}.pptx"
-        html_path = category_dir / f"{file_name}.html"
-
-        if md_path.exists():
-            results.append({
-                "name": file_name,
-                "path": f"{category_dir.name}/{file_name}.md",
-                "content": md_path.read_text(encoding="utf-8"),
-            })
-        elif pptx_path.exists():
-            if not has_page_specifier:
-                # No page specifier — return slide description listing
-                from sdpm.reference import list_pptx_descriptions
-                descriptions = list_pptx_descriptions(str(pptx_path))
-                content = "\n".join(f"  {page:>3}  {desc}" for page, desc in descriptions)
-                results.append({
-                    "name": name,
-                    "path": f"{category_dir.name}/{file_name}.pptx",
-                    "content": content,
-                })
-            else:
-                from sdpm.reference import get_pptx_notes
-                notes = get_pptx_notes(pptx_path, pages=pages)
-                content_lines: list[str] = []
-                for page_num, note_text in notes:
-                    content_lines.append(f"## Page {page_num}\n\n{note_text}\n")
-                results.append({
-                    "name": name,
-                    "path": f"{category_dir.name}/{file_name}.pptx",
-                    "content": "\n".join(content_lines),
-                })
-        elif html_path.exists():
-            results.append({
-                "name": file_name,
-                "path": f"{category_dir.name}/{file_name}.html",
-                "content": html_path.read_text(encoding="utf-8"),
-            })
-        else:
-            available = sorted({
-                str(f.relative_to(category_dir).with_suffix(""))
-                for f in category_dir.rglob("*")
-                if f.suffix in (".md", ".pptx", ".html")
-            })
-            raise FileNotFoundError(
-                f"'{file_name}' not found in {category_dir.name}/. Available: {', '.join(available)}"
-            )
-    return results
-
-
 def list_styles(skill_dir: Path) -> dict[str, Any]:
-    """List available design styles from references/examples/styles/.
-
-    Extracts name and description from each HTML file's <title> tag.
-
-    Args:
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with styles list (name + description).
-    """
+    """List available design styles."""
+    from sdpm.reference import list_styles as _list_styles
     styles_dir = skill_dir / "references" / "examples" / "styles"
-    if not styles_dir.exists():
-        return {"styles": []}
-
-    styles: list[dict[str, str]] = []
-    for f in sorted(styles_dir.iterdir()):
-        if f.suffix != ".html" or f.name.startswith("."):
-            continue
-        description = ""
-        try:
-            content = f.read_text(encoding="utf-8")
-            m = re.search(r"<title>(.*?)</title>", content, re.IGNORECASE)
-            if m:
-                description = m.group(1).strip()
-        except Exception:
-            pass
-        styles.append({"name": f.stem, "description": description})
-    return {"styles": styles}
+    return {"styles": _list_styles(styles_dir)}
 
 
 def read_examples(names: list[str], skill_dir: Path) -> dict[str, Any]:
-    """Read design examples (components/patterns).
-
-    Without page specifier returns a listing of slide descriptions.
-    With page specifier returns full content.
-
-    Args:
-        names: Example names (e.g. ["patterns", "patterns/3", "components/all"]).
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with documents list.
-    """
-    return {"documents": _read_docs(skill_dir / "references" / "examples", names)}
+    """Read design examples."""
+    from sdpm.reference import read_docs
+    return {"documents": read_docs(skill_dir / "references" / "examples", names)}
 
 
 def list_workflows(skill_dir: Path) -> dict[str, Any]:
-    """List all workflow documents.
-
-    Args:
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with items list.
-    """
-    return {"items": _list_category(skill_dir / "references" / "workflows")}
+    """List all workflow documents."""
+    from sdpm.reference import list_category
+    return {"items": list_category(skill_dir / "references" / "workflows")}
 
 
 def read_workflows(names: list[str], skill_dir: Path) -> dict[str, Any]:
-    """Read one or more workflow documents.
-
-    Args:
-        names: Workflow names (e.g. ["create-new-2-build", "slide-json-spec"]).
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with documents list.
-    """
-    return {"documents": _read_docs(skill_dir / "references" / "workflows", names)}
+    """Read workflow documents."""
+    from sdpm.reference import read_docs
+    return {"documents": read_docs(skill_dir / "references" / "workflows", names)}
 
 
 def list_guides(skill_dir: Path) -> dict[str, Any]:
-    """List all guide documents.
-
-    Args:
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with items list.
-    """
-    return {"items": _list_category(skill_dir / "references" / "guides")}
+    """List all guide documents."""
+    from sdpm.reference import list_category
+    return {"items": list_category(skill_dir / "references" / "guides")}
 
 
 def read_guides(names: list[str], skill_dir: Path) -> dict[str, Any]:
-    """Read one or more guide documents.
-
-    Args:
-        names: Guide names (e.g. ["design-rules"]).
-        skill_dir: Path to the skill/ directory.
-
-    Returns:
-        Dict with documents list.
-    """
-    return {"documents": _read_docs(skill_dir / "references" / "guides", names)}
+    """Read guide documents."""
+    from sdpm.reference import read_docs
+    return {"documents": read_docs(skill_dir / "references" / "guides", names)}
 
 
 def code_block(
-    code: str,
-    language: str = "python",
-    theme: str = "dark",
-    x: int = 0,
-    y: int = 0,
-    width: int = 800,
-    height: int = 300,
+    code: str, language: str = "python", theme: str = "dark",
+    x: int = 0, y: int = 0, width: int = 800, height: int = 300,
 ) -> list[dict[str, Any]]:
-    """Generate slide elements JSON for a syntax-highlighted code block.
-
-    Args:
-        code: Source code text.
-        language: Programming language.
-        theme: Color theme ("dark" or "light").
-        x: X position in pixels.
-        y: Y position in pixels.
-        width: Width in pixels.
-        height: Height in pixels.
-
-    Returns:
-        List of slide element dicts for the code block.
-    """
-    from sdpm.utils.text import highlight_code
-    from sdpm.builder.constants import CODE_COLORS
-
-    colors = CODE_COLORS.get(theme, CODE_COLORS["dark"])
-    bg = colors["background"]
-    inverse_theme = "light" if theme == "dark" else "dark"
-    inverse_bg = CODE_COLORS[inverse_theme]["background"]
-    label_fg = "000000" if theme == "dark" else "FFFFFF"
-    label_height = 22
-
-    label_map = {"typescript": "TypeScript", "javascript": "JavaScript", "csharp": "C#", "cpp": "C++"}
-    label_text = label_map.get(language, language.capitalize())
-
-    elements: list[dict[str, Any]] = [
-        {
-            "type": "textbox",
-            "x": x, "y": y, "width": width, "height": label_height,
-            "fontSize": 8, "align": "left",
-            "fill": inverse_bg,
-            "text": f"{{{{#{label_fg}:{label_text}}}}}",
-            "marginLeft": 50000, "marginTop": 0, "marginRight": 0, "marginBottom": 0,
-            "autoWidth": True,
-        },
-    ]
-
-    spans = highlight_code(code, language, theme)
-    elements.append({
-        "type": "textbox",
-        "x": x, "y": y + label_height,
-        "width": width, "height": height - label_height,
-        "fill": bg,
-        "text": spans,
-        "fontSize": 11, "fontFamily": "Courier New",
-        "marginLeft": 50000, "marginTop": 30000, "marginRight": 50000, "marginBottom": 30000,
-    })
-
-    return elements
+    """Generate slide elements for a syntax-highlighted code block."""
+    from sdpm.api import code_block as _code_block
+    return _code_block(code=code, language=language, theme=theme, x=x, y=y, width=width, height=height)
 
 
-def pptx_to_json(
-    pptx_path: str,
-) -> dict[str, Any]:
-    """Convert PPTX to JSON representation.
-
-    Args:
-        pptx_path: Path to .pptx file.
-
-    Returns:
-        Dict with JSON representation of slides.
-    """
+def pptx_to_json(pptx_path: str) -> dict[str, Any]:
+    """Convert PPTX to JSON representation."""
     from sdpm.converter import pptx_to_json as _convert
-
     path = Path(pptx_path)
     if not path.exists():
         raise FileNotFoundError(f"PPTX not found: {pptx_path}")
-
     return _convert(str(path))

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -9,7 +9,6 @@ Thin wrappers around sdpm high-level APIs for local filesystem usage.
 No AWS dependencies. No deck management (that's Layer 3).
 """
 
-import json
 from pathlib import Path
 from typing import Any
 

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -94,9 +94,10 @@ def list_asset_sources(skill_dir: Path) -> dict[str, Any]:
 
 
 def list_styles(skill_dir: Path) -> dict[str, Any]:
-    """List available design styles."""
-    from sdpm.reference import list_styles as _list_styles
+    """List available design styles and open gallery in browser."""
+    from sdpm.reference import list_styles as _list_styles, open_styles_gallery
     styles_dir = skill_dir / "references" / "examples" / "styles"
+    open_styles_gallery(styles_dir)
     return {"styles": _list_styles(styles_dir)}
 
 

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -280,7 +280,7 @@ def _preview_macos(pptx_path: Path, pages: str) -> dict[str, Any]:
     import glob
 
     from pptx import Presentation
-    from sdpm.preview import _mac_open_pptx_background, _mac_restore_pptx_focus_async
+    from sdpm.preview.backend import _mac_open_pptx_background, _mac_restore_pptx_focus_async
 
     output_dir = Path("/tmp/pptx-preview")
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -55,7 +55,6 @@ from sdpm.preview import (
     refresh_autofit,
     unlock_height_constraints,
 )
-from sdpm.reference import _get_description
 from sdpm.utils.effects import apply_effects  # noqa: F401
 from sdpm.utils.image import apply_image_effects, resolve_image_path  # noqa: F401
 from sdpm.utils.io import read_json, write_json
@@ -241,101 +240,6 @@ def cmd_list_templates(args):
         print(f"  {t.stem}")
 
 
-def _list_or_show(category_dir, names, category_label):
-    """List or show documents in a category directory.
-
-    Supports two layouts:
-    - Categorized: subdirectories as categories, names use 'category/name' format
-    - Flat: files directly in category_dir, names use plain 'name' format
-
-    Args:
-        category_dir: Path to the category directory.
-        names: List of names to show. Empty list shows the listing.
-        category_label: Display label (e.g. "Examples").
-    """
-    if not category_dir.exists():
-        print(f"Directory not found: {category_dir}", file=sys.stderr)
-        return
-
-    # Discover subdirectories as categories
-    subdirs = sorted(d for d in category_dir.iterdir() if d.is_dir())
-    flat = not subdirs
-    root_files = _collect_files(category_dir) if flat else {}
-
-    if names:
-        for name in names:
-            if flat or '/' not in name:
-                # Flat mode: look up directly in category_dir
-                files = root_files if flat else {}
-                if not flat:
-                    # Categorized mode but no slash — try to find in subdirs
-                    for sd in subdirs:
-                        files = _collect_files(sd)
-                        if name in files:
-                            print(f"# Format: category/name (e.g. {sd.name}/{name})", file=sys.stderr)
-                            break
-                    else:
-                        print(f"# Format: category/name (e.g. pattern/{name})", file=sys.stderr)
-                    continue
-                doc = files.get(name)
-                if not doc:
-                    print(f"# Not found: {name}", file=sys.stderr)
-                    print(f"# Available: {', '.join(sorted(files.keys()))}", file=sys.stderr)
-                    continue
-            else:
-                cat, stem = name.split('/', 1)
-                sub = category_dir / cat
-                if not sub.is_dir():
-                    cats = [d.name for d in subdirs]
-                    print(f"# Category not found: {cat}", file=sys.stderr)
-                    print(f"# Available: {', '.join(cats)}", file=sys.stderr)
-                    continue
-                files = _collect_files(sub)
-                doc = files.get(stem)
-                if not doc:
-                    print(f"# Not found: {name}", file=sys.stderr)
-                    print(f"# Available in {cat}/: {', '.join(sorted(files.keys()))}", file=sys.stderr)
-                    continue
-            if doc.suffix == '.md':
-                text = doc.read_text(encoding="utf-8")
-                # Strip YAML frontmatter
-                lines = text.splitlines(True)
-                if lines and lines[0].strip() == '---':
-                    for i, line in enumerate(lines[1:], 1):
-                        if line.strip() == '---':
-                            text = ''.join(lines[i + 1:]).lstrip('\n')
-                            break
-                print(text)
-            print()
-    else:
-        print(f"# {category_label}")
-        if flat:
-            for stem in sorted(root_files.keys()):
-                f = root_files[stem]
-                desc = _get_description(f) or stem
-                print(f"  {stem:<36} {desc}")
-        else:
-            for sd in subdirs:
-                files = _collect_files(sd)
-                if not files:
-                    continue
-                print(f"\n## {sd.name.title()}")
-                for stem in sorted(files.keys()):
-                    f = files[stem]
-                    desc = _get_description(f) or stem
-                    print(f"  {sd.name}/{stem:<28} {desc}")
-
-
-def _collect_files(directory):
-    """Collect md/pptx files in directory. md takes priority over pptx for same stem."""
-    files = {}
-    for f in sorted(directory.glob("*.pptx")):
-        files[f.stem] = f
-    for f in sorted(directory.glob("*.md")):
-        files[f.stem] = f
-    return files
-
-
 def cmd_search_patterns(args):
     """Search patterns by keywords."""
     from sdpm.reference import search_patterns
@@ -350,7 +254,7 @@ def cmd_search_patterns(args):
 
 def cmd_examples(args):
     """List or show design examples (components/patterns/styles)."""
-    from sdpm.reference import get_pptx_notes, list_pptx_descriptions
+    from sdpm.reference import list_styles, open_styles_gallery, read_docs
 
     examples_dir = Path(__file__).parent.parent / "references" / "examples"
     if not examples_dir.exists():
@@ -367,33 +271,29 @@ def cmd_examples(args):
         base = parts[0]
         sub = parts[1] if len(parts) > 1 else None
 
-        # styles/ directory — always show full content
+        # styles/ directory
         if base == "styles":
             styles_dir = examples_dir / "styles"
             if not styles_dir.exists():
                 print("# Not found: styles/", file=sys.stderr)
                 continue
             if sub is None:
-                # List styles
-                for f in sorted(styles_dir.iterdir()):
-                    if f.suffix == '.html' and not f.name.startswith('.'):
-                        from sdpm.reference import _get_description
-                        desc = _get_description(f)
-                        print(f"  styles/{f.stem}  {desc}")
-                # Open index in browser unless --no-browse
+                for s in list_styles(styles_dir):
+                    print(f"  styles/{s['name']}  {s['description']}")
                 if not args.no_browse:
-                    import webbrowser
-                    from sdpm.reference import generate_styles_index
-                    index_path = generate_styles_index(styles_dir)
-                    if index_path.exists():
-                        webbrowser.open(index_path.as_uri())
+                    open_styles_gallery(styles_dir)
             else:
                 print("# Copy a style to your project: cp references/examples/styles/{name}.html specs/art-direction.html", file=sys.stderr)
             continue
 
-        # pptx files (components, patterns) — directory-like behavior
-        pptx_path = examples_dir / f"{base}.pptx"
-        if not pptx_path.is_file():
+        # pptx files (components, patterns)
+        query = f"{base}/{sub}" if sub else base
+        try:
+            docs = read_docs(examples_dir, [query])
+            for doc in docs:
+                print(doc["content"])
+                print()
+        except FileNotFoundError:
             print(f"# Not found: {base}", file=sys.stderr)
             cats = []
             for f in sorted(examples_dir.iterdir()):
@@ -402,40 +302,40 @@ def cmd_examples(args):
                 elif f.is_dir() and not f.name.startswith('.'):
                     cats.append(f"{f.name}/")
             print(f"# Available: {', '.join(cats)}", file=sys.stderr)
-            continue
-
-        if sub is None:
-            # List slides
-            for page, desc in list_pptx_descriptions(str(pptx_path)):
-                print(f"  {page:>3}  {desc}")
-        elif sub == "all":
-            # All notes
-            for _, notes in get_pptx_notes(str(pptx_path)):
-                print(notes)
-                print()
-        else:
-            # Specific pages
-            try:
-                pages = [int(p.strip()) for p in sub.split(",")]
-            except ValueError:
-                print(f"# Invalid page: {sub}", file=sys.stderr)
-                continue
-            results = get_pptx_notes(str(pptx_path), pages=pages)
-            if not results:
-                print(f"# No notes found for page(s): {sub}", file=sys.stderr)
-            for _, notes in results:
-                print(notes)
-                print()
 
 
 def cmd_workflows(args):
     """List or show workflow documents."""
-    _list_or_show(Path(__file__).parent.parent / "references" / "workflows", args.names, "Workflows")
+    from sdpm.reference import list_category, read_docs
+    d = Path(__file__).parent.parent / "references" / "workflows"
+    if not args.names:
+        print("# Workflows")
+        for item in list_category(d):
+            print(f"  {item['name']:<36} {item['description']}")
+    else:
+        try:
+            for doc in read_docs(d, args.names):
+                print(doc["content"])
+                print()
+        except FileNotFoundError as e:
+            print(f"# {e}", file=sys.stderr)
 
 
 def cmd_guides(args):
     """List or show guide documents."""
-    _list_or_show(Path(__file__).parent.parent / "references" / "guides", args.names, "Guides")
+    from sdpm.reference import list_category, read_docs
+    d = Path(__file__).parent.parent / "references" / "guides"
+    if not args.names:
+        print("# Guides")
+        for item in list_category(d):
+            print(f"  {item['name']:<36} {item['description']}")
+    else:
+        try:
+            for doc in read_docs(d, args.names):
+                print(doc["content"])
+                print()
+        except FileNotFoundError as e:
+            print(f"# {e}", file=sys.stderr)
 
 
 def _get_documents_dir():

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -213,7 +213,6 @@ def cmd_search_assets(args):
 
 
 # Backward-compatible alias
-cmd_icon_search = cmd_search_assets
 
 
 def cmd_list_asset_sources(args):
@@ -1087,13 +1086,7 @@ def main():
     p_search.add_argument("-t", "--type", help="Filter by type (e.g. service, resource)")
     p_search.add_argument("--theme", choices=["light", "dark"], help="Filter by theme (light/dark)")
 
-    # Backward-compatible alias
-    p_icon = subparsers.add_parser("icon-search", help="Search assets (alias for search-assets)")
-    p_icon.add_argument("query", help="Search keywords (space-separated)")
-    p_icon.add_argument("-n", "--limit", type=int, default=20, help="Max results (default: 20)")
-    p_icon.add_argument("-s", "--source", help="Filter by source (e.g. aws, material)")
-    p_icon.add_argument("-t", "--type", help="Filter by type (e.g. service, resource)")
-    p_icon.add_argument("--theme", choices=["light", "dark"], help="Filter by theme (light/dark)")
+    # Backward-compatible alias removed (icon-search was alias for search-assets)
 
     subparsers.add_parser("list-asset-sources", help="List available asset sources")
     subparsers.add_parser("list-templates", help="List available PPTX templates")
@@ -1164,8 +1157,6 @@ def main():
         cmd_preview(args)
     elif args.command == "search-assets":
         cmd_search_assets(args)
-    elif args.command == "icon-search":
-        cmd_icon_search(args)
     elif args.command == "list-asset-sources":
         cmd_list_asset_sources(args)
     elif args.command == "list-templates":

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -13,10 +13,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import argparse
 import json
-import re
-from datetime import datetime
-
-from pptx import Presentation
 
 from sdpm.assets import (  # noqa: F401
     ICON_DIR,
@@ -27,11 +23,6 @@ from sdpm.assets import (  # noqa: F401
     resolve_asset_path,
     resolve_icon_path,
     search_assets,
-)
-from sdpm.builder import (
-    PPTXBuilder,
-    resolve_override,
-    validate_icons_in_json,
 )
 from sdpm.diff import (
     _diff_value,
@@ -47,14 +38,7 @@ from sdpm.layout import (
     _layout_translate,
     box_to_elements,
 )
-from sdpm.preview import (
-    _is_wsl,
-    check_layout_imbalance,
-    export_pdf,
-    get_tmp_project_dir,
-    refresh_autofit,
-    unlock_height_constraints,
-)
+from sdpm.preview import _is_wsl
 from sdpm.utils.effects import apply_effects  # noqa: F401
 from sdpm.utils.image import apply_image_effects, resolve_image_path  # noqa: F401
 from sdpm.utils.io import read_json, write_json
@@ -91,7 +75,7 @@ def _resolve_template(data, input_path):
 def cmd_generate(args):
     """Generate PPTX from JSON."""
     from sdpm.api import generate
-    from sdpm.preview import check_layout_imbalance, get_tmp_project_dir
+    from sdpm.preview import get_tmp_project_dir
 
     try:
         result = generate(
@@ -858,7 +842,6 @@ def cmd_image_size(args):
 def cmd_grid(args):
     """Compute CSS Grid layout coordinates."""
     from sdpm.layout.grid import compute_grid
-    from sdpm.utils.io import read_json, write_json
 
     if args.input == "-":
         spec = json.loads(sys.stdin.read())

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -91,86 +91,49 @@ def _resolve_template(data, input_path):
 
 def cmd_generate(args):
     """Generate PPTX from JSON."""
-    # Read input data first
-    if args.input and args.input != "-":
-        data = read_json(Path(args.input))
-    else:
-        data = json.load(sys.stdin)
+    from sdpm.api import generate
+    from sdpm.preview import check_layout_imbalance, get_tmp_project_dir
 
-    template, custom_template = _resolve_template(
-        data,
-        args.input if hasattr(args, 'input') else None
-    )
-
-    if not template.exists():
-        print(f"Error: Template not found: {template}", file=sys.stderr)
+    try:
+        result = generate(
+            json_path=args.input if args.input and args.input != "-" else None,
+            output_path=args.output,
+            no_autofit=args.no_autofit,
+            no_preview=args.no_preview,
+        )
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    missing_icons = validate_icons_in_json(data)
-    if missing_icons:
-        print(f"Error: Missing assets ({len(missing_icons)}):", file=sys.stderr)
-        for icon in sorted(missing_icons):
-            print(f"  - {icon}", file=sys.stderr)
+    except ValueError as e:
+        # Missing assets
+        print(f"Error: {e}", file=sys.stderr)
         print("", file=sys.stderr)
         print("Run the following command to download assets:", file=sys.stderr)
         print("  python3 scripts/download_aws_icons.py", file=sys.stderr)
         print("  python3 scripts/download_material_icons.py", file=sys.stderr)
         sys.exit(1)
 
-    base_dir = Path(args.input).parent if args.input and args.input != "-" else Path(".")
-    builder = PPTXBuilder(template, custom_template=custom_template,
-                          fonts=data.get("fonts"), base_dir=base_dir,
-                          keep_empty_placeholders=getattr(args, 'keep_empty_placeholders', False),
-                          default_text_color=data.get("defaultTextColor"))
-    slides = data.get("slides", [])
+    print(f"Generated: {Path(result['output_path']).resolve()}")
+    for line in result["slides"]:
+        print(line)
 
-    id_map = {}
-    for slide_def in slides:
-        if "id" in slide_def:
-            sid = slide_def["id"]
-            if sid in id_map:
-                print(f"Error: Duplicate slide id: {sid}", file=sys.stderr)
-                sys.exit(1)
-            id_map[sid] = slide_def
-
-    for slide_def in slides:
-        resolved = resolve_override(slide_def, id_map)
-        builder.add_slide(resolved)
-    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-    p = Path(args.output)
-    output_path = p.with_stem(f"{p.stem}_{ts}")
-    builder.save(output_path)
-
-    print(f"Generated: {output_path.resolve()}")
-    for i, slide_def in enumerate(slides, 1):
-        title = (slide_def.get("placeholders") or {}).get("0", "(no title)")
-        if isinstance(title, dict):
-            title = title.get("text", "(no title)")
-        print(f"page{i:02d} - {title}")
-
-    pdf_path = None
-    if not args.no_autofit:
-        pptx_path = output_path.resolve()
-        if not args.no_preview:
-            preview_dir = Path("/tmp/pptx-preview")
-            preview_dir.mkdir(parents=True, exist_ok=True)
-            pdf_path = preview_dir / "slides.pdf"
-        refresh_autofit(pptx_path, pdf_path=pdf_path)
-        unlock_height_constraints(pptx_path)
-    check_layout_imbalance(output_path, slides)
-
-    tmp_project = None
-    if args.input and args.input != "-":
-        tmp_project = get_tmp_project_dir(args.input)
+    if result["warnings"]:
+        print(f"⚠️  Layout bias detected ({len(result['warnings'])} slides):")
+        for w in result["warnings"]:
+            print(f"  {w}")
+        print("  → MUST FIX unless the layout type is intentionally asymmetric.")
 
     if not args.no_preview:
+        tmp_project = None
+        if args.input and args.input != "-":
+            tmp_project = get_tmp_project_dir(args.input)
         preview_dir = tmp_project / 'preview' if tmp_project else Path("/tmp/pptx-preview")
         preview_dir.mkdir(parents=True, exist_ok=True)
         preview_args = argparse.Namespace(
-            input=str(output_path),
+            input=str(result["output_path"]),
             pages=None,
             no_grid=True,
-            _pdf_path=str(pdf_path) if pdf_path and pdf_path.exists() else None,
+            _pdf_path=result.get("pdf_path"),
             _output_dir=str(preview_dir),
         )
         cmd_preview(preview_args)
@@ -198,146 +161,40 @@ def _export_png_win32(pptx_path, output_dir):
     return png_dir
 def cmd_preview(args):
     """Export PPTX slides as PNG images."""
-    import glob
-    import subprocess
-    
+    from sdpm.api import preview as api_preview
+
     pptx_path = Path(args.input).resolve()
-    
-    if _is_wsl() or sys.platform == "win32":
-        output_dir = pptx_path.parent / "preview"
-    elif hasattr(args, '_output_dir') and args._output_dir:
-        output_dir = Path(args._output_dir)
-    else:
-        output_dir = Path("/tmp/pptx-preview")
-    output_dir.mkdir(parents=True, exist_ok=True)
-    
     if not pptx_path.exists():
         print(f"Error: File not found: {pptx_path}", file=sys.stderr)
         sys.exit(1)
-    
-    if sys.platform == "win32":
-        # Windows native: direct PNG export via COM
-        png_dir = _export_png_win32(pptx_path, output_dir)
-        
-        # Parse pages to export
-        pages_to_export = None
-        if args.pages:
-            pages_to_export = set(int(p.strip()) for p in args.pages.split(","))
-        
-        # Collect PNGs from PowerPoint output
-        png_files = sorted(glob.glob(str(png_dir / "**" / "*.png"), recursive=True))
-        if not png_files:
-            png_files = sorted(glob.glob(str(png_dir / "**" / "*.PNG"), recursive=True))
-        
-        # Rename with slide titles
-        prs = Presentation(str(pptx_path))
-        titles = {}
-        for i, slide in enumerate(prs.slides, 1):
-            title = ""
-            if slide.shapes.title:
-                title = slide.shapes.title.text.strip().replace("\n", " ")[:30]
-            title = re.sub(r'[\\/:*?"<>|]', '', title)
-            titles[i] = title or "notitle"
-        
-        generated = []
-        for idx, png in enumerate(png_files, 1):
-            if pages_to_export and idx not in pages_to_export:
-                Path(png).unlink()
-                continue
-            new_name = f"page{idx:02d}-{titles.get(idx, 'notitle')}.png"
-            new_path = output_dir / new_name
-            Path(png).rename(new_path)
-            generated.append(new_path)
-        
-        # Cleanup temp PNG dir
-        import shutil
-        shutil.rmtree(png_dir, ignore_errors=True)
-    else:
-        # PDF + pdftoppm pipeline (macOS / WSL / Linux)
-        pdf_path = output_dir / "slides.pdf"
-        pre_generated_pdf = getattr(args, '_pdf_path', None)
-        
-        if pre_generated_pdf and Path(pre_generated_pdf).exists():
-            import shutil
-            if str(Path(pre_generated_pdf).resolve()) != str(pdf_path.resolve()):
-                shutil.copy2(pre_generated_pdf, pdf_path)
-        else:
-            if not export_pdf(pptx_path, pdf_path):
-                print("Error: PDF export failed", file=sys.stderr)
-                sys.exit(1)
-        
-        # Parse pages to export
-        pages_to_export = None
-        if args.pages:
-            pages_to_export = set(int(p.strip()) for p in args.pages.split(","))
-        
-        # PDF -> PNG via pdftoppm (max 1280px wide for compact preview)
-        cmd = ["pdftoppm", "-png", "-scale-to", "1280", str(pdf_path), str(output_dir / "page")]
-        result = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
-        if result.returncode != 0:
-            print(f"Error: PNG conversion failed: {result.stderr}", file=sys.stderr)
-            sys.exit(1)
-        
-        # Rename with slide titles
-        prs = Presentation(str(pptx_path))
-        titles = {}
-        for i, slide in enumerate(prs.slides, 1):
-            title = ""
-            if slide.shapes.title:
-                title = slide.shapes.title.text.strip().replace("\n", " ")[:30]
-            title = re.sub(r'[\\/:*?"<>|]', '', title)
-            titles[i] = title or "notitle"
-        
-        generated = []
-        for png in sorted(glob.glob(str(output_dir / "page-*.png"))):
-            basename = Path(png).name
-            match = re.match(r'page-(\d+)\.png', basename)
-            if match:
-                num = int(match.group(1))
-                if pages_to_export and num not in pages_to_export:
-                    Path(png).unlink()
-                    continue
-                new_name = f"page{num:02d}-{titles.get(num, 'notitle')}.png"
-                new_path = output_dir / new_name
-                Path(png).rename(new_path)
-                generated.append(new_path)
-        
-        # Cleanup PDF
-        pdf_path.unlink()
-    
-    # Add grid overlay unless disabled
-    if not args.no_grid:
-        from PIL import Image, ImageDraw, ImageFont
-        color = (255, 0, 0, 128)
-        try:
-            font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 24)
-        except Exception:
-            try:
-                font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24)
-            except Exception:
-                font = ImageFont.load_default()
-        
-        for png_path in generated:
-            img = Image.open(png_path).convert("RGBA")
-            w, h = img.size
-            overlay = Image.new("RGBA", (w, h), (0, 0, 0, 0))
-            draw = ImageDraw.Draw(overlay)
-            for pct in range(5, 100, 5):
-                x, y = int(w * pct / 100), int(h * pct / 100)
-                px_x, px_y = int(1920 * pct / 100), int(1080 * pct / 100)
-                draw.line([(x, 0), (x, h)], fill=color, width=1)
-                draw.line([(0, y), (w, y)], fill=color, width=1)
-                if pct % 10 == 0:
-                    draw.text((x + 4, 4), f"{px_x}px ({pct}%)", fill=color, font=font)
-                    draw.text((4, y + 4), f"{px_y}px ({pct}%)", fill=color, font=font)
-            Image.alpha_composite(img, overlay).convert("RGB").save(png_path)
-    
-    for path in generated:
+
+    pages_list = None
+    if args.pages:
+        pages_list = [int(p.strip()) for p in args.pages.split(",")]
+
+    # Determine output dir
+    output_dir = None
+    if hasattr(args, '_output_dir') and args._output_dir:
+        output_dir = args._output_dir
+
+    pre_pdf = getattr(args, '_pdf_path', None)
+
+    try:
+        result = api_preview(
+            pptx_path=pptx_path,
+            pages=pages_list,
+            output_dir=output_dir,
+            grid=not args.no_grid,
+            pdf_path=pre_pdf,
+        )
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for path in result["files"]:
         print(f"Generated: {path}")
-    if generated:
-        print(f"Preview: {generated[0].parent}")
-    if generated:
-        print(f"Preview: {generated[0].parent}")
+    if result["files"]:
+        print(f"Preview: {result['preview_dir']}")
 
 
 
@@ -607,28 +464,18 @@ def _get_documents_dir():
 
 
 def cmd_init(args):
-    if args.output:
-        out_dir = Path(args.output).expanduser()
-    else:
-        ts = datetime.now().strftime("%Y%m%d-%H%M")
-        name = f"{ts}-{args.name}" if args.name else ts
-        out_dir = _get_documents_dir() / name
-    out_dir.mkdir(parents=True, exist_ok=True)
-    pres_data = {"fonts": {"fullwidth": None, "halfwidth": None}, "slides": []}
-    json_path = out_dir / "presentation.json"
-    write_json(json_path, pres_data, suffix="\n")
-    specs_dir = out_dir / "specs"
-    specs_dir.mkdir(exist_ok=True)
-    spec_files = ["brief.md", "outline.md"]
-    for name in spec_files:
-        (specs_dir / name).touch()
-    print(f"output_json: {json_path}")
-    for name in spec_files:
-        print(f"specs:       {specs_dir / name}")
+    from sdpm.api import init
+    result = init(
+        name=args.name or "",
+        output_dir=args.output if hasattr(args, 'output') and args.output else None,
+    )
+    print(f"output_json: {result['json_path']}")
+    for f in result["workspace"]:
+        if f.startswith("specs/"):
+            print(f"specs:       {Path(result['output_dir']) / f}")
 def cmd_code_block(args):
     """Generate elements JSON for a syntax-highlighted code block."""
-    from sdpm.builder.constants import CODE_COLORS
-    from sdpm.utils.text import highlight_code
+    from sdpm.api import code_block
 
     if args.input == "-":
         import sys as _sys
@@ -636,53 +483,15 @@ def cmd_code_block(args):
     else:
         code = Path(args.input).read_text(encoding="utf-8")
 
-    language = args.language or "text"
-    theme = args.theme or "dark"
-    x = args.x or 0
-    y = args.y or 0
-    width = args.width or 800
-    height = args.height or 300
-    label_height = 22
-    show_label = not args.no_label
-
-    colors = CODE_COLORS.get(theme, CODE_COLORS["dark"])
-    bg = colors["background"]
-    inverse_theme = "light" if theme == "dark" else "dark"
-    inverse_bg = f"#{CODE_COLORS[inverse_theme]['background'].lstrip('#')}" if isinstance(CODE_COLORS[inverse_theme]['background'], str) else CODE_COLORS[inverse_theme]['background']
-    # Resolve string hex colors
-    if isinstance(bg, str):
-        bg_hex = bg
-    else:
-        bg_hex = f"#{bg:06x}" if isinstance(bg, int) else bg
-
-    highlighted = highlight_code(code, language, theme)
-    label_map = {"typescript": "TypeScript", "javascript": "JavaScript", "csharp": "C#", "cpp": "C++"}
-    label_text = label_map.get(language, language.capitalize())
-
-    elements = []
-    if show_label:
-        elements.append({
-            "type": "textbox",
-            "x": x, "y": y, "width": width, "height": label_height,
-            "fontSize": 8, "align": "left",
-            "fill": inverse_bg,
-            "text": f"{{{{#{'000000' if theme == 'dark' else 'FFFFFF'}:{label_text}}}}}",
-            "marginLeft": 50000, "marginTop": 0, "marginRight": 0, "marginBottom": 0,
-            "autoWidth": True,
-        })
-        code_y = y + label_height
-        code_height = height - label_height
-    else:
-        code_y = y
-        code_height = height
-
-    elements.append({
-        "type": "textbox",
-        "x": x, "y": code_y, "width": width, "height": code_height,
-        "fontSize": args.font_size or 12, "align": "left",
-        "fill": bg_hex,
-        "text": highlighted,
-    })
+    elements = code_block(
+        code=code,
+        language=args.language or "text",
+        theme=args.theme or "dark",
+        x=args.x or 0, y=args.y or 0,
+        width=args.width or 800, height=args.height or 300,
+        font_size=args.font_size or 12,
+        show_label=not args.no_label,
+    )
 
     output = {"elements": elements}
     out_str = json.dumps(output, ensure_ascii=False, indent=2)

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -105,12 +105,12 @@ def cmd_generate(args):
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     except ValueError as e:
-        # Missing assets
         print(f"Error: {e}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Run the following command to download assets:", file=sys.stderr)
-        print("  python3 scripts/download_aws_icons.py", file=sys.stderr)
-        print("  python3 scripts/download_material_icons.py", file=sys.stderr)
+        if "Missing assets" in str(e):
+            print("", file=sys.stderr)
+            print("Run the following command to download assets:", file=sys.stderr)
+            print("  python3 scripts/download_aws_icons.py", file=sys.stderr)
+            print("  python3 scripts/download_material_icons.py", file=sys.stderr)
         sys.exit(1)
 
     print(f"Generated: {Path(result['output_path']).resolve()}")

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -6,7 +6,6 @@ These functions encapsulate the full workflow that the CLI (pptx_builder.py) per
 mcp-local and other consumers should call these instead of assembling low-level APIs.
 """
 
-import json
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -319,7 +318,6 @@ def preview(
 def _preview_win32(pptx_path: Path, output_dir: Path, pages_set: set[int] | None) -> list[str]:
     """Windows native PNG export via PowerShell COM."""
     import glob
-    import re
     import shutil
     import subprocess
 

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -86,7 +86,7 @@ def init(
     pres_data: dict[str, Any] = {"fonts": {"fullwidth": None, "halfwidth": None}, "slides": []}
 
     if template:
-        templates_dir = Path(__file__).parent / "templates"  # skill/templates/
+        templates_dir = Path(__file__).parent.parent / "templates"  # skill/templates/
         template_src = Path(template).expanduser()
         if not template_src.exists():
             candidate = templates_dir / (str(template) if str(template).endswith(".pptx") else f"{template}.pptx")
@@ -151,7 +151,7 @@ def generate(
         raise FileNotFoundError(f"Slides JSON not found: {json_path}")
 
     data = read_json(input_path)
-    templates_dir = Path(__file__).parent / "templates"
+    templates_dir = Path(__file__).parent.parent / "templates"  # skill/templates/
     warnings: list[str] = []
 
     # Resolve template

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -1,0 +1,470 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""High-level API for sdpm — single entry points for generate, preview, init, code_block.
+
+These functions encapsulate the full workflow that the CLI (pptx_builder.py) performs.
+mcp-local and other consumers should call these instead of assembling low-level APIs.
+"""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_template(data: dict, input_path: str | Path | None, templates_dir: Path) -> tuple[Path, bool]:
+    """Resolve template path from presentation data.
+
+    Returns (template_path, custom_template) or raises FileNotFoundError.
+    """
+    if data.get("template"):
+        base_dir = Path(input_path).parent if input_path else Path(".")
+        template = base_dir / data["template"]
+        if template.exists():
+            return template, True
+        name = data["template"]
+        named = templates_dir / (name if name.endswith(".pptx") else name + ".pptx")
+        if named.exists():
+            return named, True
+    raise FileNotFoundError("No template specified. Set \"template\" in presentation JSON.")
+
+
+def _get_output_base_dir() -> Path:
+    """Get output base directory from config, with WSL fallback."""
+    try:
+        from sdpm.config import get_output_dir
+        return get_output_dir()
+    except Exception:
+        pass
+    from sdpm.preview import _is_wsl
+    if _is_wsl():
+        import subprocess
+        try:
+            result = subprocess.run(  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+                ["/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe", "-Command",
+                 "[Environment]::GetFolderPath('MyDocuments')"],
+                capture_output=True, timeout=10)
+            win_path = result.stdout.decode("cp932", errors="replace").strip()
+            if win_path:
+                wsl = subprocess.run(["wslpath", win_path], capture_output=True, text=True)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+                if wsl.returncode == 0:
+                    return Path(wsl.stdout.strip()) / "SDPM-Presentations"
+        except Exception:
+            pass
+    return Path.home() / "Documents" / "SDPM-Presentations"
+
+
+def init(
+    name: str,
+    template: str | Path | None = None,
+    output_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Initialize a presentation workspace.
+
+    Creates output directory with presentation.json and specs/.
+
+    Args:
+        name: Presentation name (used in directory name).
+        template: Template name or path. If provided, extracts fonts.
+        output_dir: Explicit output directory. Auto-generated if None.
+
+    Returns:
+        Dict with output_dir, json_path, template, fonts, workspace.
+    """
+    from sdpm.analyzer import extract_fonts
+    from sdpm.utils.io import write_json
+
+    if output_dir:
+        out_dir = Path(output_dir).expanduser()
+    else:
+        ts = datetime.now().strftime("%Y%m%d-%H%M")
+        dir_name = f"{ts}-{name}" if name else ts
+        out_dir = _get_output_base_dir() / dir_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pres_data: dict[str, Any] = {"fonts": {"fullwidth": None, "halfwidth": None}, "slides": []}
+
+    if template:
+        templates_dir = Path(__file__).parent / "templates"  # skill/templates/
+        template_src = Path(template).expanduser()
+        if not template_src.exists():
+            candidate = templates_dir / (str(template) if str(template).endswith(".pptx") else f"{template}.pptx")
+            if candidate.exists():
+                template_src = candidate
+        if template_src.exists():
+            template_src = template_src.resolve()
+            pres_data["template"] = template_src.name
+            pres_data["fonts"] = extract_fonts(template_src)
+
+    json_path = out_dir / "presentation.json"
+    write_json(json_path, pres_data, suffix="\n")
+
+    specs_dir = out_dir / "specs"
+    specs_dir.mkdir(exist_ok=True)
+    spec_files = ("brief.md", "outline.md")
+    for spec_name in spec_files:
+        (specs_dir / spec_name).touch()
+
+    return {
+        "output_dir": str(out_dir),
+        "json_path": str(json_path),
+        "template": pres_data.get("template", ""),
+        "fonts": pres_data.get("fonts", {}),
+        "workspace": ["presentation.json"] + [f"specs/{s}" for s in spec_files],
+    }
+
+
+def generate(
+    json_path: str | Path,
+    template: str | Path | None = None,
+    output_path: str | Path | None = None,
+    no_autofit: bool = False,
+    no_preview: bool = False,
+) -> dict[str, Any]:
+    """Generate PPTX from JSON with full post-processing.
+
+    Includes: template resolution, icon validation, build,
+    autofit refresh, unlock_height_constraints, check_layout_imbalance.
+
+    Args:
+        json_path: Path to the slides JSON file.
+        template: Template override (name or path). Uses JSON's "template" if None.
+        output_path: Output .pptx path. Auto-generated if None.
+        no_autofit: Skip autofit refresh.
+        no_preview: Skip PDF generation during autofit.
+
+    Returns:
+        Dict with output_path, slide_count, slides summary, warnings.
+    """
+    from sdpm.builder import PPTXBuilder, resolve_override, validate_icons_in_json
+    from sdpm.preview import (
+        check_layout_imbalance_data,
+        get_tmp_project_dir,
+        refresh_autofit,
+        unlock_height_constraints,
+    )
+    from sdpm.utils.io import read_json
+
+    input_path = Path(json_path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Slides JSON not found: {json_path}")
+
+    data = read_json(input_path)
+    templates_dir = Path(__file__).parent / "templates"
+    warnings: list[str] = []
+
+    # Resolve template
+    if template:
+        p = Path(template)
+        if p.exists():
+            template_file, custom = p, True
+        else:
+            named = templates_dir / (str(template) if str(template).endswith(".pptx") else f"{template}.pptx")
+            if named.exists():
+                template_file, custom = named, True
+            else:
+                raise FileNotFoundError(f"Template not found: {template}")
+    else:
+        template_file, custom = _resolve_template(data, str(input_path), templates_dir)
+
+    # Validate icons
+    missing = validate_icons_in_json(data)
+    if missing:
+        raise ValueError(f"Missing assets ({len(missing)}): {', '.join(sorted(missing)[:10])}")
+
+    # Build
+    builder = PPTXBuilder(
+        template_file, custom_template=custom,
+        fonts=data.get("fonts"), base_dir=input_path.parent,
+        default_text_color=data.get("defaultTextColor"),
+    )
+    slides = data.get("slides", [])
+    id_map = {}
+    for s in slides:
+        if "id" in s:
+            id_map[s["id"]] = s
+    for s in slides:
+        builder.add_slide(resolve_override(s, id_map))
+
+    # Output path
+    if not output_path:
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        p = input_path.with_suffix(".pptx")
+        out = p.with_stem(f"{p.stem}_{ts}")
+    else:
+        out = Path(output_path)
+
+    builder.save(out)
+
+    # Post-processing
+    pdf_path = None
+    if not no_autofit:
+        pptx_resolved = out.resolve()
+        if not no_preview:
+            tmp_project = get_tmp_project_dir(str(input_path))
+            preview_dir = tmp_project / "preview"
+            preview_dir.mkdir(parents=True, exist_ok=True)
+            pdf_path = preview_dir / "slides.pdf"
+        refresh_autofit(pptx_resolved, pdf_path=pdf_path)
+        unlock_height_constraints(pptx_resolved)
+
+    imbalance = check_layout_imbalance_data(out, slides)
+    if imbalance:
+        for a in imbalance:
+            warnings.append(f"page{a['slide']:02d} ({a['layout']}) offset: {a['offset']} ({a['direction']})")
+
+    # Summary
+    summary = []
+    for i, s in enumerate(slides, 1):
+        title = s.get("title", "(no title)")
+        if isinstance(title, dict):
+            title = title.get("text", "(no title)")
+        summary.append(f"page{i:02d} - {title}")
+
+    return {
+        "output_path": str(out),
+        "slide_count": len(slides),
+        "slides": summary,
+        "warnings": warnings,
+        "pdf_path": str(pdf_path) if pdf_path and pdf_path.exists() else None,
+    }
+
+
+def preview(
+    pptx_path: str | Path,
+    pages: list[int] | None = None,
+    output_dir: str | Path | None = None,
+    grid: bool = False,
+    pdf_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Export PPTX slides as PNG images.
+
+    Uses export_pdf → pdftoppm pipeline on macOS/Linux/WSL.
+    Uses COM → PNG direct export on Windows native.
+
+    Args:
+        pptx_path: Path to .pptx file.
+        pages: Page numbers to export. None for all.
+        output_dir: Output directory. Auto-generated if None.
+        grid: Add grid overlay to PNGs.
+        pdf_path: Pre-generated PDF to skip export step.
+
+    Returns:
+        Dict with preview_dir and files list.
+    """
+    import glob
+    import re
+    import subprocess
+
+    from pptx import Presentation
+
+    from sdpm.preview import _is_wsl, export_pdf
+
+    path = Path(pptx_path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"PPTX not found: {pptx_path}")
+
+    if output_dir:
+        out_dir = Path(output_dir)
+    elif _is_wsl() or sys.platform == "win32":
+        out_dir = path.parent / "preview"
+    else:
+        out_dir = Path("/tmp/pptx-preview")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pages_set = set(pages) if pages else None
+
+    if sys.platform == "win32":
+        generated = _preview_win32(path, out_dir, pages_set)
+    else:
+        # PDF + pdftoppm pipeline
+        pdf = Path(pdf_path) if pdf_path and Path(pdf_path).exists() else out_dir / "slides.pdf"
+        if not pdf.exists():
+            if not export_pdf(path, pdf):
+                raise RuntimeError("PDF export failed. Is a presentation app installed?")
+
+        cmd = ["pdftoppm", "-png", "-scale-to", "1280", str(pdf), str(out_dir / "page")]
+        result = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+        if result.returncode != 0:
+            raise RuntimeError(f"PNG conversion failed. Is poppler (pdftoppm) installed? {result.stderr}")
+
+        # Rename with slide titles
+        prs = Presentation(str(path))
+        titles = _extract_slide_titles(prs)
+
+        generated = []
+        for png in sorted(glob.glob(str(out_dir / "page-*.png"))):
+            match = re.match(r'page-(\d+)\.png', Path(png).name)
+            if match:
+                num = int(match.group(1))
+                if pages_set and num not in pages_set:
+                    Path(png).unlink()
+                    continue
+                new_name = f"page{num:02d}-{titles.get(num, 'notitle')}.png"
+                new_path = out_dir / new_name
+                Path(png).rename(new_path)
+                generated.append(str(new_path))
+
+        # Cleanup PDF only if we generated it
+        if not pdf_path:
+            pdf.unlink(missing_ok=True)
+
+    if grid:
+        _apply_grid_overlay(generated)
+
+    return {"preview_dir": str(out_dir), "files": generated}
+
+
+def _preview_win32(pptx_path: Path, output_dir: Path, pages_set: set[int] | None) -> list[str]:
+    """Windows native PNG export via PowerShell COM."""
+    import glob
+    import re
+    import shutil
+    import subprocess
+
+    from pptx import Presentation
+
+    png_dir = output_dir / "ppt_png"
+    png_dir.mkdir(parents=True, exist_ok=True)
+    ps_cmd = (
+        f"$app = New-Object -ComObject PowerPoint.Application; "
+        f"$prs = $app.Presentations.Open('{pptx_path}', "
+        f"[Microsoft.Office.Core.MsoTriState]::msoTrue, "
+        f"[Microsoft.Office.Core.MsoTriState]::msoFalse, "
+        f"[Microsoft.Office.Core.MsoTriState]::msoFalse); "
+        f"$prs.SaveAs('{png_dir}', 18); "
+        f"$prs.Close(); $app.Quit()"
+    )
+    result = subprocess.run(["powershell.exe", "-Command", ps_cmd], capture_output=True, timeout=60)  # nosec B603 # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+    if result.returncode != 0:
+        stderr = result.stderr.decode("cp932", errors="replace") if result.stderr else ""
+        raise RuntimeError(f"PNG export failed: {stderr}")
+
+    prs = Presentation(str(pptx_path))
+    titles = _extract_slide_titles(prs)
+
+    png_files = sorted(glob.glob(str(png_dir / "**" / "*.png"), recursive=True))
+    if not png_files:
+        png_files = sorted(glob.glob(str(png_dir / "**" / "*.PNG"), recursive=True))
+
+    generated = []
+    for idx, png in enumerate(png_files, 1):
+        if pages_set and idx not in pages_set:
+            Path(png).unlink()
+            continue
+        new_name = f"page{idx:02d}-{titles.get(idx, 'notitle')}.png"
+        new_path = output_dir / new_name
+        Path(png).rename(new_path)
+        generated.append(str(new_path))
+
+    shutil.rmtree(png_dir, ignore_errors=True)
+    return generated
+
+
+def _extract_slide_titles(prs) -> dict[int, str]:
+    """Extract sanitized slide titles from a Presentation object."""
+    import re
+    titles = {}
+    for i, slide in enumerate(prs.slides, 1):
+        title = ""
+        if slide.shapes.title:
+            title = slide.shapes.title.text.strip().replace("\n", " ")[:30]
+        title = re.sub(r'[\\/:*?"<>|]', '', title)
+        titles[i] = title or "notitle"
+    return titles
+
+
+def _apply_grid_overlay(png_paths: list[str]) -> None:
+    """Add coordinate grid overlay to PNG files."""
+    from PIL import Image, ImageDraw, ImageFont
+
+    color = (255, 0, 0, 128)
+    try:
+        font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 24)
+    except Exception:
+        try:
+            font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 24)
+        except Exception:
+            font = ImageFont.load_default()
+
+    for png_path in png_paths:
+        img = Image.open(png_path).convert("RGBA")
+        w, h = img.size
+        overlay = Image.new("RGBA", (w, h), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay)
+        for pct in range(5, 100, 5):
+            x, y = int(w * pct / 100), int(h * pct / 100)
+            px_x, px_y = int(1920 * pct / 100), int(1080 * pct / 100)
+            draw.line([(x, 0), (x, h)], fill=color, width=1)
+            draw.line([(0, y), (w, y)], fill=color, width=1)
+            if pct % 10 == 0:
+                draw.text((x + 4, 4), f"{px_x}px ({pct}%)", fill=color, font=font)
+                draw.text((4, y + 4), f"{px_y}px ({pct}%)", fill=color, font=font)
+        Image.alpha_composite(img, overlay).convert("RGB").save(png_path)
+
+
+def code_block(
+    code: str,
+    language: str = "python",
+    theme: str = "dark",
+    x: int = 0,
+    y: int = 0,
+    width: int = 800,
+    height: int = 300,
+    font_size: int = 12,
+    show_label: bool = True,
+) -> list[dict[str, Any]]:
+    """Generate slide elements for a syntax-highlighted code block.
+
+    Args:
+        code: Source code text.
+        language: Programming language for highlighting.
+        theme: Color theme ("dark" or "light").
+        x, y, width, height: Position and size in pixels.
+        font_size: Code font size in pt.
+        show_label: Show language label bar.
+
+    Returns:
+        List of element dicts for slide JSON.
+    """
+    from sdpm.builder.constants import CODE_COLORS
+    from sdpm.utils.text import highlight_code
+
+    colors = CODE_COLORS.get(theme, CODE_COLORS["dark"])
+    bg = colors["background"]
+    inverse_theme = "light" if theme == "dark" else "dark"
+    inverse_bg = CODE_COLORS[inverse_theme]["background"]
+    label_fg = "000000" if theme == "dark" else "FFFFFF"
+    label_height = 22
+
+    label_map = {"typescript": "TypeScript", "javascript": "JavaScript", "csharp": "C#", "cpp": "C++"}
+    label_text = label_map.get(language, language.capitalize())
+
+    elements: list[dict[str, Any]] = []
+    if show_label:
+        elements.append({
+            "type": "textbox",
+            "x": x, "y": y, "width": width, "height": label_height,
+            "fontSize": 8, "align": "left",
+            "fill": inverse_bg,
+            "text": f"{{{{#{label_fg}:{label_text}}}}}",
+            "marginLeft": 50000, "marginTop": 0, "marginRight": 0, "marginBottom": 0,
+            "autoWidth": True,
+        })
+        code_y = y + label_height
+        code_height = height - label_height
+    else:
+        code_y = y
+        code_height = height
+
+    spans = highlight_code(code, language, theme)
+    elements.append({
+        "type": "textbox",
+        "x": x, "y": code_y, "width": width, "height": code_height,
+        "fontSize": font_size, "align": "left",
+        "fill": bg,
+        "text": spans,
+    })
+
+    return elements

--- a/skill/sdpm/reference/__init__.py
+++ b/skill/sdpm/reference/__init__.py
@@ -253,3 +253,114 @@ def get_pptx_notes(pptx_path, pages=None):
         if notes:
             results.append((page_num, notes))
     return results
+
+
+# ---------------------------------------------------------------------------
+# High-level reference helpers (local filesystem)
+# ---------------------------------------------------------------------------
+
+def list_category(category_dir: Path) -> list[dict[str, str]]:
+    """List all .md, .pptx, and .html files in a category directory with descriptions.
+
+    Recurses into subdirectories. Returns list of dicts with name, description, path.
+    """
+    if not category_dir.exists():
+        return []
+    items: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for f in sorted(category_dir.rglob("*")):
+        if f.suffix not in (".md", ".pptx", ".html"):
+            continue
+        rel = f.relative_to(category_dir)
+        stem_key = str(rel.with_suffix(""))
+        if stem_key in seen:
+            continue
+        seen.add(stem_key)
+        desc = _get_description(f)
+        items.append({
+            "name": stem_key,
+            "description": desc,
+            "path": f"{category_dir.name}/{rel}",
+        })
+    return items
+
+
+def read_docs(category_dir: Path, names: list[str]) -> list[dict]:
+    """Read one or more documents from a category directory.
+
+    Supports .md (text), .pptx (notes via get_pptx_notes), .html (text).
+    Names can include page specifiers: "name/3" or "name/all".
+
+    Returns list of dicts with name, path, content.
+    """
+    results = []
+    for name in names:
+        # Parse page specifier
+        pages = None
+        has_page_specifier = False
+        parts = name.rsplit("/", 1)
+        file_name = name
+        if len(parts) == 2 and (parts[1].isdigit() or parts[1] == "all"):
+            file_name = parts[0]
+            has_page_specifier = True
+            pages = None if parts[1] == "all" else [int(parts[1])]
+
+        md_path = category_dir / f"{file_name}.md"
+        pptx_path = category_dir / f"{file_name}.pptx"
+        html_path = category_dir / f"{file_name}.html"
+
+        if md_path.exists():
+            results.append({
+                "name": file_name,
+                "path": f"{category_dir.name}/{file_name}.md",
+                "content": md_path.read_text(encoding="utf-8"),
+            })
+        elif pptx_path.exists():
+            if not has_page_specifier:
+                descriptions = list_pptx_descriptions(str(pptx_path))
+                content = "\n".join(f"  {page:>3}  {desc}" for page, desc in descriptions)
+                results.append({
+                    "name": name,
+                    "path": f"{category_dir.name}/{file_name}.pptx",
+                    "content": content,
+                })
+            else:
+                notes = get_pptx_notes(pptx_path, pages=pages)
+                content_lines = [f"## Page {pn}\n\n{text}\n" for pn, text in notes]
+                results.append({
+                    "name": name,
+                    "path": f"{category_dir.name}/{file_name}.pptx",
+                    "content": "\n".join(content_lines),
+                })
+        elif html_path.exists():
+            results.append({
+                "name": file_name,
+                "path": f"{category_dir.name}/{file_name}.html",
+                "content": html_path.read_text(encoding="utf-8"),
+            })
+        else:
+            available = sorted({
+                str(f.relative_to(category_dir).with_suffix(""))
+                for f in category_dir.rglob("*")
+                if f.suffix in (".md", ".pptx", ".html")
+            })
+            raise FileNotFoundError(
+                f"'{file_name}' not found in {category_dir.name}/. Available: {', '.join(available)}"
+            )
+    return results
+
+
+def list_styles(styles_dir: Path) -> list[dict[str, str]]:
+    """List available styles from HTML files in a styles directory.
+
+    Returns list of dicts with name and description.
+    """
+    if not styles_dir.exists():
+        return []
+    styles: list[dict[str, str]] = []
+    for f in sorted(styles_dir.iterdir()):
+        if f.suffix != ".html" or f.name.startswith("."):
+            continue
+        desc = _get_description(f)
+        styles.append({"name": f.stem, "description": desc})
+    return styles

--- a/skill/sdpm/reference/__init__.py
+++ b/skill/sdpm/reference/__init__.py
@@ -259,6 +259,18 @@ def get_pptx_notes(pptx_path, pages=None):
 # High-level reference helpers (local filesystem)
 # ---------------------------------------------------------------------------
 
+
+def open_styles_gallery(styles_dir: Path) -> Path | None:
+    """Generate styles gallery HTML and open in browser. Returns index path or None."""
+    import webbrowser
+
+    index_path = generate_styles_index(styles_dir)
+    if index_path and index_path.exists():
+        webbrowser.open(index_path.as_uri())
+        return index_path
+    return None
+
+
 def _collect_files(directory: Path) -> dict[str, Path]:
     """Collect md/pptx files in directory. md takes priority over pptx for same stem."""
     files: dict[str, Path] = {}

--- a/skill/sdpm/reference/__init__.py
+++ b/skill/sdpm/reference/__init__.py
@@ -259,43 +259,55 @@ def get_pptx_notes(pptx_path, pages=None):
 # High-level reference helpers (local filesystem)
 # ---------------------------------------------------------------------------
 
-def list_category(category_dir: Path) -> list[dict[str, str]]:
-    """List all .md, .pptx, and .html files in a category directory with descriptions.
+def _collect_files(directory: Path) -> dict[str, Path]:
+    """Collect md/pptx files in directory. md takes priority over pptx for same stem."""
+    files: dict[str, Path] = {}
+    for f in sorted(directory.glob("*.pptx")):
+        files[f.stem] = f
+    for f in sorted(directory.glob("*.md")):
+        files[f.stem] = f  # md overwrites pptx
+    return files
 
-    Recurses into subdirectories. Returns list of dicts with name, description, path.
+
+def _strip_frontmatter(text: str) -> str:
+    """Strip YAML frontmatter from markdown text."""
+    lines = text.splitlines(True)
+    if lines and lines[0].strip() == "---":
+        for i, line in enumerate(lines[1:], 1):
+            if line.strip() == "---":
+                return "".join(lines[i + 1:]).lstrip("\n")
+    return text
+
+
+def list_category(category_dir: Path) -> list[dict[str, str]]:
+    """List documents in a category directory with descriptions.
+
+    Supports flat and subdirectory layouts (matching CLI _list_or_show).
+    md takes priority over pptx for same stem.
     """
     if not category_dir.exists():
         return []
+    subdirs = sorted(d for d in category_dir.iterdir() if d.is_dir())
+    flat = not subdirs
     items: list[dict[str, str]] = []
-    seen: set[str] = set()
-    for f in sorted(category_dir.rglob("*")):
-        if f.suffix not in (".md", ".pptx", ".html"):
-            continue
-        rel = f.relative_to(category_dir)
-        stem_key = str(rel.with_suffix(""))
-        if stem_key in seen:
-            continue
-        seen.add(stem_key)
-        desc = _get_description(f)
-        items.append({
-            "name": stem_key,
-            "description": desc,
-            "path": f"{category_dir.name}/{rel}",
-        })
+    if flat:
+        for stem, f in sorted(_collect_files(category_dir).items()):
+            items.append({"name": stem, "description": _get_description(f)})
+    else:
+        for sd in subdirs:
+            for stem, f in sorted(_collect_files(sd).items()):
+                items.append({"name": f"{sd.name}/{stem}", "description": _get_description(f)})
     return items
 
 
 def read_docs(category_dir: Path, names: list[str]) -> list[dict]:
-    """Read one or more documents from a category directory.
+    """Read documents by name from a category directory.
 
-    Supports .md (text), .pptx (notes via get_pptx_notes), .html (text).
-    Names can include page specifiers: "name/3" or "name/all".
-
-    Returns list of dicts with name, path, content.
+    Supports .md (with frontmatter strip), .pptx (notes via get_pptx_notes).
+    Names can include page specifiers for pptx: "name/3" or "name/all".
     """
     results = []
     for name in names:
-        # Parse page specifier
         pages = None
         has_page_specifier = False
         parts = name.rsplit("/", 1)
@@ -307,43 +319,21 @@ def read_docs(category_dir: Path, names: list[str]) -> list[dict]:
 
         md_path = category_dir / f"{file_name}.md"
         pptx_path = category_dir / f"{file_name}.pptx"
-        html_path = category_dir / f"{file_name}.html"
 
         if md_path.exists():
-            results.append({
-                "name": file_name,
-                "path": f"{category_dir.name}/{file_name}.md",
-                "content": md_path.read_text(encoding="utf-8"),
-            })
+            text = _strip_frontmatter(md_path.read_text(encoding="utf-8"))
+            results.append({"name": file_name, "content": text})
         elif pptx_path.exists():
             if not has_page_specifier:
                 descriptions = list_pptx_descriptions(str(pptx_path))
                 content = "\n".join(f"  {page:>3}  {desc}" for page, desc in descriptions)
-                results.append({
-                    "name": name,
-                    "path": f"{category_dir.name}/{file_name}.pptx",
-                    "content": content,
-                })
             else:
                 notes = get_pptx_notes(pptx_path, pages=pages)
-                content_lines = [f"## Page {pn}\n\n{text}\n" for pn, text in notes]
-                results.append({
-                    "name": name,
-                    "path": f"{category_dir.name}/{file_name}.pptx",
-                    "content": "\n".join(content_lines),
-                })
-        elif html_path.exists():
-            results.append({
-                "name": file_name,
-                "path": f"{category_dir.name}/{file_name}.html",
-                "content": html_path.read_text(encoding="utf-8"),
-            })
+                content = "\n".join(f"## Page {pn}\n\n{text}\n" for pn, text in notes)
+            results.append({"name": name, "content": content})
         else:
-            available = sorted({
-                str(f.relative_to(category_dir).with_suffix(""))
-                for f in category_dir.rglob("*")
-                if f.suffix in (".md", ".pptx", ".html")
-            })
+            # Collect available names for error message
+            available = sorted(_collect_files(category_dir).keys())
             raise FileNotFoundError(
                 f"'{file_name}' not found in {category_dir.name}/. Available: {', '.join(available)}"
             )


### PR DESCRIPTION
### Problem
mcp-local/tools.py (768 lines) independently reimplemented business logic from the CLI, causing:
- 3 bugs from API drift (analyze_template, code_block, preview import)
- Missing post-processing in generate (autofit, unlock, imbalance check)
- Duplicated platform-specific preview logic

### Solution
Extract business logic into shared APIs in `skill/`, used by both CLI and mcp-local.

**New: `skill/sdpm/api.py`** — High-level operations
- `generate()` — PPTX generation with full post-processing pipeline
- `preview()` — Cross-platform PPTX→PNG export
- `init()` — Workspace initialization
- `code_block()` — Syntax-highlighted code block elements

**Extended: `skill/sdpm/reference/__init__.py`** — Reference document access
- `list_category()` — Directory listing with flat/subdir detection, md priority
- `read_docs()` — Document reading with frontmatter strip, pptx page support
- `list_styles()` — Style gallery listing
- `open_styles_gallery()` — Browser-based style preview (local environments)

**Rewritten: `mcp-local/tools.py`** (768L → 148L)
- All 16 tools are now thin wrappers: input conversion → API call → output formatting

**Migrated: `skill/scripts/pptx_builder.py`** (net -540L)
- All commands use the same APIs as mcp-local
- Removed `_list_or_show`, `_collect_files`, `_get_documents_dir`, `icon-search` alias

### Design principle
- CLI behavior is the canonical spec
- `sdpm.*` APIs provide core business logic
- CLI and mcp-local each handle their own input/output interface

### Verification
- All 16 mcp-local tools pass JSON-RPC testing
- All CLI commands verified with real files (generate, preview, init, code-block, workflows, guides, examples, etc.)
- 28 existing tests pass
- mcp-server (Layer 3) unaffected — no imports changed

### Out of scope
- mcp-server changes (S3/DynamoDB dependencies, separate architecture)