### PR TITLE
feat: add slide JSON linter to validate elements against spec

### DIFF
--- a/mcp-server/tools/generate.py
+++ b/mcp-server/tools/generate.py
@@ -145,6 +145,10 @@ def generate_pptx(
         default_text_color=presentation.get("defaultTextColor"),
     )
 
+    # Lint slide JSON
+    from sdpm.schema.lint import lint as lint_slides
+    lint_diagnostics = lint_slides(presentation)
+
     # Build id_map for resolve_override
     id_map: dict[str, dict] = {}
     for s in slides:
@@ -260,4 +264,6 @@ def generate_pptx(
     }
     if warnings:
         result["warnings"] = warnings
+    if lint_diagnostics:
+        result["errors"] = {"lintDiagnostics": lint_diagnostics}
     return result

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -193,6 +193,10 @@ def generate(
         dtc = "#FFFFFF" if is_dark else "#333333"
         warnings.append(f"defaultTextColor auto-set to {dtc}")
 
+    # Lint slide JSON
+    from sdpm.schema.lint import lint as lint_slides
+    lint_diagnostics = lint_slides(data)
+
     # Validate icons
     missing = validate_icons_in_json(data)
     if missing:
@@ -251,13 +255,16 @@ def generate(
             title = title.get("text", "(no title)")
         summary.append(f"page{i:02d} - {title}")
 
-    return {
+    result = {
         "output_path": str(out),
         "slide_count": len(slides),
         "slides": summary,
         "warnings": warnings,
         "pdf_path": str(pdf_path) if pdf_path and pdf_path.exists() else None,
     }
+    if lint_diagnostics:
+        result["errors"] = {"lintDiagnostics": lint_diagnostics}
+    return result
 
 
 def preview(

--- a/skill/sdpm/schema/lint.py
+++ b/skill/sdpm/schema/lint.py
@@ -4,6 +4,12 @@
 
 from __future__ import annotations
 
+import re
+
+_COLOR_RE = re.compile(r'^#[0-9A-Fa-f]{6}$')
+_ALIGN_VALUES = {"left", "center", "right"}
+_VALIGN_VALUES = {"top", "middle", "bottom"}
+
 
 def lint(data: list | dict) -> list[dict]:
     """Lint slide JSON and return diagnostics.
@@ -30,7 +36,7 @@ def _diag(slide: int, element: int, rule: str, message: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Per-element-type linting
+# Dispatch
 # ---------------------------------------------------------------------------
 
 def _lint_element(si: int, ei: int, elem: dict) -> list[dict]:
@@ -38,28 +44,72 @@ def _lint_element(si: int, ei: int, elem: dict) -> list[dict]:
     if etype is None:
         return [_diag(si, ei, "missing-type", "element has no 'type' field")]
     results: list[dict] = []
-    checker = _CHECKERS.get(etype)
+    checker = _TYPE_CHECKERS.get(etype)
     if checker:
         results.extend(checker(si, ei, elem))
+    # Common checks for all element types
+    results.extend(_lint_common(si, ei, elem))
     return results
 
 
-# --- line ---
+# ===================================================================
+# Common checks (all element types)
+# ===================================================================
 
-# Keys valid for line elements per slide-json-spec.md
-_LINE_COORD_KEYS = {"x1", "y1", "x2", "y2"}
-_LINE_POLYLINE_KEYS = {"points"}
-_LINE_STYLE_KEYS = {
-    "color", "lineWidth", "dashStyle", "connectorType", "elbowStart",
-    "preset", "adjustments", "arrowStart", "arrowEnd", "lineGradient",
-    "opacity",
-}
-_LINE_META_KEYS = {"type", "_comment"}
-_LINE_ALL_KEYS = _LINE_COORD_KEYS | _LINE_POLYLINE_KEYS | _LINE_STYLE_KEYS | _LINE_META_KEYS
+def _lint_common(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    # opacity
+    val = elem.get("opacity")
+    if val is not None and (not isinstance(val, (int, float)) or val < 0 or val > 1):
+        results.append(_diag(si, ei, "invalid-opacity",
+                             f"opacity {val} is out of range. Must be 0–1."))
+    # fontSize
+    fs = elem.get("fontSize")
+    if fs is not None:
+        if not isinstance(fs, (int, float)) or fs <= 0:
+            results.append(_diag(si, ei, "invalid-fontSize",
+                                 f"fontSize {fs} is invalid. Must be a positive number."))
+        elif isinstance(fs, float) and fs != 10.5:
+            results.append(_diag(si, ei, "invalid-fontSize",
+                                 f"fontSize {fs} is non-integer. Only integers and 10.5 are valid."))
+    # color fields
+    for key in ("fill", "color", "fontColor", "line"):
+        c = elem.get(key)
+        if isinstance(c, str) and c not in ("none", ""):
+            if c.startswith("#") and not _COLOR_RE.match(c):
+                results.append(_diag(si, ei, "invalid-color",
+                                     f"'{key}' value '{c}' is not valid #RRGGBB."))
+    # align
+    a = elem.get("align")
+    if a is not None and a not in _ALIGN_VALUES:
+        results.append(_diag(si, ei, "invalid-align",
+                             f"align '{a}' is not valid. Allowed: {sorted(_ALIGN_VALUES)}"))
+    # verticalAlign
+    va = elem.get("verticalAlign")
+    if va is not None and va not in _VALIGN_VALUES:
+        results.append(_diag(si, ei, "invalid-verticalAlign",
+                             f"verticalAlign '{va}' is not valid. Allowed: {sorted(_VALIGN_VALUES)}"))
+    # out-of-bounds (bbox elements)
+    etype = elem.get("type", "")
+    if etype in ("shape", "textbox", "image", "chart", "table", "video", "freeform"):
+        x = elem.get("x", 0)
+        y = elem.get("y", 0)
+        w = elem.get("width", 0)
+        h = elem.get("height", 0)
+        if isinstance(x, (int, float)) and isinstance(w, (int, float)) and x + w > 1920:
+            results.append(_diag(si, ei, "out-of-bounds",
+                                 f"x({x}) + width({w}) = {x+w} exceeds slide width 1920."))
+        if isinstance(y, (int, float)) and isinstance(h, (int, float)) and y + h > 1080:
+            results.append(_diag(si, ei, "out-of-bounds",
+                                 f"y({y}) + height({h}) = {y+h} exceeds slide height 1080."))
+    return results
 
-# Keys that belong to bbox-positioned elements (shape/textbox/image), not line
+
+# ===================================================================
+# line
+# ===================================================================
+
 _BBOX_KEYS = {"x", "y", "width", "height"}
-
 _ARROW_VALUES = {"arrow", "triangle", "stealth", "oval", "diamond", "none"}
 _DASH_VALUES = {"solid", "dash", "dot", "dash_dot", "long_dash", "square_dot",
                 "dash_dot_dot", "long_dash_dot"}
@@ -72,39 +122,32 @@ def _lint_line(si: int, ei: int, elem: dict) -> list[dict]:
     has_x1 = "x1" in elem
     has_bbox = bool(_BBOX_KEYS & elem.keys())
 
-    # Core coordinate check
     if not has_points and not has_x1:
         if has_bbox:
             bbox_found = sorted(_BBOX_KEYS & elem.keys())
             results.append(_diag(
                 si, ei, "line-bbox-keys",
                 f"line element uses {bbox_found} instead of x1/y1/x2/y2. "
-                f"line requires x1/y1 (start) and x2/y2 (end), or points for polyline."
-            ))
+                f"line requires x1/y1 (start) and x2/y2 (end), or points for polyline."))
         else:
             results.append(_diag(
                 si, ei, "line-missing-coords",
-                "line element has no coordinates. Use x1/y1/x2/y2 or points."
-            ))
+                "line element has no coordinates. Use x1/y1/x2/y2 or points."))
 
     if has_x1 and not has_points:
         for k in ("x1", "y1", "x2", "y2"):
             if k not in elem:
                 results.append(_diag(
                     si, ei, "line-missing-coord",
-                    f"line element missing '{k}'. All of x1/y1/x2/y2 are required."
-                ))
+                    f"line element missing '{k}'. All of x1/y1/x2/y2 are required."))
 
-    # Polyline validation
     if has_points:
         pts = elem["points"]
         if not isinstance(pts, list) or len(pts) < 2:
             results.append(_diag(
                 si, ei, "line-points-invalid",
-                "line points must be an array of 2+ coordinate pairs."
-            ))
+                "line points must be an array of 2+ coordinate pairs."))
 
-    # Enum checks
     for key, allowed in (
         ("arrowStart", _ARROW_VALUES),
         ("arrowEnd", _ARROW_VALUES),
@@ -115,13 +158,14 @@ def _lint_line(si: int, ei: int, elem: dict) -> list[dict]:
         if val is not None and val not in allowed:
             results.append(_diag(
                 si, ei, f"line-invalid-{key}",
-                f"line '{key}' value '{val}' is not valid. Allowed: {sorted(allowed)}"
-            ))
+                f"line '{key}' value '{val}' is not valid. Allowed: {sorted(allowed)}"))
 
     return results
 
 
-# --- shape ---
+# ===================================================================
+# shape
+# ===================================================================
 
 _SHAPE_NAMES = {
     "rectangle", "rounded_rectangle", "oval", "circle",
@@ -143,72 +187,195 @@ def _lint_shape(si: int, ei: int, elem: dict) -> list[dict]:
     results: list[dict] = []
     shape = elem.get("shape")
     if shape is not None and shape not in _SHAPE_NAMES:
-        results.append(_diag(
-            si, ei, "shape-unknown-name",
-            f"shape name '{shape}' is not recognized."
-        ))
-    results.extend(_lint_bbox(si, ei, elem, "shape"))
-    results.extend(_lint_opacity(si, ei, elem))
+        results.append(_diag(si, ei, "shape-unknown-name",
+                             f"shape name '{shape}' is not recognized."))
+    results.extend(_lint_bbox_required(si, ei, elem, "shape"))
     return results
 
 
-# --- textbox ---
+# ===================================================================
+# textbox
+# ===================================================================
 
 def _lint_textbox(si: int, ei: int, elem: dict) -> list[dict]:
     results: list[dict] = []
     if "height" not in elem:
-        results.append(_diag(
-            si, ei, "textbox-missing-height",
-            "textbox requires 'height'. Text overflow cannot be detected without it."
-        ))
-    results.extend(_lint_opacity(si, ei, elem))
+        results.append(_diag(si, ei, "textbox-missing-height",
+                             "textbox requires 'height'. Text overflow cannot be detected without it."))
     return results
 
 
-# --- image ---
+# ===================================================================
+# image
+# ===================================================================
 
 def _lint_image(si: int, ei: int, elem: dict) -> list[dict]:
     results: list[dict] = []
     if "src" not in elem:
-        results.append(_diag(
-            si, ei, "image-missing-src",
-            "image element requires 'src'."
-        ))
-    results.extend(_lint_bbox(si, ei, elem, "image"))
-    results.extend(_lint_opacity(si, ei, elem))
+        results.append(_diag(si, ei, "image-missing-src",
+                             "image element requires 'src'."))
+    results.extend(_lint_bbox_required(si, ei, elem, "image"))
     return results
 
 
-# --- common helpers ---
+# ===================================================================
+# chart
+# ===================================================================
 
-def _lint_bbox(si: int, ei: int, elem: dict, etype: str) -> list[dict]:
+_CHART_TYPES = {"bar", "line", "pie", "donut"}
+
+
+def _lint_chart(si: int, ei: int, elem: dict) -> list[dict]:
     results: list[dict] = []
-    for k in ("x", "y"):
-        if k not in elem:
-            results.append(_diag(
-                si, ei, f"{etype}-missing-{k}",
-                f"{etype} element missing '{k}'."
-            ))
+    ct = elem.get("chartType")
+    if ct is None:
+        results.append(_diag(si, ei, "chart-missing-chartType",
+                             "chart element has no 'chartType'. Specify bar, line, pie, or donut."))
+    elif ct not in _CHART_TYPES:
+        results.append(_diag(si, ei, "chart-invalid-chartType",
+                             f"chartType '{ct}' is not valid. Allowed: {sorted(_CHART_TYPES)}"))
+
+    series = elem.get("series")
+    if not series:
+        results.append(_diag(si, ei, "chart-missing-series",
+                             "chart element has no 'series' data."))
+    else:
+        cats = elem.get("categories", [])
+        if cats:
+            n_cats = len(cats)
+            for i, s in enumerate(series):
+                vals = s.get("values", [])
+                if len(vals) != n_cats:
+                    results.append(_diag(
+                        si, ei, "chart-series-values-mismatch",
+                        f"series[{i}] has {len(vals)} values but categories has {n_cats}."))
+
+    if elem.get("holeSize") is not None and ct != "donut":
+        results.append(_diag(si, ei, "chart-holeSize-wrong-type",
+                             f"holeSize is only valid for chartType 'donut', not '{ct}'."))
+    if elem.get("stacked") and ct not in ("bar", None):
+        results.append(_diag(si, ei, "chart-stacked-wrong-type",
+                             f"stacked is only valid for chartType 'bar', not '{ct}'."))
+
+    results.extend(_lint_bbox_required(si, ei, elem, "chart"))
     return results
 
 
-def _lint_opacity(si: int, ei: int, elem: dict) -> list[dict]:
-    val = elem.get("opacity")
-    if val is not None and (not isinstance(val, (int, float)) or val < 0 or val > 1):
-        return [_diag(
-            si, ei, "invalid-opacity",
-            f"opacity {val} is out of range. Must be 0–1."
-        )]
+# ===================================================================
+# table
+# ===================================================================
+
+def _lint_table(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    headers = elem.get("headers")
+    rows = elem.get("rows")
+
+    if not headers:
+        results.append(_diag(si, ei, "table-missing-headers",
+                             "table element has no 'headers'."))
+    if not rows:
+        results.append(_diag(si, ei, "table-missing-rows",
+                             "table element has no 'rows'."))
+
+    if headers and isinstance(headers, list):
+        n_cols = len(headers)
+        col_widths = elem.get("colWidths")
+        if col_widths and isinstance(col_widths, list) and len(col_widths) != n_cols:
+            results.append(_diag(
+                si, ei, "table-column-count-mismatch",
+                f"colWidths has {len(col_widths)} entries but headers has {n_cols} columns."))
+        if rows and isinstance(rows, list):
+            for ri, row in enumerate(rows):
+                if isinstance(row, list) and len(row) != n_cols:
+                    results.append(_diag(
+                        si, ei, "table-column-count-mismatch",
+                        f"rows[{ri}] has {len(row)} cells but headers has {n_cols} columns."))
+
+    results.extend(_lint_bbox_required(si, ei, elem, "table"))
+    return results
+
+
+# ===================================================================
+# freeform
+# ===================================================================
+
+_FREEFORM_CMDS = {"M", "L", "C", "Q", "A", "Z"}
+
+
+def _lint_freeform(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    path = elem.get("path")
+    paths = elem.get("paths")
+    custom = elem.get("customGeometry")
+
+    if not path and not paths and not custom:
+        results.append(_diag(si, ei, "freeform-missing-path",
+                             "freeform element has no 'path', 'paths', or 'customGeometry'."))
+
+    if path and isinstance(path, list):
+        if path and path[0].get("cmd") != "M":
+            results.append(_diag(si, ei, "freeform-no-moveTo",
+                                 "freeform path must start with 'M' (moveTo) command."))
+        for pi, cmd in enumerate(path):
+            c = cmd.get("cmd")
+            if c and c not in _FREEFORM_CMDS:
+                results.append(_diag(
+                    si, ei, "freeform-invalid-cmd",
+                    f"freeform path[{pi}] cmd '{c}' is not valid. Allowed: {sorted(_FREEFORM_CMDS)}"))
+
+    results.extend(_lint_bbox_required(si, ei, elem, "freeform"))
+    return results
+
+
+# ===================================================================
+# include
+# ===================================================================
+
+def _lint_include(si: int, ei: int, elem: dict) -> list[dict]:
+    if "src" not in elem:
+        return [_diag(si, ei, "include-missing-src",
+                       "include element requires 'src'.")]
     return []
 
 
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
+# ===================================================================
+# video
+# ===================================================================
 
-_CHECKERS = {
+def _lint_video(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    if "src" not in elem:
+        results.append(_diag(si, ei, "video-missing-src",
+                             "video element requires 'src'."))
+    results.extend(_lint_bbox_required(si, ei, elem, "video"))
+    return results
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+def _lint_bbox_required(si: int, ei: int, elem: dict, etype: str) -> list[dict]:
+    results: list[dict] = []
+    for k in ("x", "y"):
+        if k not in elem:
+            results.append(_diag(si, ei, f"{etype}-missing-{k}",
+                                 f"{etype} element missing '{k}'."))
+    return results
+
+
+# ===================================================================
+# Registry
+# ===================================================================
+
+_TYPE_CHECKERS = {
     "line": _lint_line,
     "shape": _lint_shape,
     "textbox": _lint_textbox,
     "image": _lint_image,
+    "chart": _lint_chart,
+    "table": _lint_table,
+    "freeform": _lint_freeform,
+    "include": _lint_include,
+    "video": _lint_video,
 }

--- a/skill/sdpm/schema/lint.py
+++ b/skill/sdpm/schema/lint.py
@@ -1,0 +1,214 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Slide JSON linter — validates elements against slide-json-spec.md."""
+
+from __future__ import annotations
+
+
+def lint(data: list | dict) -> list[dict]:
+    """Lint slide JSON and return diagnostics.
+
+    Args:
+        data: Slide list or presentation dict with "slides" key.
+
+    Returns:
+        List of diagnostic dicts with slide, element, rule, message.
+        Empty list means no issues found.
+    """
+    slides = data.get("slides", data) if isinstance(data, dict) else data
+    if not isinstance(slides, list):
+        return []
+    diagnostics: list[dict] = []
+    for si, slide in enumerate(slides):
+        for ei, elem in enumerate(slide.get("elements") or []):
+            diagnostics.extend(_lint_element(si, ei, elem))
+    return diagnostics
+
+
+def _diag(slide: int, element: int, rule: str, message: str) -> dict:
+    return {"slide": slide, "element": element, "rule": rule, "message": message}
+
+
+# ---------------------------------------------------------------------------
+# Per-element-type linting
+# ---------------------------------------------------------------------------
+
+def _lint_element(si: int, ei: int, elem: dict) -> list[dict]:
+    etype = elem.get("type")
+    if etype is None:
+        return [_diag(si, ei, "missing-type", "element has no 'type' field")]
+    results: list[dict] = []
+    checker = _CHECKERS.get(etype)
+    if checker:
+        results.extend(checker(si, ei, elem))
+    return results
+
+
+# --- line ---
+
+# Keys valid for line elements per slide-json-spec.md
+_LINE_COORD_KEYS = {"x1", "y1", "x2", "y2"}
+_LINE_POLYLINE_KEYS = {"points"}
+_LINE_STYLE_KEYS = {
+    "color", "lineWidth", "dashStyle", "connectorType", "elbowStart",
+    "preset", "adjustments", "arrowStart", "arrowEnd", "lineGradient",
+    "opacity",
+}
+_LINE_META_KEYS = {"type", "_comment"}
+_LINE_ALL_KEYS = _LINE_COORD_KEYS | _LINE_POLYLINE_KEYS | _LINE_STYLE_KEYS | _LINE_META_KEYS
+
+# Keys that belong to bbox-positioned elements (shape/textbox/image), not line
+_BBOX_KEYS = {"x", "y", "width", "height"}
+
+_ARROW_VALUES = {"arrow", "triangle", "stealth", "oval", "diamond", "none"}
+_DASH_VALUES = {"solid", "dash", "dot", "dash_dot", "long_dash", "square_dot",
+                "dash_dot_dot", "long_dash_dot"}
+_CONNECTOR_VALUES = {"straight", "elbow", "curved"}
+
+
+def _lint_line(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    has_points = "points" in elem
+    has_x1 = "x1" in elem
+    has_bbox = bool(_BBOX_KEYS & elem.keys())
+
+    # Core coordinate check
+    if not has_points and not has_x1:
+        if has_bbox:
+            bbox_found = sorted(_BBOX_KEYS & elem.keys())
+            results.append(_diag(
+                si, ei, "line-bbox-keys",
+                f"line element uses {bbox_found} instead of x1/y1/x2/y2. "
+                f"line requires x1/y1 (start) and x2/y2 (end), or points for polyline."
+            ))
+        else:
+            results.append(_diag(
+                si, ei, "line-missing-coords",
+                "line element has no coordinates. Use x1/y1/x2/y2 or points."
+            ))
+
+    if has_x1 and not has_points:
+        for k in ("x1", "y1", "x2", "y2"):
+            if k not in elem:
+                results.append(_diag(
+                    si, ei, "line-missing-coord",
+                    f"line element missing '{k}'. All of x1/y1/x2/y2 are required."
+                ))
+
+    # Polyline validation
+    if has_points:
+        pts = elem["points"]
+        if not isinstance(pts, list) or len(pts) < 2:
+            results.append(_diag(
+                si, ei, "line-points-invalid",
+                "line points must be an array of 2+ coordinate pairs."
+            ))
+
+    # Enum checks
+    for key, allowed in (
+        ("arrowStart", _ARROW_VALUES),
+        ("arrowEnd", _ARROW_VALUES),
+        ("dashStyle", _DASH_VALUES),
+        ("connectorType", _CONNECTOR_VALUES),
+    ):
+        val = elem.get(key)
+        if val is not None and val not in allowed:
+            results.append(_diag(
+                si, ei, f"line-invalid-{key}",
+                f"line '{key}' value '{val}' is not valid. Allowed: {sorted(allowed)}"
+            ))
+
+    return results
+
+
+# --- shape ---
+
+_SHAPE_NAMES = {
+    "rectangle", "rounded_rectangle", "oval", "circle",
+    "arrow_right", "arrow_left", "arrow_up", "arrow_down",
+    "arrow_circular", "arrow_left_right", "arrow_up_down",
+    "arrow_curved_right", "arrow_curved_left", "arrow_curved_up", "arrow_curved_down",
+    "arrow_circular_left", "arrow_circular_left_right",
+    "triangle", "diamond", "pentagon", "hexagon", "cross",
+    "trapezoid", "parallelogram", "chevron", "donut", "arc", "block_arc",
+    "chord", "pie", "pie_wedge", "cloud", "lightning_bolt", "star_5_point",
+    "no_symbol",
+    "callout_rectangle", "callout_rounded_rectangle", "callout_oval",
+    "flowchart_process", "flowchart_decision", "flowchart_terminator",
+    "left_brace", "right_brace", "left_bracket", "right_bracket",
+}
+
+
+def _lint_shape(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    shape = elem.get("shape")
+    if shape is not None and shape not in _SHAPE_NAMES:
+        results.append(_diag(
+            si, ei, "shape-unknown-name",
+            f"shape name '{shape}' is not recognized."
+        ))
+    results.extend(_lint_bbox(si, ei, elem, "shape"))
+    results.extend(_lint_opacity(si, ei, elem))
+    return results
+
+
+# --- textbox ---
+
+def _lint_textbox(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    if "height" not in elem:
+        results.append(_diag(
+            si, ei, "textbox-missing-height",
+            "textbox requires 'height'. Text overflow cannot be detected without it."
+        ))
+    results.extend(_lint_opacity(si, ei, elem))
+    return results
+
+
+# --- image ---
+
+def _lint_image(si: int, ei: int, elem: dict) -> list[dict]:
+    results: list[dict] = []
+    if "src" not in elem:
+        results.append(_diag(
+            si, ei, "image-missing-src",
+            "image element requires 'src'."
+        ))
+    results.extend(_lint_bbox(si, ei, elem, "image"))
+    results.extend(_lint_opacity(si, ei, elem))
+    return results
+
+
+# --- common helpers ---
+
+def _lint_bbox(si: int, ei: int, elem: dict, etype: str) -> list[dict]:
+    results: list[dict] = []
+    for k in ("x", "y"):
+        if k not in elem:
+            results.append(_diag(
+                si, ei, f"{etype}-missing-{k}",
+                f"{etype} element missing '{k}'."
+            ))
+    return results
+
+
+def _lint_opacity(si: int, ei: int, elem: dict) -> list[dict]:
+    val = elem.get("opacity")
+    if val is not None and (not isinstance(val, (int, float)) or val < 0 or val > 1):
+        return [_diag(
+            si, ei, "invalid-opacity",
+            f"opacity {val} is out of range. Must be 0–1."
+        )]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_CHECKERS = {
+    "line": _lint_line,
+    "shape": _lint_shape,
+    "textbox": _lint_textbox,
+    "image": _lint_image,
+}

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,163 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for sdpm.schema.lint."""
+
+import pytest
+from sdpm.schema.lint import lint
+
+
+class TestLintLine:
+    """Line element linting."""
+
+    def test_valid_line(self):
+        slides = [{"elements": [
+            {"type": "line", "x1": 80, "y1": 350, "x2": 700, "y2": 350}
+        ]}]
+        assert lint(slides) == []
+
+    def test_valid_polyline(self):
+        slides = [{"elements": [
+            {"type": "line", "points": [[100, 200], [300, 400]], "arrowEnd": "triangle"}
+        ]}]
+        assert lint(slides) == []
+
+    def test_bbox_keys_instead_of_x1y1(self):
+        slides = [{"elements": [
+            {"type": "line", "x": 80, "y": 350, "x2": 700, "y2": 350}
+        ]}]
+        diags = lint(slides)
+        assert len(diags) == 1
+        assert diags[0]["rule"] == "line-bbox-keys"
+        assert "x1/y1" in diags[0]["message"]
+
+    def test_missing_coords(self):
+        slides = [{"elements": [
+            {"type": "line", "color": "#FF0000"}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-missing-coords" for d in diags)
+
+    def test_partial_coords(self):
+        slides = [{"elements": [
+            {"type": "line", "x1": 80, "y1": 350}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-missing-coord" and "x2" in d["message"] for d in diags)
+
+    def test_invalid_arrow(self):
+        slides = [{"elements": [
+            {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "arrowEnd": "bad"}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-invalid-arrowEnd" for d in diags)
+
+    def test_invalid_dash(self):
+        slides = [{"elements": [
+            {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "dashStyle": "dotdot"}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-invalid-dashStyle" for d in diags)
+
+    def test_invalid_connector(self):
+        slides = [{"elements": [
+            {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "connectorType": "zigzag"}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-invalid-connectorType" for d in diags)
+
+    def test_points_too_few(self):
+        slides = [{"elements": [
+            {"type": "line", "points": [[100, 200]]}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "line-points-invalid" for d in diags)
+
+
+class TestLintShape:
+    """Shape element linting."""
+
+    def test_valid_shape(self):
+        slides = [{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "width": 100, "height": 50}
+        ]}]
+        assert lint(slides) == []
+
+    def test_unknown_shape(self):
+        slides = [{"elements": [
+            {"type": "shape", "shape": "banana", "x": 0, "y": 0}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "shape-unknown-name" for d in diags)
+
+    def test_missing_position(self):
+        slides = [{"elements": [
+            {"type": "shape", "shape": "rectangle", "width": 100}
+        ]}]
+        diags = lint(slides)
+        assert any("missing 'x'" in d["message"] for d in diags)
+
+
+class TestLintTextbox:
+    """Textbox element linting."""
+
+    def test_missing_height(self):
+        slides = [{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "text": "hi"}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "textbox-missing-height" for d in diags)
+
+    def test_valid_textbox(self):
+        slides = [{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "text": "hi"}
+        ]}]
+        assert lint(slides) == []
+
+
+class TestLintImage:
+    """Image element linting."""
+
+    def test_missing_src(self):
+        slides = [{"elements": [
+            {"type": "image", "x": 0, "y": 0, "width": 100}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "image-missing-src" for d in diags)
+
+
+class TestLintCommon:
+    """Common checks."""
+
+    def test_missing_type(self):
+        slides = [{"elements": [{"x": 0, "y": 0}]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "missing-type" for d in diags)
+
+    def test_invalid_opacity(self):
+        slides = [{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "opacity": 1.5}
+        ]}]
+        diags = lint(slides)
+        assert any(d["rule"] == "invalid-opacity" for d in diags)
+
+    def test_presentation_dict_format(self):
+        """lint accepts presentation dict with 'slides' key."""
+        data = {"slides": [{"elements": [
+            {"type": "line", "x": 80, "y": 350, "x2": 700, "y2": 350}
+        ]}]}
+        diags = lint(data)
+        assert len(diags) == 1
+        assert diags[0]["rule"] == "line-bbox-keys"
+
+    def test_multiple_slides(self):
+        slides = [
+            {"elements": [{"type": "line", "x1": 0, "y1": 0, "x2": 10, "y2": 10}]},
+            {"elements": [{"type": "line", "x": 0, "y": 0, "x2": 10, "y2": 10}]},
+        ]
+        diags = lint(slides)
+        assert len(diags) == 1
+        assert diags[0]["slide"] == 1
+
+    def test_empty_slides(self):
+        assert lint([]) == []
+        assert lint({"slides": []}) == []

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,162 +2,393 @@
 # SPDX-License-Identifier: MIT-0
 """Tests for sdpm.schema.lint."""
 
-import pytest
 from sdpm.schema.lint import lint
 
 
-class TestLintLine:
-    """Line element linting."""
+# ===================================================================
+# line
+# ===================================================================
 
+class TestLintLine:
     def test_valid_line(self):
-        slides = [{"elements": [
+        assert lint([{"elements": [
             {"type": "line", "x1": 80, "y1": 350, "x2": 700, "y2": 350}
-        ]}]
-        assert lint(slides) == []
+        ]}]) == []
 
     def test_valid_polyline(self):
-        slides = [{"elements": [
+        assert lint([{"elements": [
             {"type": "line", "points": [[100, 200], [300, 400]], "arrowEnd": "triangle"}
-        ]}]
-        assert lint(slides) == []
+        ]}]) == []
 
-    def test_bbox_keys_instead_of_x1y1(self):
-        slides = [{"elements": [
+    def test_bbox_keys(self):
+        diags = lint([{"elements": [
             {"type": "line", "x": 80, "y": 350, "x2": 700, "y2": 350}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert len(diags) == 1
         assert diags[0]["rule"] == "line-bbox-keys"
-        assert "x1/y1" in diags[0]["message"]
 
     def test_missing_coords(self):
-        slides = [{"elements": [
-            {"type": "line", "color": "#FF0000"}
-        ]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"type": "line", "color": "#FF0000"}]}])
         assert any(d["rule"] == "line-missing-coords" for d in diags)
 
     def test_partial_coords(self):
-        slides = [{"elements": [
-            {"type": "line", "x1": 80, "y1": 350}
-        ]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"type": "line", "x1": 80, "y1": 350}]}])
         assert any(d["rule"] == "line-missing-coord" and "x2" in d["message"] for d in diags)
 
     def test_invalid_arrow(self):
-        slides = [{"elements": [
+        diags = lint([{"elements": [
             {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "arrowEnd": "bad"}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "line-invalid-arrowEnd" for d in diags)
 
     def test_invalid_dash(self):
-        slides = [{"elements": [
+        diags = lint([{"elements": [
             {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "dashStyle": "dotdot"}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "line-invalid-dashStyle" for d in diags)
 
     def test_invalid_connector(self):
-        slides = [{"elements": [
+        diags = lint([{"elements": [
             {"type": "line", "x1": 0, "y1": 0, "x2": 100, "y2": 100, "connectorType": "zigzag"}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "line-invalid-connectorType" for d in diags)
 
     def test_points_too_few(self):
-        slides = [{"elements": [
-            {"type": "line", "points": [[100, 200]]}
-        ]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"type": "line", "points": [[100, 200]]}]}])
         assert any(d["rule"] == "line-points-invalid" for d in diags)
 
 
+# ===================================================================
+# shape
+# ===================================================================
+
 class TestLintShape:
-    """Shape element linting."""
-
-    def test_valid_shape(self):
-        slides = [{"elements": [
+    def test_valid(self):
+        assert lint([{"elements": [
             {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "width": 100, "height": 50}
-        ]}]
-        assert lint(slides) == []
+        ]}]) == []
 
-    def test_unknown_shape(self):
-        slides = [{"elements": [
+    def test_unknown_name(self):
+        diags = lint([{"elements": [
             {"type": "shape", "shape": "banana", "x": 0, "y": 0}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "shape-unknown-name" for d in diags)
 
     def test_missing_position(self):
-        slides = [{"elements": [
-            {"type": "shape", "shape": "rectangle", "width": 100}
-        ]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"type": "shape", "shape": "rectangle", "width": 100}]}])
         assert any("missing 'x'" in d["message"] for d in diags)
 
 
-class TestLintTextbox:
-    """Textbox element linting."""
+# ===================================================================
+# textbox
+# ===================================================================
 
+class TestLintTextbox:
     def test_missing_height(self):
-        slides = [{"elements": [
+        diags = lint([{"elements": [
             {"type": "textbox", "x": 0, "y": 0, "width": 100, "text": "hi"}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "textbox-missing-height" for d in diags)
 
-    def test_valid_textbox(self):
-        slides = [{"elements": [
+    def test_valid(self):
+        assert lint([{"elements": [
             {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "text": "hi"}
-        ]}]
-        assert lint(slides) == []
+        ]}]) == []
 
+
+# ===================================================================
+# image
+# ===================================================================
 
 class TestLintImage:
-    """Image element linting."""
-
     def test_missing_src(self):
-        slides = [{"elements": [
-            {"type": "image", "x": 0, "y": 0, "width": 100}
-        ]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"type": "image", "x": 0, "y": 0, "width": 100}]}])
         assert any(d["rule"] == "image-missing-src" for d in diags)
 
+    def test_valid(self):
+        assert lint([{"elements": [
+            {"type": "image", "src": "assets:aws/Lambda_48", "x": 0, "y": 0, "width": 100}
+        ]}]) == []
+
+
+# ===================================================================
+# chart
+# ===================================================================
+
+class TestLintChart:
+    def _base(self, **overrides):
+        elem = {
+            "type": "chart", "chartType": "bar", "x": 0, "y": 0,
+            "width": 800, "height": 400,
+            "categories": ["A", "B"], "series": [{"name": "S1", "values": [1, 2]}],
+        }
+        elem.update(overrides)
+        return [{"elements": [elem]}]
+
+    def test_valid(self):
+        assert lint(self._base()) == []
+
+    def test_missing_chartType(self):
+        slides = self._base()
+        del slides[0]["elements"][0]["chartType"]
+        diags = lint(slides)
+        assert any(d["rule"] == "chart-missing-chartType" for d in diags)
+
+    def test_invalid_chartType(self):
+        diags = lint(self._base(chartType="scatter"))
+        assert any(d["rule"] == "chart-invalid-chartType" for d in diags)
+
+    def test_missing_series(self):
+        diags = lint(self._base(series=[]))
+        assert any(d["rule"] == "chart-missing-series" for d in diags)
+
+    def test_series_values_mismatch(self):
+        diags = lint(self._base(
+            categories=["A", "B", "C"],
+            series=[{"name": "S1", "values": [1, 2]}],
+        ))
+        assert any(d["rule"] == "chart-series-values-mismatch" for d in diags)
+
+    def test_holeSize_wrong_type(self):
+        diags = lint(self._base(chartType="bar", holeSize=50))
+        assert any(d["rule"] == "chart-holeSize-wrong-type" for d in diags)
+
+    def test_holeSize_donut_ok(self):
+        diags = lint(self._base(chartType="donut", holeSize=50))
+        assert not any(d["rule"] == "chart-holeSize-wrong-type" for d in diags)
+
+    def test_stacked_wrong_type(self):
+        diags = lint(self._base(chartType="pie", stacked=True))
+        assert any(d["rule"] == "chart-stacked-wrong-type" for d in diags)
+
+    def test_stacked_bar_ok(self):
+        diags = lint(self._base(chartType="bar", stacked=True))
+        assert not any(d["rule"] == "chart-stacked-wrong-type" for d in diags)
+
+
+# ===================================================================
+# table
+# ===================================================================
+
+class TestLintTable:
+    def _base(self, **overrides):
+        elem = {
+            "type": "table", "x": 0, "y": 0, "width": 800, "height": 200,
+            "headers": ["A", "B", "C"],
+            "rows": [["1", "2", "3"], ["4", "5", "6"]],
+        }
+        elem.update(overrides)
+        return [{"elements": [elem]}]
+
+    def test_valid(self):
+        assert lint(self._base()) == []
+
+    def test_missing_headers(self):
+        slides = self._base()
+        del slides[0]["elements"][0]["headers"]
+        diags = lint(slides)
+        assert any(d["rule"] == "table-missing-headers" for d in diags)
+
+    def test_missing_rows(self):
+        slides = self._base()
+        del slides[0]["elements"][0]["rows"]
+        diags = lint(slides)
+        assert any(d["rule"] == "table-missing-rows" for d in diags)
+
+    def test_colWidths_mismatch(self):
+        diags = lint(self._base(colWidths=[100, 200]))
+        assert any(d["rule"] == "table-column-count-mismatch" for d in diags)
+
+    def test_row_column_mismatch(self):
+        diags = lint(self._base(rows=[["1", "2"]]))
+        assert any(d["rule"] == "table-column-count-mismatch" for d in diags)
+
+
+# ===================================================================
+# freeform
+# ===================================================================
+
+class TestLintFreeform:
+    def test_valid(self):
+        assert lint([{"elements": [
+            {"type": "freeform", "x": 0, "y": 0, "width": 100, "height": 100,
+             "path": [{"cmd": "M", "x": 0, "y": 0}, {"cmd": "L", "x": 100, "y": 100}]}
+        ]}]) == []
+
+    def test_missing_path(self):
+        diags = lint([{"elements": [
+            {"type": "freeform", "x": 0, "y": 0, "width": 100, "height": 100}
+        ]}])
+        assert any(d["rule"] == "freeform-missing-path" for d in diags)
+
+    def test_no_moveTo(self):
+        diags = lint([{"elements": [
+            {"type": "freeform", "x": 0, "y": 0, "width": 100, "height": 100,
+             "path": [{"cmd": "L", "x": 100, "y": 100}]}
+        ]}])
+        assert any(d["rule"] == "freeform-no-moveTo" for d in diags)
+
+    def test_invalid_cmd(self):
+        diags = lint([{"elements": [
+            {"type": "freeform", "x": 0, "y": 0, "width": 100, "height": 100,
+             "path": [{"cmd": "M", "x": 0, "y": 0}, {"cmd": "X", "x": 50, "y": 50}]}
+        ]}])
+        assert any(d["rule"] == "freeform-invalid-cmd" for d in diags)
+
+    def test_customGeometry_ok(self):
+        diags = lint([{"elements": [
+            {"type": "freeform", "x": 0, "y": 0, "width": 100, "height": 100,
+             "customGeometry": "<xml/>"}
+        ]}])
+        assert not any(d["rule"] == "freeform-missing-path" for d in diags)
+
+
+# ===================================================================
+# include
+# ===================================================================
+
+class TestLintInclude:
+    def test_valid(self):
+        assert lint([{"elements": [{"type": "include", "src": "arch.json"}]}]) == []
+
+    def test_missing_src(self):
+        diags = lint([{"elements": [{"type": "include"}]}])
+        assert any(d["rule"] == "include-missing-src" for d in diags)
+
+
+# ===================================================================
+# video
+# ===================================================================
+
+class TestLintVideo:
+    def test_valid(self):
+        assert lint([{"elements": [
+            {"type": "video", "src": "demo.mp4", "x": 0, "y": 0, "width": 800, "height": 450}
+        ]}]) == []
+
+    def test_missing_src(self):
+        diags = lint([{"elements": [
+            {"type": "video", "x": 0, "y": 0, "width": 800, "height": 450}
+        ]}])
+        assert any(d["rule"] == "video-missing-src" for d in diags)
+
+
+# ===================================================================
+# Common checks
+# ===================================================================
 
 class TestLintCommon:
-    """Common checks."""
-
     def test_missing_type(self):
-        slides = [{"elements": [{"x": 0, "y": 0}]}]
-        diags = lint(slides)
+        diags = lint([{"elements": [{"x": 0, "y": 0}]}])
         assert any(d["rule"] == "missing-type" for d in diags)
 
     def test_invalid_opacity(self):
-        slides = [{"elements": [
+        diags = lint([{"elements": [
             {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "opacity": 1.5}
-        ]}]
-        diags = lint(slides)
+        ]}])
         assert any(d["rule"] == "invalid-opacity" for d in diags)
 
-    def test_presentation_dict_format(self):
-        """lint accepts presentation dict with 'slides' key."""
-        data = {"slides": [{"elements": [
+    def test_valid_opacity(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "opacity": 0.5}
+        ]}])
+        assert not any(d["rule"] == "invalid-opacity" for d in diags)
+
+    # fontSize
+    def test_fontSize_integer_ok(self):
+        assert lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "fontSize": 14}
+        ]}]) == []
+
+    def test_fontSize_10_5_ok(self):
+        assert lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "fontSize": 10.5}
+        ]}]) == []
+
+    def test_fontSize_non_integer_float(self):
+        diags = lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "fontSize": 11.5}
+        ]}])
+        assert any(d["rule"] == "invalid-fontSize" for d in diags)
+
+    def test_fontSize_zero(self):
+        diags = lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "fontSize": 0}
+        ]}])
+        assert any(d["rule"] == "invalid-fontSize" for d in diags)
+
+    def test_fontSize_negative(self):
+        diags = lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "fontSize": -12}
+        ]}])
+        assert any(d["rule"] == "invalid-fontSize" for d in diags)
+
+    # color
+    def test_invalid_color_short(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "fill": "#FFF"}
+        ]}])
+        assert any(d["rule"] == "invalid-color" for d in diags)
+
+    def test_valid_color(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "fill": "#FF9900"}
+        ]}])
+        assert not any(d["rule"] == "invalid-color" for d in diags)
+
+    def test_color_none_ok(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "fill": "none"}
+        ]}])
+        assert not any(d["rule"] == "invalid-color" for d in diags)
+
+    # align
+    def test_invalid_align(self):
+        diags = lint([{"elements": [
+            {"type": "textbox", "x": 0, "y": 0, "width": 100, "height": 40, "align": "justify"}
+        ]}])
+        assert any(d["rule"] == "invalid-align" for d in diags)
+
+    def test_invalid_verticalAlign(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "verticalAlign": "center"}
+        ]}])
+        assert any(d["rule"] == "invalid-verticalAlign" for d in diags)
+
+    # out-of-bounds
+    def test_out_of_bounds_x(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 1800, "y": 0, "width": 200, "height": 50}
+        ]}])
+        assert any(d["rule"] == "out-of-bounds" for d in diags)
+
+    def test_out_of_bounds_y(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 1000, "width": 100, "height": 100}
+        ]}])
+        assert any(d["rule"] == "out-of-bounds" for d in diags)
+
+    def test_within_bounds(self):
+        diags = lint([{"elements": [
+            {"type": "shape", "shape": "rectangle", "x": 0, "y": 0, "width": 1920, "height": 1080}
+        ]}])
+        assert not any(d["rule"] == "out-of-bounds" for d in diags)
+
+    # presentation dict format
+    def test_presentation_dict(self):
+        diags = lint({"slides": [{"elements": [
             {"type": "line", "x": 80, "y": 350, "x2": 700, "y2": 350}
-        ]}]}
-        diags = lint(data)
-        assert len(diags) == 1
-        assert diags[0]["rule"] == "line-bbox-keys"
+        ]}]})
+        assert any(d["rule"] == "line-bbox-keys" for d in diags)
 
     def test_multiple_slides(self):
-        slides = [
+        diags = lint([
             {"elements": [{"type": "line", "x1": 0, "y1": 0, "x2": 10, "y2": 10}]},
             {"elements": [{"type": "line", "x": 0, "y": 0, "x2": 10, "y2": 10}]},
-        ]
-        diags = lint(slides)
-        assert len(diags) == 1
+        ])
+        assert len([d for d in diags if d["rule"] == "line-bbox-keys"]) == 1
         assert diags[0]["slide"] == 1
 
-    def test_empty_slides(self):
+    def test_empty(self):
         assert lint([]) == []
         assert lint({"slides": []}) == []


### PR DESCRIPTION
## Summary

Add a rule-based linter (`sdpm.schema.lint`) that validates slide JSON elements against `slide-json-spec.md` before PPTX generation. Diagnostics are returned in the `errors.lintDiagnostics` field of the generate response, enabling agents to fix issues and re-generate.

## Background

When generating PPTX via the Web UI (Layer 4), the agent produced slide JSON with `line` elements using `x`/`y` instead of the spec-required `x1`/`y1`:

```json
// Agent generated (incorrect)
{"type": "line", "x": 80, "y": 350, "x2": 700, "y2": 350}

// Spec requires
{"type": "line", "x1": 80, "y1": 350, "x2": 700, "y2": 350}
```

The builder's `_add_line` looks up `x1`/`y1` only, so `x`/`y` was ignored and the default value `10` was used for the start point. This caused every line to be drawn from near the origin (10,10) to the correct endpoint — resulting in garbage diagonal lines across every slide.

The issue was not caught because:
- `amazon-jassy-2025-letter.json` used `x`/`y`/`width`/`height` format (no `x2`/`y2` either), so both start and end fell back to defaults, producing tiny invisible lines
- `s3-files-deep-dive.json` used `x`/`y`/`x2`/`y2`, so only the start point was wrong — producing visible broken lines from origin to the correct endpoint

## Design Decisions

### Why not auto-fix?

The initial approach was to add a fallback in `_add_line` (`elem.get("x1", elem.get("x", 10))`). This was reverted because:

1. **Ambiguous intent**: When a line element has `x`/`y`, the linter cannot determine whether the author meant `x1`/`y1` (start point) or `x`/`y`/`width`/`height` (bounding box). Auto-fixing could silently produce wrong results.
2. **Agent learning**: By returning errors to the agent, it can fix the JSON with full context and avoid repeating the mistake.

### Why errors, not warnings?

Lines with wrong coordinate keys will render incorrectly (start point at origin). This is not a cosmetic issue — it produces visually broken output. The `errors` field (parallel to existing `warnings`) signals that the agent must fix and re-generate.

### Why lint inside generate, not as a separate MCP tool?

Existing MCP tools follow a pattern where `generate_pptx` is a thin wrapper around `sdpm.api.generate`. Adding a separate `lint_slides` tool would break this granularity. Instead, lint runs as a pre-build step inside `generate`, and diagnostics are returned in the existing response structure. No MCP interface changes needed.

### Integration points

```
Layer 1 CLI:  sdpm.api.generate → (lint) → build → return {errors, warnings, ...}
Layer 2 MCP:  generate_pptx → tools.generate_pptx → sdpm.api.generate → (lint)
Layer 3 MCP:  generate_pptx → tools/generate.py → (lint) → builder
Layer 4 Web:  Agent calls generate_pptx → receives errors → fixes JSON → re-generates
```

Layer 3 (`mcp-server/tools/generate.py`) uses the builder directly rather than `sdpm.api.generate`, so lint is called separately there.

## Rules Implemented

| Rule | Element | Description |
|---|---|---|
| `line-bbox-keys` | line | Uses `x`/`y`/`width`/`height` instead of `x1`/`y1`/`x2`/`y2` |
| `line-missing-coords` | line | No coordinates at all |
| `line-missing-coord` | line | Partial `x1`/`y1`/`x2`/`y2` |
| `line-points-invalid` | line | Polyline `points` array invalid |
| `line-invalid-*` | line | Invalid enum values for `arrowEnd`, `dashStyle`, `connectorType` |
| `shape-unknown-name` | shape | Unrecognized shape name |
| `shape-missing-x/y` | shape | Missing position |
| `textbox-missing-height` | textbox | Missing required `height` |
| `image-missing-src` | image | Missing `src` |
| `missing-type` | all | Missing `type` field |
| `invalid-opacity` | all | `opacity` outside 0–1 range |

## Validation

Tested against the two real-world JSONs that triggered this investigation:

- `s3-files-deep-dive.json`: 50 diagnostics (all `line-bbox-keys` — `x`/`y` + `x2`/`y2`)
- `amazon-jassy-2025-letter.json`: 29 diagnostics (all `line-bbox-keys` — `x`/`y`/`width`/`height`)

## Response Format

```json
{
  "output_path": "...",
  "slide_count": 20,
  "warnings": [...],
  "errors": {
    "lintDiagnostics": [
      {"slide": 1, "element": 2, "rule": "line-bbox-keys",
       "message": "line element uses ['x', 'y'] instead of x1/y1/x2/y2. ..."}
    ]
  }
}
```

## Files Changed

- **New**: `skill/sdpm/schema/lint.py` — linter core (rules + registry)
- **New**: `tests/test_lint.py` — 20 test cases
- **Modified**: `skill/sdpm/api.py` — call lint in `generate`, add `errors` to return
- **Modified**: `mcp-server/tools/generate.py` — call lint before build, add `errors` to return

## TODO (follow-up)

- [ ] Add lint guidance to MCP server `_INSTRUCTIONS` so agents know to check `errors` and re-generate
- [x] Add more rules as spec violations are discovered (chart, table, freeform, etc.)
- [ ] Consider CLI `lint` subcommand for standalone validation