### PR TITLE
fix: resolve redirect loop after OIDC callback

### DIFF
--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -70,10 +70,32 @@ export class WebUiStack extends cdk.Stack {
     const oai = new cloudfront.OriginAccessIdentity(this, "OAI");
     siteBucket.grantRead(oai);
 
+    // CloudFront Function to rewrite directory requests to index.html
+    // (S3 REST API does not support index documents for subdirectories)
+    const urlRewrite = new cloudfront.Function(this, "UrlRewrite", {
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+  if (uri.endsWith('/')) {
+    request.uri += 'index.html';
+  } else if (!uri.includes('.')) {
+    request.uri += '/index.html';
+  }
+  return request;
+}
+`),
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+    });
+
     const distribution = new cloudfront.Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: new origins.S3Origin(siteBucket, { originAccessIdentity: oai }),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        functionAssociations: [{
+          function: urlRewrite,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        }],
       },
       defaultRootObject: "index.html",
       errorResponses: [

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -43,6 +43,7 @@
         "semver"
       ],
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.4"
@@ -145,6 +146,7 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -592,7 +594,8 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
       "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -668,6 +671,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -167,6 +167,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.1.tgz",
       "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.973.1",
@@ -1637,6 +1638,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3463,6 +3465,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7113,6 +7116,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7122,6 +7126,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7132,6 +7137,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7200,6 +7206,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -7719,6 +7726,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8266,6 +8274,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9405,6 +9414,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9590,6 +9600,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10015,6 +10026,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10863,6 +10875,7 @@
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11852,7 +11865,6 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14420,6 +14432,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14429,6 +14442,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16094,7 +16108,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -16414,6 +16429,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17075,6 +17091,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web-ui/src/app/(authenticated)/page.tsx
+++ b/web-ui/src/app/(authenticated)/page.tsx
@@ -7,21 +7,15 @@
 "use client"
 
 import { useEffect } from "react"
-import { useRouter } from "next/navigation"
 
 export default function RootPage() {
-  const router = useRouter()
-
   useEffect(() => {
     const returnUrl = sessionStorage.getItem("post_signin_return_url")
-    console.log("[RootPage] returnUrl from sessionStorage:", returnUrl)
-    if (returnUrl && returnUrl !== "/") {
-      sessionStorage.removeItem("post_signin_return_url")
-      router.replace(returnUrl)
-    } else {
-      router.replace("/decks")
-    }
-  }, [router])
+    sessionStorage.removeItem("post_signin_return_url")
+    // Avoid redirecting to "/" (this page) which would cause an infinite loop
+    const target = returnUrl && returnUrl !== "/" ? returnUrl : "/decks/"
+    window.location.replace(target)
+  }, [])
 
   return null
 }

--- a/web-ui/src/components/auth/AuthProvider.tsx
+++ b/web-ui/src/components/auth/AuthProvider.tsx
@@ -64,10 +64,7 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
       {...authConfig}
       // This callback removes the `?code=` from the URL, which will break page refreshes
       onSigninCallback={() => {
-        // Restore the URL the user was on before OIDC redirect (saved by AutoSignin)
-        const returnUrl = sessionStorage.getItem("post_signin_return_url") || ""
-        sessionStorage.removeItem("post_signin_return_url")
-        window.history.replaceState({}, document.title, returnUrl || window.location.pathname)
+        window.history.replaceState({}, document.title, window.location.pathname)
       }}
     >
       <AutoSignin>{children}</AutoSignin>

--- a/web-ui/src/components/auth/AutoSignin.tsx
+++ b/web-ui/src/components/auth/AutoSignin.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 "use client"
 
-import { ReactNode, useSyncExternalStore } from "react"
+import { ReactNode, useEffect, useSyncExternalStore } from "react"
 import { useAutoSignin } from "react-oidc-context"
 
 /**
@@ -10,10 +10,13 @@ import { useAutoSignin } from "react-oidc-context"
  * Handles hasAuthParams check, redirect loop prevention, and error states internally.
  */
 function AutoSigninContent({ children }: { children: ReactNode }) {
-  // Save current URL (with hash) before potential OIDC redirect
-  if (typeof window !== "undefined" && !window.location.search.includes("code=")) {
-    sessionStorage.setItem("post_signin_return_url", window.location.pathname + window.location.hash)
-  }
+  // Save current URL once on mount (before potential OIDC redirect).
+  // Using useEffect to avoid re-saving on re-renders after the OIDC callback.
+  useEffect(() => {
+    if (!window.location.search.includes("code=")) {
+      sessionStorage.setItem("post_signin_return_url", window.location.pathname + window.location.hash)
+    }
+  }, [])
 
   const { isLoading, isAuthenticated, error } = useAutoSignin({
     signinMethod: "signinRedirect",


### PR DESCRIPTION
## Problem

After logging in via Cognito, the app enters an infinite redirect loop at \`/\`, resulting in a blank screen.

## Root Cause

\`AutoSigninContent\` saves the current URL to \`sessionStorage\` during **render** (not in a \`useEffect\`). After the OIDC callback:

1. \`onSigninCallback\` cleans the URL (removes \`?code=\`) via \`history.replaceState\`
2. React re-renders \`AutoSigninContent\`
3. The re-render sees no \`code=\` in the URL → re-saves \`/\` to \`sessionStorage\`
4. \`RootPage\` reads \`/\` from \`sessionStorage\` → \`window.location.replace(\"/\")\` → loops

## Fix

- **\`AutoSignin.tsx\`**: Move \`sessionStorage\` save into \`useEffect([], [])\` so it only runs once on mount, preventing re-saves on re-renders after the OIDC callback.
- **\`AuthProvider.tsx\`**: Simplify \`onSigninCallback\` to only clean the URL query params. Let \`RootPage\` handle return URL consumption.
- **\`page.tsx\` (RootPage)**: Filter out \`/\` as a return URL to prevent self-redirect loops.
- **\`web-ui-stack.ts\`**: Add CloudFront Function to rewrite directory paths (e.g. \`/decks/\`) to \`index.html\` for Next.js static export compatibility.

## Testing

- Verified full login flow: \`/\` → Cognito → \`/?code=...\` → \`/decks/\` ✅
- Verified after clearing localStorage/sessionStorage (with active Cognito session): auto-login works ✅
- Verified direct navigation to \`/decks/\` works ✅