### PR TITLE
♻️ refactor: sync from internal — Design/Build compose restructure, p…

### DIFF
--- a/skill/references/workflows/create-new-1-art-direction.md
+++ b/skill/references/workflows/create-new-1-art-direction.md
@@ -20,7 +20,7 @@ You MUST NOT read the next workflow file until the user explicitly approves the 
 
 ## Constraints
 
-- Design level, tone, and color decisions apply to ALL slides — Phase 2's design MUST be consistent with them
+- Tone and color decisions apply to ALL slides — Phase 2's design MUST be consistent with them
 
 ---
 
@@ -39,7 +39,10 @@ When a style is selected, copy it as the art direction base:
 cp references/examples/styles/{name}.html specs/art-direction.html
 ```
 
-Read `specs/art-direction.html` after copying — understand the design tokens before proceeding.
+Read `specs/art-direction.html` after copying — read the ENTIRE file including all `<body>` content.
+Do NOT truncate at `<head>` or `:root`. The body contains slide composition examples that define
+container styles, card layouts, spacing patterns, and decoration details.
+Internalize the design tokens and visual language now — Phase 2 will not re-read this file.
 
 ### 1. Select and analyze template
 
@@ -97,19 +100,10 @@ Write `specs/art-direction.md` — design direction in prose. Cover color, decor
 density, and impression. This is a human-readable agreement, not a machine-readable spec.
 
 Also confirm:
-- **Design level** — Simple / Standard / Premium. Propose one based on context.
-
-| Level | Name | Use cases | Color | Decoration | Layout tendency |
-|-------|------|-----------|-------|------------|-----------------|
-| 1 | Simple | Internal sharing, tech discussions, weekly reports | White text + 2 accent colors | Minimal | Text & data focused |
-| 2 | Standard | Customer proposals, internal presentations, workshops | 2-3 accent colors, gradient borders | Moderate | Structured, visual grouping |
-| 3 | Premium | Executive presentations, conference talks, new service launches | Multi-color, gradient fills, textGradient | Rich | Visual impact focused |
-
 - **Source materials** — When image assets are provided, read each one with fs_read Image mode to understand the content and determine placement across slides.
 
 #### Constraints
 - You MUST propose an art direction based on Phase 1 context, not ask the user to choose from abstract options
-- You MUST confirm design level — propose one if user doesn't specify
 - You MUST use analyze-template color output to determine color scheme for the chosen template
 - Text color, table color, chart color, etc. are auto-resolved from the template's theme colors
 
@@ -119,12 +113,19 @@ When it was copied from a style without changes, text confirmation is sufficient
 ### 4. Review outline fit
 
 After art direction is confirmed, check whether the outline still fits the design direction.
-Design level and information density may require splitting dense slides or merging thin ones.
+Information density may require splitting dense slides or merging thin ones.
 
 Do NOT ask "shall we review the outline?" every time — that becomes ritual.
-Instead, read the outline against the confirmed design level and propose specific changes
-if needed (e.g., "Slide 4 has too much for Premium — split into overview + detail").
+Instead, read the outline against the confirmed direction and propose specific changes
+if needed (e.g., "Slide 4 has too much content — split into overview + detail").
 If the outline fits, say so briefly and move on.
+
+### Scope of art direction
+
+Art direction defines the visual style layer only — colors, typography, spacing, decoration.
+It does NOT define slide composition. How elements are arranged (patterns) and how each element
+is built (components) are decided per-slide in Phase 2. Art direction constrains the palette;
+it does not constrain the structure.
 
 ---
 

--- a/skill/references/workflows/create-new-2-compose.md
+++ b/skill/references/workflows/create-new-2-compose.md
@@ -1,12 +1,29 @@
 ---
 name: new-phase-2-compose
-description: "Phase 2: Compose slides — notes + elements, one slide at a time"
+description: "Phase 2: Compose slides — design then build, one slide at a time"
 category: workflow
 ---
 
 # Phase 2: Compose
 
-Build each slide one at a time: notes first, then elements.
+Build each slide one at a time: design then build.
+
+## Design = Style × Components × Patterns
+
+Slide design is formed by three layers:
+- **Style** (art-direction.html) — visual tokens: colors, typography, spacing, decoration
+- **Components** — building blocks: how to construct each element (card, icon-label, table, etc.)
+- **Patterns** — composition thinking: how to arrange components to express a message
+
+Components and patterns are references, not constraints. They teach principles and techniques —
+you are expected to combine, adapt, and invent new compositions that don't exist in the catalog.
+Do not shy away from complex compositions or subtle decoration — details that carry
+no information still carry craft. The audience feels the difference.
+Bold layouts — asymmetry, extreme size contrast, generous whitespace, full-bleed visuals —
+create impact. Safe, centered, evenly-spaced arrangements are forgettable.
+The slide-json-spec gives you the full vocabulary of what's possible; components and patterns
+show how others have used that vocabulary. Use them as a springboard, not a ceiling.
+Style decides *how it looks*. Components decide *what to use*. Patterns decide *how to compose*.
 
 **Before starting, you MUST run:**
 
@@ -17,7 +34,7 @@ uv run python3 scripts/pptx_builder.py examples components/all
 uv run python3 scripts/pptx_builder.py examples patterns
 ```
 
-**Reminder:** Read relevant guides as needed.
+**Reminder:** Read relevant guides as needed. When a slide contains a chart, read the corresponding guide (`guides chart-bar`, `guides chart-line`, or `guides chart-pie`) before building elements.
 
 Slides that share a label prefix in the outline share a visual base — use override (inheritance) to build them. The base slide carries the common elements; each derived slide adds or highlights its part. Slide transitions between them create animation effects.
 
@@ -30,63 +47,60 @@ load(slide-json-spec, grid-guide, components)
 patterns = read("examples patterns")   # read the full catalog once
 
 for slide in slides:
-    read_patterns(relevant ones)        # read several patterns for this slide
-    notes    = write_notes(outline, art_direction)
-    source   = lookup_source(slide)
-    grid     = run("grid", ...)
+    # Design
+    read_patterns(relevant ones)
+    think: message + visual structure together
+    check: layout fits message? no repetition?
+
+    # Build
+    coords   = calculate(grid_command, inline_python)
     assets   = run("search-assets", ...)
-    elements = build_elements(grid, assets, source)
-    write(slide)                        # notes + elements — one slide at a time
+    elements = build_elements(coords, assets)
+    write(slide)                        # notes + elements
 ```
 
-Each variable is input to the next step — do not skip or reorder.
-Complete one full iteration before moving to the next slide.
+Complete one full Design → Build iteration before moving to the next slide.
 
 **You MUST write one slide at a time.** Do NOT batch-generate multiple slides at once.
-Skipping `grid` or `search-assets` produces broken layouts and missing icons — these are not optional.
 Writing all slides in a single operation risks output truncation and write failure — always write per slide.
 
 ---
 
-## Notes
+## Design
 
-For each slide, write notes before elements. Notes are the content spec — you cannot build elements without knowing what the slide says.
+For each slide, think through what to say and how to show it — together.
 
 1. Check the slide's message in `specs/outline.md`
-2. Read `specs/art-direction.html` — this HTML IS the target design. The visual style shown in the HTML
-   (colors, typography, containers, spacing, decoration) is exactly what the slides should look like.
-   Read `:root` CSS variables for concrete design tokens (hex colors, pt sizes, shadow values).
-   Use these values directly in slides.json.
-3. Read several patterns (`examples patterns/N`) that might offer effective ways to express the message's logical structure. Don't copy one pattern — absorb the thinking from multiple patterns and combine, adapt, or reinvent. The message drives the design; patterns expand how you deliver it.
-4. Write `notes` (speaker notes) — must align with the message in outline.md
+2. Apply the design tokens and visual language from art direction (already internalized in Phase 1)
+3. Read several patterns (`examples patterns/N`) that might express the message's logical structure. Don't copy one pattern — absorb the thinking from multiple patterns and combine, adapt, or reinvent. The message drives the design; patterns expand how you deliver it.
+4. Decide notes content and visual structure together — what you say shapes how you show it, and how you show it shapes what you say. The message's logical structure determines the layout, not the number of items. Three points don't automatically mean three cards — think about what relationship the items have (hierarchy, sequence, contrast, grouping) and choose a layout that expresses it.
+5. No repetition without intent. Same layout on consecutive slides feels monotonous — the audience sees the shape before reading the words. Same component reused across the deck feels cheap — especially containers. Don't default to lining up cards. Explore different components, add supporting elements (icons, dividers, accent shapes), or rethink the layout entirely. Vary unless repetition serves a clear purpose (e.g. comparison).
+6. Check: does this layout fit the message's logical structure? If not, rethink before building.
 
-## Elements
+## Build
 
-For each slide, build elements after notes are written.
+For each slide, execute the design decisions.
 
-**grid:**
-- Computing coordinates before deciding structure makes the layout rigid — decide structure first, then map to coordinates
+**coordinate calculation:**
+- Decide structure first, then calculate coordinates — computing coordinates before structure makes the layout rigid
+- **grid command**: rectangular layouts — rows × columns with items at intersections
+- **inline python** (`python3 -c "..."`): everything else — arcs, bezier curves, radial placement, trigonometric positions, color interpolation, any free-form calculation. Use it whenever you need a value that isn't a simple grid intersection
+- Relying only on grid produces rectangular arrangements for every slide. Inline python unlocks curves, diagonals, and organic placement that give a deck visual variety
+- When both are needed (e.g. arc positions + card internals), use inline python for the outer structure and grid for the inner content
 
 **search-assets:**
 - AWS icons have `_dark` and `_light` variants — select based on the template's background color from `analyze-template` Theme Colors (dark background → `_dark`, light background → `_light`)
 
 **build_elements:**
-- Use components / style components and grid output coordinates
-- When style is specified, use the style's components as the primary source — common/components provides the foundation, style provides the application
-- Do not avoid or simplify a component/layout just because it is complex — use the component that best fits the content. Simplification is only acceptable when the agreed design level (1/2/3) explicitly calls for it
 - Do not carry over colors or styles from source slides — always apply the new theme's design guidelines because source styles conflict with the target theme
 - Do not use emoji in slide text, titles, or notes — emoji render inconsistently across platforms. Use icons (`search-assets`) instead
 - Include reference URLs in `notes` (after `---` separator) when the slide content is based on external sources
-- Do not scale font sizes based on slide dimensions because PowerPoint font size (pt) is absolute — 20pt renders the same physical size on 1280x720 and 1920x1080. Only coordinates (x, y, width, height) change with slide size
 - When placing images, maintain the original aspect ratio — run `image-size {path} --width {px}` or `--height {px}` to get the correct dimensions before writing the element. If width-based calculation exceeds the content area height, recalculate with `--height` instead
-- Use `mask: "rounded_rectangle"` with `maskAdjustments: [0.03~0.05]` for screenshots because raw edges look unfinished
-- When building a code block, use the `code-block` command to generate elements JSON and include it via `{"type": "include", "src": "code.json"}` because inline code properties are no longer supported
+- When building a code block, use the `code-block` command and include the output via `{"type": "include", "src": "code.json"}`
 
 **custom template:**
 - Use layout names from `analyze-template` output in the `layout` field
-- When using a layout for the first time, read its detail file via `analyze-template {template} --layout {name}` to understand placeholder positions and content areas because coordinates differ per layout
-- When a layout has a `sample` field in its detail, reference the sample's elements (font sizes, colors, shapes, spacing) to match the template's design language
-- When a layout defines content areas via placeholders (OBJECT, BODY, PICTURE), place elements approximately within those areas as a guide — exact alignment is not required
+- When using a layout for the first time, read its detail via `analyze-template {template} --layout {name}` to understand placeholder positions and content areas
 
 ---
 

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -200,12 +200,14 @@ def generate(
     pdf_path = None
     if not no_autofit:
         pptx_resolved = out.resolve()
+        pre_autofit_pdf = None
         if not no_preview:
             tmp_project = get_tmp_project_dir(str(input_path))
             preview_dir = tmp_project / "preview"
             preview_dir.mkdir(parents=True, exist_ok=True)
-            pdf_path = preview_dir / "slides.pdf"
-        refresh_autofit(pptx_resolved, pdf_path=pdf_path)
+            pre_autofit_pdf = preview_dir / "slides.pdf"
+        refresh_autofit(pptx_resolved, pdf_path=None, pre_autofit_pdf=pre_autofit_pdf)
+        pdf_path = pre_autofit_pdf
         unlock_height_constraints(pptx_resolved)
 
     imbalance = check_layout_imbalance_data(out, slides)

--- a/skill/sdpm/preview/__init__.py
+++ b/skill/sdpm/preview/__init__.py
@@ -13,13 +13,13 @@ from pptx import Presentation
 from .backend import _is_wsl as _is_wsl, detect_backend
 
 
-def refresh_autofit(pptx_path, pdf_path=None):
+def refresh_autofit(pptx_path, pdf_path=None, pre_autofit_pdf=None):
     """Refresh autofit via detected presentation backend."""
     backend = detect_backend()
     if backend is None:
         print("Warning: Autofit refresh skipped (no presentation app available)", file=sys.stderr)
         return False
-    result = backend.refresh_autofit(Path(pptx_path), Path(pdf_path) if pdf_path else None)
+    result = backend.refresh_autofit(Path(pptx_path), Path(pdf_path) if pdf_path else None, pre_autofit_pdf=Path(pre_autofit_pdf) if pre_autofit_pdf else None)
     if not result:
         print(f"Warning: Autofit refresh failed ({backend.name})", file=sys.stderr)
     return result

--- a/skill/sdpm/preview/backend.py
+++ b/skill/sdpm/preview/backend.py
@@ -21,7 +21,7 @@ class PresentationBackend:
         """Export PPTX to PDF. Returns True on success."""
         raise NotImplementedError
 
-    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None) -> bool:
+    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None, pre_autofit_pdf: Path | None = None) -> bool:
         """Refresh autofit and optionally export PDF. Returns True on success."""
         raise NotImplementedError
 
@@ -54,9 +54,9 @@ class PowerPointBackend(PresentationBackend):
             return self._win_export_pdf(pptx_path, pdf_path)
         return False
 
-    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None) -> bool:
+    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None, pre_autofit_pdf: Path | None = None) -> bool:
         if sys.platform == "darwin":
-            return self._mac_refresh_autofit(pptx_path, pdf_path)
+            return self._mac_refresh_autofit(pptx_path, pdf_path, pre_autofit_pdf=pre_autofit_pdf)
         elif sys.platform == "win32":
             return self._win_refresh_autofit(pptx_path, pdf_path)
         elif _is_wsl():
@@ -106,7 +106,13 @@ class PowerPointBackend(PresentationBackend):
 
     # --- macOS AppleScript helpers ---
 
-    def _mac_refresh_autofit(self, pptx_path: Path, pdf_path: Path | None) -> bool:
+    def _mac_refresh_autofit(self, pptx_path: Path, pdf_path: Path | None, pre_autofit_pdf: Path | None = None) -> bool:
+        pre_pdf_lines = ""
+        if pre_autofit_pdf:
+            pre_pdf_lines = f'''
+                set preOutPath to (POSIX file "{pre_autofit_pdf}") as text
+                save pres in preOutPath as save as PDF
+            '''
         pdf_lines = ""
         if pdf_path:
             pdf_lines = f'''
@@ -122,6 +128,7 @@ class PowerPointBackend(PresentationBackend):
             tell application "Microsoft PowerPoint"
                 set pres to presentation "{pptx_name}"
                 set slideCount to count of slides of pres
+                {pre_pdf_lines}
                 if (count of shapes of slide 1 of pres) > 0 then
                     set sh to shape 1 of slide 1 of pres
                     set w to width of sh
@@ -274,7 +281,7 @@ class LibreOfficeBackend(PresentationBackend):
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None) -> bool:
+    def refresh_autofit(self, pptx_path: Path, pdf_path: Path | None = None, pre_autofit_pdf: Path | None = None) -> bool:
         from .autofit import extract_scaling, unlock_autofit
         tmp_dir = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
…re-autofit PDF export

- Art direction: remove Design Level, add scope section, full HTML read in Phase 1
- Compose: restructure into Design/Build phases, add craft/bold principles, inline python, container overuse warning
- Preview: export PDF before autofit in single PowerPoint session

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
