### PR TITLE
feat: graceful MCP fallback, IAM auth, and connection status UI

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -42,9 +42,10 @@ app = BedrockAgentCoreApp()
 #     - For MCP servers deployed on Amazon Bedrock AgentCore Runtime with JWT authentication
 #     - Requires: Runtime ARN, caller's JWT token
 #
-#   Pattern 2: Public Remote MCP (no auth)
-#     - For publicly accessible MCP servers (e.g. AWS Knowledge MCP)
-#     - Requires: URL only
+#   Pattern 2: IAM-authenticated Remote MCP (with public fallback)
+#     - For AWS-managed MCP servers (e.g. AWS Knowledge MCP)
+#     - Primary: IAM-authenticated endpoint via mcp-proxy-for-aws
+#     - Fallback: Public unauthenticated endpoint
 #
 #   Pattern 3: Local stdio MCP
 #     - For MCP servers that run as local processes
@@ -83,17 +84,31 @@ def _mcp_agentcore_runtime(jwt_token: str) -> MCPClient:
 
 
 def _mcp_aws_knowledge() -> MCPClient:
-    """Pattern 2: Public Remote MCP Server (no authentication).
+    """Pattern 2: IAM-authenticated AWS Knowledge MCP with public fallback.
 
     AWS Knowledge MCP provides access to AWS documentation, API references,
     What's New, Well-Architected guidance, and blog posts.
 
+    Primary: IAM-authenticated endpoint (higher rate limits).
+    Fallback: Public unauthenticated endpoint.
+
     Returns:
         MCPClient for AWS Knowledge MCP.
     """
-    return MCPClient(
-        lambda: streamablehttp_client(url="https://knowledge-mcp.global.api.aws"),
-    )
+    region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+    try:
+        from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
+        return MCPClient(
+            lambda: aws_iam_streamablehttp_client(
+                endpoint=f"https://aws-mcp.{region}.api.aws/mcp",
+                aws_service="aws-mcp",
+            ),
+        )
+    except Exception:
+        logger.warning("IAM auth unavailable for AWS Knowledge MCP, using public endpoint")
+        return MCPClient(
+            lambda: streamablehttp_client(url="https://knowledge-mcp.global.api.aws"),
+        )
 
 
 def _mcp_aws_pricing() -> MCPClient:
@@ -155,6 +170,13 @@ def _build_system_prompt(mcp_instructions: str) -> str:
 # Agent Factory
 # ---------------------------------------------------------------------------
 
+# MCP server definitions: (factory, display_name, required)
+_MCP_DEFS: list[tuple[str, bool]] = [
+    ("Presentation Maker", True),
+    ("AWS Knowledge", False),
+    ("AWS Pricing", False),
+]
+
 
 def _collect_mcp_instructions(mcp_servers: list[MCPClient]) -> str:
     """Collect server_instructions from all MCP servers.
@@ -177,11 +199,12 @@ def _collect_mcp_instructions(mcp_servers: list[MCPClient]) -> str:
     return "\n\n".join(sections)
 
 
-def create_agent(user_id: str, session_id: str, jwt_token: str) -> Agent:
+def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, list[dict]]:
     """Create a Strands Agent with MCP tools and memory.
 
     MCP servers are initialized first so that server_instructions can be
     collected and injected into the system prompt (MCP spec compliance).
+    Optional MCP servers that fail to initialize are skipped.
 
     Args:
         user_id: User identifier (JWT sub claim).
@@ -189,7 +212,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> Agent:
         jwt_token: JWT access token for MCP Server authentication.
 
     Returns:
-        Configured Strands Agent instance.
+        Tuple of (Configured Strands Agent instance, MCP status list).
     """
     memory_id = os.environ.get("MEMORY_ID", "")
     region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
@@ -211,31 +234,70 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> Agent:
         temperature=0.1,
     )
 
-    # --- Register MCP Servers ---
-    mcp_servers = [
-        _mcp_agentcore_runtime(jwt_token=jwt_token),  # Pattern 1: sdpm (AgentCore + JWT)
-        _mcp_aws_knowledge(),       # Pattern 2: AWS docs (public, no auth)
-        _mcp_aws_pricing(),         # Pattern 3: AWS pricing (local stdio)
+    # --- Build MCP server list with resilience ---
+    factories = [
+        lambda: _mcp_agentcore_runtime(jwt_token=jwt_token),
+        _mcp_aws_knowledge,
+        _mcp_aws_pricing,
     ]
 
-    # Collect server_instructions from MCP servers for system prompt injection.
-    # Agent.__init__ triggers tool loading which initializes all MCP clients,
-    # so server_instructions is available after Agent creation.
-    agent = Agent(
-        name="SdpmAgent",
-        system_prompt="",  # placeholder — replaced below after MCP init
-        tools=[*mcp_servers, read_uploaded_file, list_uploads, web_fetch],
-        model=model,
-        session_manager=session_manager,
-        trace_attributes={"user.id": user_id, "session.id": session_id},
-    )
+    mcp_servers: list[MCPClient] = []
+    mcp_status: list[dict] = []
+
+    for (name, required), factory in zip(_MCP_DEFS, factories):
+        try:
+            mcp_servers.append(factory())
+            mcp_status.append({"name": name, "status": "ok"})
+        except Exception as e:
+            mcp_status.append({"name": name, "status": "error", "error": str(e)})
+            if required:
+                raise
+
+    # Agent.__init__ triggers MCP client connections.
+    # If optional MCP servers fail during init, retry with required-only.
+    tools = [*mcp_servers, read_uploaded_file, list_uploads, web_fetch]
+    try:
+        agent = Agent(
+            name="SdpmAgent",
+            system_prompt="",
+            tools=tools,
+            model=model,
+            session_manager=session_manager,
+            trace_attributes={"user.id": user_id, "session.id": session_id},
+        )
+    except Exception as init_err:
+        init_reason = str(init_err)
+        logger.warning("Agent init failed with all MCP servers, retrying with required-only: %s", init_reason)
+        # Keep only required MCP servers
+        required_servers = []
+        new_status = []
+        for (name, required), st in zip(_MCP_DEFS, mcp_status):
+            if required and st["status"] == "ok":
+                required_servers.append(mcp_servers[len(new_status)])
+                new_status.append(st)
+            else:
+                if st["status"] == "ok":
+                    new_status.append({"name": name, "status": "error", "error": "Service unavailable"})
+                else:
+                    new_status.append(st)
+
+        mcp_servers = required_servers
+        mcp_status = new_status
+        agent = Agent(
+            name="SdpmAgent",
+            system_prompt="",
+            tools=[*mcp_servers, read_uploaded_file, list_uploads, web_fetch],
+            model=model,
+            session_manager=session_manager,
+            trace_attributes={"user.id": user_id, "session.id": session_id},
+        )
 
     # Now that MCP clients are initialized, inject their instructions.
     agent.system_prompt = _build_system_prompt(
         mcp_instructions=_collect_mcp_instructions(mcp_servers),
     )
 
-    return agent
+    return agent, mcp_status
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +432,11 @@ async def agent_stream(payload, context):
 
     try:
         os.environ["_CURRENT_SESSION_ID"] = session_id
-        agent = create_agent(user_id=user_id, session_id=session_id, jwt_token=jwt_token)
+        agent, mcp_status = create_agent(user_id=user_id, session_id=session_id, jwt_token=jwt_token)
+
+        # Emit MCP status as the first SSE event
+        yield {"mcp_status": mcp_status}
+
         _fix_excess_tool_results(agent.messages)
 
         async def _next(aiter):

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -5,5 +5,6 @@ mcp>=1.23.1
 bedrock-agentcore[strands-agents]>=1.0.6
 aws-opentelemetry-distro>=0.10.0
 awslabs.aws-pricing-mcp-server
+mcp-proxy-for-aws>=1.1.0
 requests
 html2text

--- a/infra/lib/agent-stack.ts
+++ b/infra/lib/agent-stack.ts
@@ -81,6 +81,14 @@ export class AgentStack extends cdk.Stack {
       })
     );
 
+    // AWS MCP service (IAM-authenticated Knowledge MCP endpoint)
+    role.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["aws-mcp:*"],
+        resources: ["*"],
+      })
+    );
+
     // ECR pull
     role.addToPolicy(
       new iam.PolicyStatement({
@@ -140,6 +148,7 @@ export class AgentStack extends cdk.Stack {
         DECKS_TABLE: props.table.tableName,
         PPTX_BUCKET: props.pptxBucket.bucketName,
         AWS_DEFAULT_REGION: this.region,
+        DEPLOY_TIMESTAMP: new Date().toISOString(),
       },
       description: "spec-driven-presentation-maker Strands Agent — connects to MCP Server for slide generation",
     });

--- a/infra/lib/runtime-stack.ts
+++ b/infra/lib/runtime-stack.ts
@@ -176,6 +176,7 @@ export class RuntimeStack extends cdk.Stack {
         KB_SSM_PARAM: props.kbSsmParamName ?? "",
         VECTOR_BUCKET_NAME: props.vectorBucketName ?? "",
         VECTOR_INDEX_NAME: props.vectorIndexName ?? "",
+        DEPLOY_TIMESTAMP: new Date().toISOString(),
       },
       description: "spec-driven-presentation-maker MCP Server — AI-powered presentation generation",
     });

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -22,6 +22,7 @@ import { getChatHistory, listDecks, patchDeck, DeckSummary } from "@/services/de
 import { uploadFile, validateFile, canAddMoreFiles, UploadedFile } from "@/services/uploadService"
 import { useCompositionSafe } from "@/hooks/useCompositionSafe"
 import { ChatMessage, ToolUse } from "./ChatMessage"
+import { McpStatusBar, McpServerStatus } from "./McpStatusBar"
 import { MentionOverlay } from "./MentionOverlay"
 import { MentionPopup, MentionItem } from "./MentionPopup"
 import { PlusMenu } from "./PlusMenu"
@@ -39,6 +40,7 @@ interface Message {
   /** Ordered sequence of text and tool blocks for inline display. */
   blocks?: { type: "text"; text: string }[] | { type: "tool"; tool: ToolUse }[]
   snippets?: { label: string; text: string }[]
+  mcpStatus?: McpServerStatus[]
 }
 
 /** Shape of tool-use callback data from the agent streaming API. */
@@ -523,6 +525,22 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         accessToken,
         userId,
         (toolName: string, toolUseData: ToolUseCallbackData | undefined) => {
+          // MCP status event — show on first message, or when status changes
+          if (toolName === '__mcp_status__' && toolUseData && 'mcpStatus' in toolUseData) {
+            const incoming = (toolUseData as unknown as { mcpStatus: McpServerStatus[] }).mcpStatus
+            setMessages((prev) => {
+              // Find the last mcpStatus in history
+              const lastStatus = [...prev].reverse().find((m) => m.mcpStatus)?.mcpStatus
+              // Skip if identical to previous
+              if (lastStatus && JSON.stringify(lastStatus) === JSON.stringify(incoming)) return prev
+              const updated = [...prev]
+              const last = updated[updated.length - 1]
+              updated[updated.length - 1] = { ...last, mcpStatus: incoming }
+              return updated
+            })
+            return
+          }
+
           // Tool result (completed) — detect deckId from any tool's result
           if (toolUseData?.completed && toolUseData?.result?.deckId && onDeckCreated) {
             // Link chat session to deck for history restore
@@ -737,16 +755,22 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
           ) : (
             <div className="space-y-4">
               {messages.map((msg, i) => (
-                <ChatMessage
-                  key={i}
-                  role={msg.role}
-                  content={msg.content}
-                  toolUses={msg.toolUses}
-                  blocks={msg.blocks}
-                  snippets={msg.snippets}
-                  isStreaming={isLoading && i === messages.length - 1}
-                  idToken={auth.user?.id_token}
-                />
+                <div key={i}>
+                  {msg.mcpStatus && (
+                    <div className="mb-2 ml-10">
+                      <McpStatusBar servers={msg.mcpStatus} />
+                    </div>
+                  )}
+                  <ChatMessage
+                    role={msg.role}
+                    content={msg.content}
+                    toolUses={msg.toolUses}
+                    blocks={msg.blocks}
+                    snippets={msg.snippets}
+                    isStreaming={isLoading && i === messages.length - 1}
+                    idToken={auth.user?.id_token}
+                  />
+                </div>
               ))}
               <div ref={messagesEndRef} />
             </div>

--- a/web-ui/src/components/chat/McpStatusBar.tsx
+++ b/web-ui/src/components/chat/McpStatusBar.tsx
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * McpStatusBar — Displays MCP server connection status at the start of a chat response.
+ *
+ * Two visual modes:
+ * - All OK: Single compact bar with check icon and dot-separated server names
+ * - Partial failure: OK servers in compact bar + individual error cards for failed servers
+ *
+ * Design language matches ToolCard (oklch colors, rounded-xl, inset borders).
+ */
+
+"use client"
+
+import { Check, AlertCircle } from "lucide-react"
+
+export interface McpServerStatus {
+  name: string
+  status: "ok" | "error"
+  error?: string
+}
+
+interface McpStatusBarProps {
+  servers: McpServerStatus[]
+}
+
+const OK_COLOR = {
+  accent: "oklch(0.72 0.15 155)",
+  bg: "oklch(0.72 0.15 155 / 6%)",
+  border: "oklch(0.72 0.15 155 / 18%)",
+}
+
+const ERR_COLOR = {
+  accent: "oklch(0.65 0.2 25)",
+  bg: "oklch(0.65 0.2 25 / 6%)",
+  border: "oklch(0.65 0.2 25 / 18%)",
+}
+
+export function McpStatusBar({ servers }: McpStatusBarProps) {
+  if (!servers || servers.length === 0) return null
+
+  const okServers = servers.filter((s) => s.status === "ok")
+  const errServers = servers.filter((s) => s.status === "error")
+
+  return (
+    <div className="flex flex-col gap-1.5 tool-card-enter">
+      {/* OK servers — compact single line */}
+      {okServers.length > 0 && (
+        <div
+          className="flex items-center gap-2 px-3 py-1.5 rounded-xl"
+          style={{
+            background: OK_COLOR.bg,
+            boxShadow: `inset 0 0 0 1px ${OK_COLOR.border}`,
+          }}
+          role="status"
+          aria-label={`Connected: ${okServers.map((s) => s.name).join(", ")}`}
+        >
+          <div
+            className="flex-none w-5 h-5 rounded-md flex items-center justify-center"
+            style={{ background: `${OK_COLOR.accent}18` }}
+          >
+            <Check className="h-3 w-3" style={{ color: OK_COLOR.accent }} />
+          </div>
+          <span className="text-[12px] font-medium" style={{ color: OK_COLOR.accent }}>
+            {okServers.map((s) => s.name).join(" · ")}
+          </span>
+        </div>
+      )}
+
+      {/* Error servers — individual cards */}
+      {errServers.map((server) => (
+        <div
+          key={server.name}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-xl"
+          style={{
+            background: ERR_COLOR.bg,
+            boxShadow: `inset 0 0 0 1px ${ERR_COLOR.border}`,
+          }}
+          role="alert"
+          aria-label={`Unavailable: ${server.name}`}
+        >
+          <div
+            className="flex-none w-5 h-5 rounded-md flex items-center justify-center"
+            style={{ background: `${ERR_COLOR.accent}18` }}
+          >
+            <AlertCircle className="h-3 w-3" style={{ color: ERR_COLOR.accent }} />
+          </div>
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium" style={{ color: ERR_COLOR.accent }}>
+              {server.name}
+            </span>
+            {server.error && (
+              <p className="text-[11px] truncate mt-0.5 leading-tight" style={{ color: `${ERR_COLOR.accent}99` }}>
+                {server.error.length > 80 ? server.error.slice(0, 80) + "…" : server.error}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web-ui/src/services/strandsParser.js
+++ b/web-ui/src/services/strandsParser.js
@@ -50,6 +50,12 @@ export const parseStreamingChunk = (line, currentCompletion, updateCallback, too
     // Keep-alive
     if (json.keepalive) return currentCompletion;
 
+    // MCP status event — pass to toolCallback with special type
+    if (json.mcp_status) {
+      if (toolCallback) toolCallback('__mcp_status__', { mcpStatus: json.mcp_status });
+      return currentCompletion;
+    }
+
     // Tool start events — tool is now executing (no input yet)
     if (json.toolStart) {
       const toolUseId = json.toolStart.toolUseId;


### PR DESCRIPTION
## Summary

When an external MCP server (AWS Knowledge, AWS Pricing) is unavailable, the agent now continues operating
with the remaining servers instead of failing entirely. Connection status is displayed in the chat UI.

## Problem

On 2026-04-10, AWS Knowledge MCP Server (knowledge-mcp.global.api.aws) experienced an outage that caused
the agent to fail completely — even though the core Presentation Maker MCP was healthy. Two independent
environments were affected simultaneously.

## Changes

### Agent (agent/)
- **Resilient MCP initialization**: Optional MCP servers that fail to connect are skipped; only
Presentation Maker is required
- **IAM-authenticated endpoint**: AWS Knowledge MCP switched from public endpoint to
aws-mcp.{region}.api.aws/mcp via mcp-proxy-for-aws (higher rate limits, with public fallback)
- **SSE status event**: mcp_status emitted as the first event in the stream with per-server connection
results

### Infrastructure (infra/)
- IAM policy for aws-mcp service added to Agent role
- DEPLOY_TIMESTAMP env var to force CDK change detection

### Frontend (web-ui/)
- New McpStatusBar component matching ToolCard design language (oklch colors, rounded-xl, inset borders)
- All OK → compact single-line bar with check icon
- Partial failure → individual error cards for failed servers
- Displayed on first response; re-displayed only when status changes

## Testing
- Verified agent responds with Presentation Maker only (knowledge + pricing down)
- Verified MCP status bar renders correctly in chat UI
- Verified status is suppressed on subsequent messages when unchanged