### PR TITLE
config: introduce __version__ and SemVer versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ web-ui/public/aws-exports.json
 !.kiro/steering/
 .kiro/steering/*
 !.kiro/steering/principles.md
+!.kiro/steering/versioning.md
+!.kiro/steering/steering-policy.md
 
 # Config (contains secrets)
 infra/config.yaml

--- a/.kiro/steering/principles.md
+++ b/.kiro/steering/principles.md
@@ -1,3 +1,5 @@
+<!-- PUBLIC: This file is git-tracked and visible in the public repository. -->
+
 # Principles
 
 ## Architecture: 3-Layer Structure

--- a/.kiro/steering/steering-policy.md
+++ b/.kiro/steering/steering-policy.md
@@ -1,0 +1,12 @@
+<!-- PUBLIC: This file is git-tracked and visible in the public repository. -->
+
+# Steering Policy
+
+## Overview
+`.kiro/steering/` contains project principles and rules.
+Referenced by both AI agents and human contributors.
+
+## Git Management
+- All steering files are excluded by `.gitignore` by default (safe by default)
+- Public files are opt-in via `!.kiro/steering/<filename>` in `.gitignore`
+- Public files must include `<!-- PUBLIC: This file is git-tracked and visible in the public repository. -->` at the top

--- a/.kiro/steering/versioning.md
+++ b/.kiro/steering/versioning.md
@@ -20,4 +20,3 @@
 - Breaking changes must always bump MAJOR
 - No release needed for internal-only refactoring
 - Git tag format: `v{MAJOR}.{MINOR}.{PATCH}` (e.g., `v0.1.0`)
-- After tag push, create GitHub Releases with key changes noted

--- a/.kiro/steering/versioning.md
+++ b/.kiro/steering/versioning.md
@@ -1,0 +1,23 @@
+<!-- PUBLIC: This file is git-tracked and visible in the public repository. -->
+
+# Versioning
+
+## Engine Version
+- Single source of truth: `__version__` in `skill/sdpm/__init__.py`
+- `skill/pyproject.toml` uses dynamic version, auto-read from `__init__.py`
+- When changing version, edit `__init__.py` only
+
+## SemVer
+- MAJOR: Breaking changes to Engine API (e.g., existing JSON no longer works)
+- MINOR: New features, new slide patterns
+- PATCH: Bug fixes
+- While in 0.x, breaking changes may occur in MINOR releases
+- The 1.0.0 release will signal API stability
+
+## Release
+- Milestone-based (manual decision)
+- Tag when user-facing changes have accumulated
+- Breaking changes must always bump MAJOR
+- No release needed for internal-only refactoring
+- Git tag format: `v{MAJOR}.{MINOR}.{PATCH}` (e.g., `v0.1.0`)
+- After tag push, create GitHub Releases with key changes noted

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ Spec-driven presentation applies the concept of Spec-Driven Development from sof
 
 Copy `skill/` to your Kiro CLI skills directory. The engine, references, and sample templates are all included.
 
+You can also install the engine as a Python package:
+
+```bash
+# Latest
+pip install git+https://github.com/aws-samples/sample-spec-driven-presentation-maker.git#subdirectory=skill
+
+# Specific version
+pip install git+https://github.com/aws-samples/sample-spec-driven-presentation-maker.git@v0.1.0#subdirectory=skill
+```
+
+Check the installed version:
+
+```python
+import sdpm
+print(sdpm.__version__)
+```
+
 ### Layer 2: Local MCP Server
 
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -42,6 +42,23 @@
 
 `skill/` を Kiro CLI のスキルディレクトリにコピーするだけで使えます。
 
+エンジンを Python パッケージとしてインストールすることもできます:
+
+```bash
+# 最新版
+pip install git+https://github.com/aws-samples/sample-spec-driven-presentation-maker.git#subdirectory=skill
+
+# バージョン指定
+pip install git+https://github.com/aws-samples/sample-spec-driven-presentation-maker.git@v0.1.0#subdirectory=skill
+```
+
+インストール済みバージョンの確認:
+
+```python
+import sdpm
+print(sdpm.__version__)
+```
+
 ### Layer 2: ローカル MCP サーバー
 
 ```bash

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sdpm-skill"
-version = "1.0.0"
+dynamic = ["version"]
 description = "PowerPoint generation engine — JSON to PPTX with template analysis and design patterns"
 requires-python = ">=3.10"
 dependencies = [
@@ -14,6 +14,9 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 include = ["sdpm*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "sdpm.__version__"}
 
 [dependency-groups]
 dev = [

--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -1,3 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
Introduce single-source version management for the sdpm-skill engine.

## Changes
- Add `__version__` to `skill/sdpm/__init__.py` as the single source of truth
- `skill/pyproject.toml` uses d__.py` from `__init
- Remove GitHub Releases from versioning policy (mileston-based manual tagging)
- Update `.kiro/steering/versioning.md` with SemVer policy