### PR TITLE
Unify bullet/numbering into list property, add master bodyStyle reference and hidden slide support

### DIFF
--- a/skill/references/workflows/slide-json-spec.md
+++ b/skill/references/workflows/slide-json-spec.md
@@ -261,18 +261,18 @@ Height includes the language label (22px). Code body height is `height - 22`.
 **Bullets / numbered lists**:
 ```json
 {"type": "textbox", "paragraphs": [
-  {"text": "Item 1", "bullet": true},
-  {"text": "Step 1", "numbering": "arabicPeriod"}
+  {"text": "Item 1", "list": {"type": "disc"}},
+  {"text": "Step 1", "list": {"type": "arabicPeriod"}}
 ]}
 ```
 
 - `spaceAfter`: space after paragraph (hundredths of a point. 800 = 8pt). Works in textbox `paragraphs` and shape `items`
 ```json
-{"text": "Item 1", "bullet": true, "spaceAfter": 800}
+{"text": "Item 1", "list": {"type": "disc"}, "spaceAfter": 800}
 ```
-- `level`: paragraph level (0=top, 1=sub, 2=sub-sub). For nested bullets
+- `list.level`: paragraph level (0=top, 1=sub, 2=sub-sub). For nested lists
 ```json
-{"text": "Sub-item", "bullet": true, "level": 1}
+{"text": "Sub-item", "list": {"type": "disc", "level": 1}}
 ```
 - `lineSpacingPct`: line spacing (percent × 1000. 120000 = 120%)
 ```json
@@ -365,7 +365,7 @@ Height includes the language label (22px). Code body height is `height - 22`.
   "flipH": false,
   "flipV": false,
   "text": "Label",
-  "paragraphs": [{"text": "Title", "fontSize": 24, "align": "center"}, {"text": "Body", "bullet": true}],
+  "paragraphs": [{"text": "Title", "fontSize": 24, "align": "center"}, {"text": "Body", "list": {"type": "disc"}}],
   "fontSize": 14,
   "align": "left|center|right",
   "verticalAlign": "top|middle|bottom",

--- a/skill/sdpm/builder/__init__.py
+++ b/skill/sdpm/builder/__init__.py
@@ -109,6 +109,7 @@ class PPTXBuilder(
         self.keep_empty_placeholders = keep_empty_placeholders
         self.layouts = self._build_layout_map()
         self._base_dir = base_dir if base_dir is not None else Path(".")
+        self._list_styles = self._load_list_styles()
         self._clear_slides()
 
     @staticmethod
@@ -192,6 +193,34 @@ class PPTXBuilder(
             name = layout.name if layout.name else f"layout-{i+1:02d}"
             layouts[name] = i
         return layouts
+
+    def _load_list_styles(self):
+        """Load bullet/numbering definitions from slide master's bodyStyle."""
+        from pptx.oxml.ns import qn
+        master = self.prs.slide_masters[self.master_idx]
+        tx_styles = master._element.find(qn('p:txStyles'))
+        if tx_styles is None:
+            return {}
+        body_style = tx_styles.find(qn('p:bodyStyle'))
+        if body_style is None:
+            return {}
+        styles = {}
+        for i, lvl in enumerate(body_style):
+            bu_char = lvl.find(qn('a:buChar'))
+            bu_font = lvl.find(qn('a:buFont'))
+            bu_auto_num = lvl.find(qn('a:buAutoNum'))
+            entry = {
+                'marL': lvl.get('marL'),
+                'indent': lvl.get('indent'),
+            }
+            if bu_char is not None:
+                entry['buChar'] = bu_char.get('char')
+            if bu_font is not None:
+                entry['buFont'] = bu_font.get('typeface')
+            if bu_auto_num is not None:
+                entry['buAutoNum'] = bu_auto_num.get('type')
+            styles[i] = entry
+        return styles
 
     def _clear_slides(self):
         while len(self.prs.slides) > 0:
@@ -356,6 +385,9 @@ class PPTXBuilder(
         self.theme_colors["text"] = saved_text
         self.theme_colors["background"] = saved_bg
         self.is_dark = saved_is_dark
+
+        if slide_def.get("hidden"):
+            slide._element.set("show", "0")
 
         return slide
 

--- a/skill/sdpm/builder/elements/textbox.py
+++ b/skill/sdpm/builder/elements/textbox.py
@@ -40,7 +40,7 @@ class TextboxMixin:
             ns = 'http://schemas.openxmlformats.org/drawingml/2006/main'
             # If paragraphs have bullets, remove buNone from lstStyle
             has_bullets = any(
-                (p.get('bullet') if isinstance(p, dict) else False)
+                (p.get('list') if isinstance(p, dict) else False)
                 for p in (elem.get('paragraphs') or [])
             )
             if has_bullets:
@@ -151,24 +151,24 @@ class TextboxMixin:
                 # Check if it's a dict with bullet/numbering info or just a string
                 if isinstance(para_item, dict):
                     para_text = para_item.get("text", "")
-                    has_bullet = para_item.get("bullet", False)
-                    numbering = para_item.get("numbering")
+                    list_def = para_item.get("list")
                 else:
                     para_text = para_item
-                    has_bullet = False
-                    numbering = None
+                    list_def = None
                 
-                # Apply bullet or numbering
-                if numbering:
-                    p.level = 0
-                    self._set_numbering(p, numbering)
-                elif has_bullet:
-                    p.level = 0
-                    self._set_bullet(p)
+                # Apply list (bullet or numbering)
+                if list_def and isinstance(list_def, dict):
+                    list_type = list_def.get("type", "disc")
+                    p.level = list_def.get("level", 0)
+                    if list_type == "disc":
+                        self._set_bullet(p)
+                    else:
+                        self._set_numbering(p, list_type)
                 
                 # Apply text
                 if para_text:
-                    self._apply_styled_text(p, para_text, default_color=default_color, default_font_size=default_font_size, font_family=font_family, no_default_font=has_lst_style)
+                    para_font_size = para_item.get("fontSize", default_font_size) if isinstance(para_item, dict) else default_font_size
+                    self._apply_styled_text(p, para_text, default_color=default_color, default_font_size=para_font_size, font_family=font_family, no_default_font=has_lst_style)
                 
                 # Apply line spacing percentage (must be before spcBef/spcAft in XML)
                 if isinstance(para_item, dict) and para_item.get("lineSpacingPct"):
@@ -205,7 +205,7 @@ class TextboxMixin:
                     p.alignment = align_map.get(effective_align, PP_ALIGN.LEFT)
                 
                 # Add buNone if lstStyle has bullet defs but paragraph has no bullet
-                if has_lst_style and not (isinstance(para_item, dict) and para_item.get("bullet")):
+                if has_lst_style and not (isinstance(para_item, dict) and para_item.get("list")):
                     from lxml import etree as _et
                     from pptx.oxml.ns import qn as _qn
                     pPr = p._element.get_or_add_pPr()

--- a/skill/sdpm/builder/placeholder.py
+++ b/skill/sdpm/builder/placeholder.py
@@ -97,32 +97,40 @@ class PlaceholderMixin:
         self._fill_placeholders(slide, d)
     
     def _set_bullet(self, paragraph, char=None):
-        """Set bullet point formatting on paragraph."""
+        """Set bullet point formatting from master's bodyStyle definition."""
         from pptx.oxml.ns import qn
         from lxml import etree
         
+        level = paragraph.level or 0
+        style = self._list_styles.get(level, {})
+        
         pPr = paragraph._element.get_or_add_pPr()
-        pPr.set('marL', '285750')
-        pPr.set('indent', '-285750')
+        if style.get('marL'):
+            pPr.set('marL', style['marL'])
+        if style.get('indent'):
+            pPr.set('indent', style['indent'])
         
-        # Add bullet font
-        buFont = etree.SubElement(pPr, qn('a:buFont'))
-        buFont.set('typeface', 'Arial')
-        
-        # Add bullet character
-        buChar = etree.SubElement(pPr, qn('a:buChar'))
-        buChar.set('char', char or '•')
+        bu_font = style.get('buFont', 'Arial')
+        bu_char = char or style.get('buChar', '•')
+        font_elem = etree.SubElement(pPr, qn('a:buFont'))
+        font_elem.set('typeface', bu_font)
+        char_elem = etree.SubElement(pPr, qn('a:buChar'))
+        char_elem.set('char', bu_char)
     
     def _set_numbering(self, paragraph, numbering_type='arabicPeriod'):
-        """Set numbering formatting on paragraph."""
+        """Set numbering formatting, using master's marL/indent for indentation."""
         from pptx.oxml.ns import qn
         from lxml import etree
         
-        pPr = paragraph._element.get_or_add_pPr()
-        pPr.set('marL', '285750')
-        pPr.set('indent', '-285750')
+        level = paragraph.level or 0
+        style = self._list_styles.get(level, {})
         
-        # Add auto numbering
+        pPr = paragraph._element.get_or_add_pPr()
+        if style.get('marL'):
+            pPr.set('marL', style['marL'])
+        if style.get('indent'):
+            pPr.set('indent', style['indent'])
+        
         buAutoNum = etree.SubElement(pPr, qn('a:buAutoNum'))
         buAutoNum.set('type', numbering_type)
     

--- a/skill/sdpm/converter/elements.py
+++ b/skill/sdpm/converter/elements.py
@@ -614,7 +614,7 @@ def extract_textbox_element(shape, theme_colors=None, color_mapping=None, theme_
             
             # Empty paragraph
             if not paragraph.text.strip():
-                paragraphs.append({"text": "", "bullet": False})
+                paragraphs.append({"text": ""})
                 continue
             
             # Check for bullet or numbering
@@ -660,10 +660,16 @@ def extract_textbox_element(shape, theme_colors=None, color_mapping=None, theme_
             
             item_text = _extract_styled_text(paragraph.runs, theme_colors, color_mapping, default_font_size=default_font_size, default_text_color=default_text_color, is_placeholder=is_placeholder, paragraph=paragraph)
             para_info = {"text": item_text}
-            if has_bullet:
-                para_info["bullet"] = True
-            elif numbering_type:
-                para_info["numbering"] = numbering_type
+            if has_bullet or numbering_type:
+                list_def = {}
+                if numbering_type:
+                    list_def["type"] = numbering_type
+                else:
+                    list_def["type"] = "disc"
+                level = paragraph.level if paragraph.level else 0
+                if level > 0:
+                    list_def["level"] = level
+                para_info["list"] = list_def
             if bu_font:
                 para_info["buFont"] = bu_font
             if mar_l is not None:


### PR DESCRIPTION
## Summary

Refactors the list formatting system and adds two small features synced from internal.

## Changes

### List property unification
- Replaces separate `bullet: true` / `numbering: "arabicPeriod"` / `level: N` paragraph properties with a single `list` object: `{"type": "disc", "level": 0}`
- `type` accepts `"disc"` (bullet) or any numbering type (e.g. `"arabicPeriod"`)
- Simplifies the JSON schema and aligns bullet/numbering under one concept

### Master bodyStyle reference
- `placeholder.py` now reads `buChar`, `buFont`, `marL`, and `indent` from the slide master's `bodyStyle` per level, instead of hardcoding `marL: 285750`
- Ensures bullet/numbering formatting matches the template's design

### Hidden slide support
- `hidden: true` on a slide definition sets `show="0"` on the slide XML
- Useful for base slides used only as override targets (id/override pattern)

### Documentation
- `slide-json-spec.md` updated to reflect the new `list` property syntax

## Breaking change

`bullet`, `numbering`, and top-level `level` paragraph properties are replaced by `list: {type, level}`. Existing JSON using the old format needs to be updated.