### PR TITLE
🐛 fix(web-ui): auto-recover from stale OIDC state on auth error

### DIFF
--- a/web-ui/src/components/auth/AutoSignin.tsx
+++ b/web-ui/src/components/auth/AutoSignin.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT-0
 "use client"
 
-import { ReactNode, useEffect, useSyncExternalStore } from "react"
-import { useAutoSignin } from "react-oidc-context"
+import { ReactNode, useEffect, useRef, useSyncExternalStore } from "react"
+import { useAuth, useAutoSignin } from "react-oidc-context"
 
 /**
  * AutoSigninContent — uses the official useAutoSignin hook from react-oidc-context.
@@ -22,16 +22,22 @@ function AutoSigninContent({ children }: { children: ReactNode }) {
     signinMethod: "signinRedirect",
   })
 
+  // On auth error, clear stale OIDC state and retry sign-in once
+  const auth = useAuth()
+  const retried = useRef(false)
+  useEffect(() => {
+    if (error && !retried.current) {
+      retried.current = true
+      auth.removeUser().then(() => auth.signinRedirect())
+    }
+  }, [error, auth])
+
   if (isLoading) {
     return <div className="flex items-center justify-center min-h-screen text-xl">Signing in...</div>
   }
 
   if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-screen text-xl text-red-400">
-        Authentication error: {error.message}
-      </div>
-    )
+    return <div className="flex items-center justify-center min-h-screen text-xl">Signing in...</div>
   }
 
   if (!isAuthenticated) {


### PR DESCRIPTION
## Problem

When users have stale or corrupted OIDC tokens in localStorage (e.g. after a redirect loop or session expiry), the app shows a dead-end "Authentication error" message. Users must manually clear browser storage to recover.

## Root Cause

`AutoSignin` displayed the error and stopped. There was no recovery path — the user was stuck until they manually cleared localStorage.

## Fix

On auth error, automatically call `removeUser()` to clear the stale OIDC state from localStorage, then retry `signinRedirect()` once. This sends the user back to the Cognito login flow cleanly.

- Uses `useRef` to ensure retry happens only once per mount (no infinite loop)
- Shows "Signing in..." during recovery instead of an error message

## Related

Also deployed the CloudFront Function (URL rewrite) from #29 via `cdk deploy SdpmWebUi` — this was the root cause of the redirect loop that produced the stale tokens in the first place.