### PR TITLE
feat: CloudFront preview delivery with signed cookies + ETag revalidation

### DIFF
--- a/PENDING_ITEMS.md
+++ b/PENDING_ITEMS.md
@@ -1,0 +1,22 @@
+# CloudFront Preview Delivery — 保留事項
+
+## PR
+- https://github.com/aws-samples/sample-spec-driven-presentation-maker/pull/42
+
+## 解消済み
+- ~~PR #40との統合~~ → rebase完了、マージ済み
+- ~~PPTX/JSONダウンロードのS3 presigned URL~~ → CF署名付きURLに移行
+
+## 残保留事項
+
+### 1. head_objectコールの最適化
+署名付きURLでもhead_objectは残る（webp/png存在確認用）。
+将来的にはDynamoDBにプレビューS3キーを記録し、head_objectを省略可能。
+
+### 2. openssl依存
+署名にLambda環境のopensslコマンドを使用。Lambda Python 3.13ランタイムには
+opensslが含まれているが、カスタムランタイムでは注意が必要。
+
+### 3. アップロード画像のpresigned URL
+`uploads/tmp/`配下の画像プレビューはS3 presigned URLのまま。
+アップロードは一時的なデータなのでCF化の優先度は低い。

--- a/api/index.py
+++ b/api/index.py
@@ -42,6 +42,9 @@ KB_ID = os.environ.get("KB_ID", "")
 VECTOR_BUCKET_NAME = os.environ.get("VECTOR_BUCKET_NAME", "")
 VECTOR_INDEX_NAME = os.environ.get("VECTOR_INDEX_NAME", "")
 RESOURCE_BUCKET = os.environ.get("RESOURCE_BUCKET", "")
+CF_DOMAIN = os.environ.get("CF_DOMAIN", "")
+CF_KEY_PAIR_ID = os.environ.get("CF_KEY_PAIR_ID", "")
+CF_PRIVATE_KEY_PARAM = os.environ.get("CF_PRIVATE_KEY_PARAM", "")
 
 # Module-level cache for styles (references are static, deployed once).
 _styles_cache: Optional[List[Dict[str, str]]] = None
@@ -56,6 +59,37 @@ if KB_ID.startswith("/"):
 
 PRESIGNED_URL_EXPIRY = 900
 MAX_FILE_SIZE = 100 * 1024 * 1024
+
+# --- CloudFront preview URL helper ---
+_cf_private_key: Optional[str] = None
+
+
+def _get_cf_private_key() -> str:
+    """Load CloudFront signing private key from SSM (cached)."""
+    global _cf_private_key
+    if _cf_private_key is None:
+        ssm = boto3.client("ssm")
+        _cf_private_key = ssm.get_parameter(
+            Name=CF_PRIVATE_KEY_PARAM, WithDecryption=True,
+        )["Parameter"]["Value"]
+    return _cf_private_key
+
+
+def preview_url(s3_key: str) -> Optional[str]:
+    """Return CloudFront signed URL for a preview S3 key, or presigned S3 URL fallback."""
+    return _cf_signed_url(s3_key) or presigned_url(s3_client, BUCKET_NAME, s3_key)
+
+
+def _preview_url_for_slide(deck_id: str, slide_id: str) -> Optional[str]:
+    """Return preview URL for a slide, checking webp then png existence."""
+    for ext in ("webp", "png"):
+        s3_key = f"previews/{deck_id}/{slide_id}.{ext}"
+        try:
+            s3_client.head_object(Bucket=BUCKET_NAME, Key=s3_key)
+            return _cf_signed_url(s3_key) or presigned_url(s3_client, BUCKET_NAME, s3_key)
+        except Exception:
+            continue
+    return None
 
 cors_origins = [o.strip() for o in CORS_ALLOWED_ORIGINS.split(",") if o.strip()]
 cors_config = CORSConfig(
@@ -133,17 +167,9 @@ def _get_deck_extras(deck_items: List[Dict]) -> Dict[str, Dict]:
 
         key = deck.get("thumbnailS3Key")
         if key:
-            thumb_url = presigned_url(s3_client, BUCKET_NAME, key)
+            thumb_url = preview_url(key) or presigned_url(s3_client, BUCKET_NAME, key)
         else:
-            # Fallback: first slide preview (webp preferred, png fallback)
-            for ext in ("webp", "png"):
-                s3_key = f"previews/{deck_id}/slide_01.{ext}"
-                try:
-                    s3_client.head_object(Bucket=BUCKET_NAME, Key=s3_key)
-                    thumb_url = presigned_url(s3_client, BUCKET_NAME, s3_key)
-                    break
-                except Exception:
-                    pass
+            thumb_url = _preview_url_for_slide(deck_id, "slide_01")
 
         extras[deck_id] = {"thumbnailUrl": thumb_url}
     return extras
@@ -370,16 +396,8 @@ def get_deck(deck_id: str) -> Dict[str, Any]:
         presentation = json.loads(resp["Body"].read())
         for i, s in enumerate(presentation.get("slides", [])):
             sid = f"slide_{i + 1:02d}"
-            preview_url = None
-            for ext in ("webp", "png"):
-                preview_key = f"previews/{deck_id}/{sid}.{ext}"
-                try:
-                    s3_client.head_object(Bucket=BUCKET_NAME, Key=preview_key)
-                    preview_url = presigned_url(s3_client, BUCKET_NAME, preview_key)
-                    break
-                except Exception:
-                    pass
-            slide_entry: Dict[str, Any] = {"slideId": sid, "previewUrl": preview_url}
+            slide_preview = _preview_url_for_slide(deck_id, sid)
+            slide_entry: Dict[str, Any] = {"slideId": sid, "previewUrl": slide_preview}
             if include_json:
                 slide_entry["slideJson"] = json.dumps(s)
             slides.append(slide_entry)
@@ -419,7 +437,7 @@ def get_deck(deck_id: str) -> Dict[str, Any]:
         "slideCount": len(slides),
         "slides": slides,
         "specs": specs,
-        "pptxUrl": presigned_url(s3_client, BUCKET_NAME, pptx_key) if pptx_key else None,
+        "pptxUrl": (_cf_signed_url(pptx_key) or presigned_url(s3_client, BUCKET_NAME, pptx_key)) if pptx_key else None,
         "updatedAt": deck.get("updatedAt", ""),
         "chatSessionId": deck.get("chatSessionId"),
         "isOwner": decision.role == "owner",
@@ -600,17 +618,10 @@ def search_slides_api() -> Dict[str, Any]:
             continue
         seen.add(dedup_key)
 
-        # Generate preview URL — slideId matches preview filename (webp preferred)
-        preview_url = ""
+        # Generate preview URL (CloudFront or presigned fallback)
+        slide_preview_url = ""
         if deck_id and slide_id:
-            for ext in ("webp", "png"):
-                s3_key = f"previews/{deck_id}/{slide_id}.{ext}"
-                try:
-                    s3_client.head_object(Bucket=BUCKET_NAME, Key=s3_key)
-                    preview_url = presigned_url(s3_client, BUCKET_NAME, s3_key)
-                    break
-                except Exception:
-                    pass
+            slide_preview_url = _preview_url_for_slide(deck_id, slide_id) or ""
 
         results.append({
             "deckId": deck_id,
@@ -619,7 +630,7 @@ def search_slides_api() -> Dict[str, Any]:
             "pageNumber": int(meta.get("pageNumber", 0)),
             "score": r.get("score", 0),
             "excerpt": r.get("content", {}).get("text", "")[:200],
-            "previewUrl": preview_url,
+            "previewUrl": slide_preview_url,
         })
 
     return {"results": results}
@@ -732,6 +743,57 @@ def _parse_memory_payload(payload_item: Dict) -> Dict | None:
     except (json.JSONDecodeError, KeyError, TypeError, IndexError, UnicodeDecodeError):
         pass
     return None
+
+
+# ---------------------------------------------------------------------------
+# CloudFront signed URL helper
+# ---------------------------------------------------------------------------
+
+
+def _cf_signed_url(s3_key: str, expires_in: int = 900) -> Optional[str]:
+    """Generate a CloudFront signed URL for an S3 key.
+
+    Args:
+        s3_key: S3 object key (e.g. previews/deck_id/slide_01.webp).
+        expires_in: URL validity in seconds (default 15 min).
+
+    Returns:
+        Signed URL string, or None if CloudFront is not configured.
+    """
+    if not CF_DOMAIN or not CF_KEY_PAIR_ID or not CF_PRIVATE_KEY_PARAM:
+        return None
+
+    import datetime
+    import base64
+    import subprocess
+    import tempfile
+
+    private_key_pem = _get_cf_private_key()
+    expires = int((datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=expires_in)).timestamp())
+    url = f"https://{CF_DOMAIN}/{s3_key}"
+
+    policy = json.dumps({
+        "Statement": [{
+            "Resource": url,
+            "Condition": {"DateLessThan": {"AWS:EpochTime": expires}},
+        }],
+    }, separators=(",", ":"))
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as kf:
+        kf.write(private_key_pem)
+        key_path = kf.name
+    try:
+        sig_raw = subprocess.check_output(  # nosec B603 B607 — fixed args, key_path is tempfile
+            ["/usr/bin/openssl", "dgst", "-sha1", "-sign", key_path],
+            input=policy.encode(), stderr=subprocess.DEVNULL,
+        )
+    finally:
+        os.unlink(key_path)
+
+    def _b64(data: bytes) -> str:
+        return base64.b64encode(data).decode().replace("+", "-").replace("=", "_").replace("/", "~")
+
+    return f"{url}?Policy={_b64(policy.encode())}&Signature={_b64(sig_raw)}&Key-Pair-Id={CF_KEY_PAIR_ID}"
 
 
 # ---------------------------------------------------------------------------

--- a/infra/lambdas/cf-key-provisioner/index.py
+++ b/infra/lambdas/cf-key-provisioner/index.py
@@ -3,7 +3,8 @@
 import json
 import subprocess  # nosec B404 — openssl invocation with fixed args only
 import logging
-import urllib.request
+import http.client
+from urllib.parse import urlparse
 
 import boto3
 
@@ -26,10 +27,12 @@ def send(event, context, status, data=None, physical_id=None, reason=None):
         "Data": data or {},
     }).encode()
     url = event["ResponseURL"]
-    if not url.startswith("https://"):  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected
+    if not url.startswith("https://"):
         raise ValueError("ResponseURL must be HTTPS")
-    req = urllib.request.Request(url, data=body, headers={"Content-Type": ""}, method="PUT")
-    urllib.request.urlopen(req)  # nosec B310 — URL validated above  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected
+    parsed = urlparse(url)
+    conn = http.client.HTTPSConnection(parsed.hostname)
+    conn.request("PUT", f"{parsed.path}?{parsed.query}", body=body, headers={"Content-Type": ""})
+    conn.getresponse()
 
 
 def handler(event, context):

--- a/infra/lambdas/cf-key-provisioner/index.py
+++ b/infra/lambdas/cf-key-provisioner/index.py
@@ -1,0 +1,70 @@
+"""CloudFront signing key provisioner — CDK Custom Resource handler."""
+
+import json
+import subprocess  # nosec B404 — openssl invocation with fixed args only
+import logging
+import urllib.request
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ssm = boto3.client("ssm")
+
+_OPENSSL = "/usr/bin/openssl"
+
+
+def send(event, context, status, data=None, physical_id=None, reason=None):
+    body = json.dumps({
+        "Status": status,
+        "Reason": reason or f"See CloudWatch Log Stream: {context.log_stream_name}",
+        "PhysicalResourceId": physical_id or event.get("PhysicalResourceId", context.log_stream_name),
+        "StackId": event["StackId"],
+        "RequestId": event["RequestId"],
+        "LogicalResourceId": event["LogicalResourceId"],
+        "Data": data or {},
+    }).encode()
+    url = event["ResponseURL"]
+    if not url.startswith("https://"):  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected
+        raise ValueError("ResponseURL must be HTTPS")
+    req = urllib.request.Request(url, data=body, headers={"Content-Type": ""}, method="PUT")
+    urllib.request.urlopen(req)  # nosec B310 — URL validated above
+
+
+def handler(event, context):
+    logger.info("Event: %s", json.dumps(event, default=str))
+    props = event["ResourceProperties"]
+    priv_param = props["PrivateKeyParam"]
+    pub_param = props["PublicKeyParam"]
+    request_type = event["RequestType"]
+
+    try:
+        if request_type == "Create":
+            priv_pem = subprocess.check_output(  # nosec B603 B607 — fixed args, no user input
+                [_OPENSSL, "genrsa", "2048"], stderr=subprocess.DEVNULL,
+            ).decode()
+            pub_pem = subprocess.check_output(  # nosec B603 B607 — fixed args, no user input
+                [_OPENSSL, "rsa", "-pubout"], input=priv_pem.encode(), stderr=subprocess.DEVNULL,
+            ).decode()
+
+            ssm.put_parameter(Name=priv_param, Value=priv_pem, Type="SecureString", Overwrite=True)
+            ssm.put_parameter(Name=pub_param, Value=pub_pem, Type="String", Overwrite=True)
+
+            send(event, context, "SUCCESS", data={"PublicKeyPem": pub_pem}, physical_id=priv_param)
+
+        elif request_type == "Delete":
+            for name in (priv_param, pub_param):
+                try:
+                    ssm.delete_parameter(Name=name)
+                except ssm.exceptions.ParameterNotFound:
+                    pass
+            send(event, context, "SUCCESS", physical_id=priv_param)
+
+        else:  # Update
+            pub_pem = ssm.get_parameter(Name=pub_param)["Parameter"]["Value"]
+            send(event, context, "SUCCESS", data={"PublicKeyPem": pub_pem}, physical_id=priv_param)
+
+    except Exception as e:
+        logger.exception("Failed")
+        send(event, context, "FAILED", reason=str(e), physical_id=priv_param)

--- a/infra/lambdas/cf-key-provisioner/index.py
+++ b/infra/lambdas/cf-key-provisioner/index.py
@@ -29,7 +29,7 @@ def send(event, context, status, data=None, physical_id=None, reason=None):
     if not url.startswith("https://"):  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected
         raise ValueError("ResponseURL must be HTTPS")
     req = urllib.request.Request(url, data=body, headers={"Content-Type": ""}, method="PUT")
-    urllib.request.urlopen(req)  # nosec B310 — URL validated above
+    urllib.request.urlopen(req)  # nosec B310 — URL validated above  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected
 
 
 def handler(event, context):

--- a/infra/lambdas/cf-key-provisioner/index.py
+++ b/infra/lambdas/cf-key-provisioner/index.py
@@ -3,10 +3,9 @@
 import json
 import subprocess  # nosec B404 — openssl invocation with fixed args only
 import logging
-import http.client
-from urllib.parse import urlparse
 
 import boto3
+import urllib3
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -14,6 +13,9 @@ logger.setLevel(logging.INFO)
 ssm = boto3.client("ssm")
 
 _OPENSSL = "/usr/bin/openssl"
+
+# urllib3 is bundled with botocore in Lambda — no extra dependency needed.
+_http = urllib3.PoolManager()
 
 
 def send(event, context, status, data=None, physical_id=None, reason=None):
@@ -29,10 +31,7 @@ def send(event, context, status, data=None, physical_id=None, reason=None):
     url = event["ResponseURL"]
     if not url.startswith("https://"):
         raise ValueError("ResponseURL must be HTTPS")
-    parsed = urlparse(url)
-    conn = http.client.HTTPSConnection(parsed.hostname)
-    conn.request("PUT", f"{parsed.path}?{parsed.query}", body=body, headers={"Content-Type": ""})
-    conn.getresponse()
+    _http.request("PUT", url, body=body, headers={"Content-Type": ""})
 
 
 def handler(event, context):

--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -93,6 +93,22 @@ export class DataStack extends cdk.Stack {
       ],
     });
 
+    // Allow CloudFront OAC to read preview images (policy added here to avoid
+    // cross-stack dependency cycle between DataStack and WebUiStack).
+    this.pptxBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: "AllowCloudFrontOACPreview",
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal("cloudfront.amazonaws.com")],
+      actions: ["s3:GetObject"],
+      resources: [
+        `${this.pptxBucket.bucketArn}/previews/*`,
+        `${this.pptxBucket.bucketArn}/decks/*`,
+      ],
+      conditions: {
+        StringEquals: { "aws:SourceAccount": this.account },
+      },
+    }));
+
     this.resourceBucket = new s3.Bucket(this, "ResourceBucket", {
       encryption: s3.BucketEncryption.S3_MANAGED,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,

--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -103,6 +103,7 @@ export class DataStack extends cdk.Stack {
       resources: [
         `${this.pptxBucket.bucketArn}/previews/*`,
         `${this.pptxBucket.bucketArn}/decks/*`,
+        `${this.pptxBucket.bucketArn}/pptx/*`,
       ],
       conditions: {
         StringEquals: { "aws:SourceAccount": this.account },

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -187,6 +187,13 @@ function handler(event) {
       CachePolicyId: previewCachePolicy.cachePolicyId,
       TrustedKeyGroups: [keyGroup.keyGroupId],
       Compress: true,
+    }, {
+      PathPattern: "pptx/*",
+      TargetOriginId: "previewS3Origin",
+      ViewerProtocolPolicy: "redirect-to-https",
+      CachePolicyId: previewCachePolicy.cachePolicyId,
+      TrustedKeyGroups: [keyGroup.keyGroupId],
+      Compress: true,
     }]);
 
     // --- REST API Lambda ---

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -22,6 +22,7 @@ import * as cr from "aws-cdk-lib/custom-resources";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import { Construct } from "constructs";
@@ -88,6 +89,64 @@ function handler(event) {
       runtime: cloudfront.FunctionRuntime.JS_2_0,
     });
 
+    // --- CloudFront signing key for preview delivery ---
+    const cfKeyProvisioner = new lambda.Function(this, "CfKeyProvisioner", {
+      runtime: lambda.Runtime.PYTHON_3_13,
+      handler: "index.handler",
+      code: lambda.Code.fromAsset(path.join(__dirname, "..", "lambdas", "cf-key-provisioner")),
+      timeout: cdk.Duration.minutes(2),
+      logGroup: new logs.LogGroup(this, "CfKeyProvisionerLogs", {
+        retention: logs.RetentionDays.ONE_WEEK,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      }),
+    });
+    cfKeyProvisioner.addToRolePolicy(new iam.PolicyStatement({
+      actions: ["ssm:PutParameter", "ssm:GetParameter", "ssm:DeleteParameter"],
+      resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/sdpm/cf-*`],
+    }));
+
+    const keyPair = new cdk.CustomResource(this, "CfSigningKey", {
+      serviceToken: cfKeyProvisioner.functionArn,
+      properties: {
+        PrivateKeyParam: "/sdpm/cf-private-key",
+        PublicKeyParam: "/sdpm/cf-public-key",
+      },
+    });
+
+    const cfPublicKey = new cloudfront.PublicKey(this, "CfPublicKey", {
+      encodedKey: keyPair.getAttString("PublicKeyPem"),
+    });
+    const keyGroup = new cloudfront.KeyGroup(this, "CfKeyGroup", {
+      items: [cfPublicKey],
+    });
+
+    // --- Preview cache policy (max-age=5, ETag revalidation) ---
+    const previewCachePolicy = new cloudfront.CachePolicy(this, "PreviewCachePolicy", {
+      cachePolicyName: "sdpm-preview-cache",
+      defaultTtl: cdk.Duration.seconds(5),
+      maxTtl: cdk.Duration.hours(1),
+      minTtl: cdk.Duration.seconds(0),
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: true,
+    });
+
+    // --- Preview origin ---
+    // Cross-stack OAC causes dependency cycles in CDK (aws/aws-cdk#31462).
+    // Workaround: define preview origin + OAC at L1 level via escape hatch.
+    const previewOac = new cloudfront.CfnOriginAccessControl(this, "PreviewOAC", {
+      originAccessControlConfig: {
+        name: `sdpm-preview-oac-${this.stackName}`,
+        originAccessControlOriginType: "s3",
+        signingBehavior: "always",
+        signingProtocol: "sigv4",
+      },
+    });
+
+    const s3RegionalDomain = cdk.Fn.sub(
+      "${Bucket}.s3.${AWS::Region}.amazonaws.com",
+      { Bucket: props.pptxBucket.bucketName },
+    );
+
     const distribution = new cloudfront.Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: new origins.S3Origin(siteBucket, { originAccessIdentity: oai }),
@@ -105,6 +164,30 @@ function handler(event) {
     });
 
     this.siteUrl = `https://${distribution.distributionDomainName}`;
+
+    // Add preview origin + behavior at L1 to avoid cross-stack dependency cycle
+    const cfnDist = distribution.node.defaultChild as cloudfront.CfnDistribution;
+    cfnDist.addPropertyOverride("DistributionConfig.Origins.1", {
+      Id: "previewS3Origin",
+      DomainName: s3RegionalDomain,
+      S3OriginConfig: { OriginAccessIdentity: "" },
+      OriginAccessControlId: previewOac.attrId,
+    });
+    cfnDist.addPropertyOverride("DistributionConfig.CacheBehaviors", [{
+      PathPattern: "previews/*",
+      TargetOriginId: "previewS3Origin",
+      ViewerProtocolPolicy: "redirect-to-https",
+      CachePolicyId: previewCachePolicy.cachePolicyId,
+      TrustedKeyGroups: [keyGroup.keyGroupId],
+      Compress: true,
+    }, {
+      PathPattern: "decks/*/*",
+      TargetOriginId: "previewS3Origin",
+      ViewerProtocolPolicy: "redirect-to-https",
+      CachePolicyId: previewCachePolicy.cachePolicyId,
+      TrustedKeyGroups: [keyGroup.keyGroupId],
+      Compress: true,
+    }]);
 
     // --- REST API Lambda ---
     const powertoolsLayer = lambda.LayerVersion.fromLayerVersionArn(
@@ -140,12 +223,20 @@ function handler(event) {
         CORS_ALLOWED_ORIGINS: "*",
         POWERTOOLS_SERVICE_NAME: "sdpm-api",
         POWERTOOLS_METRICS_NAMESPACE: "sdpm",
+        CF_DOMAIN: distribution.distributionDomainName,
+        CF_KEY_PAIR_ID: cfPublicKey.publicKeyId,
+        CF_PRIVATE_KEY_PARAM: "/sdpm/cf-private-key",
       },
     });
     // IAM: Least-privilege — API Lambda gets scoped DynamoDB and S3 access only.
     props.table.grantReadWriteData(apiLambda);
     props.pptxBucket.grantReadWrite(apiLambda);
     props.resourceBucket.grantRead(apiLambda);
+    // SSM read for CloudFront signing key
+    apiLambda.addToRolePolicy(new iam.PolicyStatement({
+      actions: ["ssm:GetParameter"],
+      resources: [`arn:aws:ssm:${this.region}:${this.account}:parameter/sdpm/cf-private-key`],
+    }));
 
     // Amazon Bedrock AgentCore Memory read access for chat history
     if (props.memoryId) {

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -43,7 +43,6 @@
         "semver"
       ],
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.4"
@@ -146,7 +145,6 @@
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -594,8 +592,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
       "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -671,7 +668,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/png-worker/handlers/png.py
+++ b/png-worker/handlers/png.py
@@ -116,7 +116,7 @@ def handle_png(payload: dict) -> None:
         Image.open(png_path).save(webp_path, "WEBP", quality=85)
 
         s3_key = f"previews/{deck_id}/slide_{i + 1:02d}.webp"
-        s3_client.upload_file(str(webp_path), bucket, s3_key, ExtraArgs={"ContentType": "image/webp"})
+        s3_client.upload_file(str(webp_path), bucket, s3_key, ExtraArgs={"ContentType": "image/webp", "CacheControl": "public, max-age=5"})
         logger.info("WebP uploaded: s3://%s/%s", bucket, s3_key)
 
     logger.info("Preview generation complete: %d pages for deck %s", len(png_files), deck_id)

--- a/web-ui/src/components/deck/SlideCarousel.tsx
+++ b/web-ui/src/components/deck/SlideCarousel.tsx
@@ -16,6 +16,7 @@ import { Download, FileJson, Layers, Loader2, LayoutGrid, Rows3 } from "lucide-r
 import { useAuth } from "react-oidc-context"
 import { usePreferences } from "@/hooks/usePreferences"
 import { SpecStepNav, SpecMarkdownPreview } from "@/components/deck/SpecStepNav"
+import { PreviewImage } from "@/components/ui/PreviewImage"
 import type { SpecTab } from "@/components/deck/SpecStepNav"
 
 interface SlideCarouselProps {
@@ -227,8 +228,11 @@ export function SlideCarousel({ slides, deckId, deckName, pptxUrl, isLoading, on
                 className="rounded-lg overflow-hidden border border-border/40 hover:border-border-hover hover:-translate-y-[1px] hover:shadow-[0_4px_16px_oklch(0_0_0/30%)] transition-all duration-200 relative group"
                 aria-label={`Slide ${i + 1}`}
               >
-                <img
+                <PreviewImage
                   src={slide.previewUrl!}
+                  deckId={deckId}
+                  slideId={slide.slideId}
+                  idToken={auth.user?.id_token}
                   alt={`Slide ${i + 1} of ${slidesWithPreview.length}${deckName ? `: ${deckName}` : ""}`}
                   className="w-full pointer-events-none"
                 />
@@ -248,8 +252,11 @@ export function SlideCarousel({ slides, deckId, deckName, pptxUrl, isLoading, on
               className="slide-shadow rounded-lg overflow-hidden w-full text-left cursor-pointer hover:ring-2 hover:ring-primary/50 transition-shadow"
               aria-label={`Insert reference to slide ${i + 1}`}
             >
-              <img
+              <PreviewImage
                 src={slide.previewUrl!}
+                deckId={deckId}
+                slideId={slide.slideId}
+                idToken={auth.user?.id_token}
                 alt={`Slide ${i + 1} of ${slidesWithPreview.length}${deckName ? `: ${deckName}` : ""}`}
                 className="w-full pointer-events-none"
               />

--- a/web-ui/src/components/deck/WorkspaceView.tsx
+++ b/web-ui/src/components/deck/WorkspaceView.tsx
@@ -15,6 +15,8 @@
 
 import { DeckDetail } from "@/services/deckService"
 import { Share2, Download, Layers } from "lucide-react"
+import { PreviewImage } from "@/components/ui/PreviewImage"
+import { useAuth } from "react-oidc-context"
 
 interface WorkspaceViewProps {
   deck: DeckDetail
@@ -41,6 +43,7 @@ function formatDate(iso: string): string {
 
 export function WorkspaceView({ deck, onShare, onDownload }: WorkspaceViewProps) {
   const slideCount = deck.slides?.length || 0
+  const auth = useAuth()
 
   return (
     <div className="h-full flex flex-col animate-card-in">
@@ -90,8 +93,11 @@ export function WorkspaceView({ deck, onShare, onDownload }: WorkspaceViewProps)
               >
                 <div className="aspect-[16/9] relative bg-muted/30">
                   {slide.previewUrl ? (
-                    <img
+                    <PreviewImage
                       src={slide.previewUrl}
+                      deckId={deck.deckId}
+                      slideId={slide.slideId}
+                      idToken={auth.user?.id_token}
                       alt={`Slide ${i + 1}`}
                       className="w-full h-full object-cover"
                     />

--- a/web-ui/src/components/ui/PreviewImage.tsx
+++ b/web-ui/src/components/ui/PreviewImage.tsx
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * PreviewImage — <img> wrapper that retries on 403 (expired signed URL).
+ *
+ * On error, fetches a fresh preview URL from the API and retries once.
+ */
+
+"use client"
+
+import { useState, useCallback, ImgHTMLAttributes } from "react"
+
+interface PreviewImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  /** Deck ID for refreshing the URL via API. */
+  deckId?: string
+  /** Slide ID (e.g. "slide_01") for refreshing. */
+  slideId?: string
+  /** Cognito ID token for API auth. */
+  idToken?: string
+}
+
+export function PreviewImage({ deckId, slideId, idToken, src, onError, ...props }: PreviewImageProps) {
+  const [currentSrc, setCurrentSrc] = useState(src)
+  const [retried, setRetried] = useState(false)
+
+  const handleError = useCallback(async (e: React.SyntheticEvent<HTMLImageElement>) => {
+    if (retried || !deckId || !idToken) {
+      onError?.(e)
+      return
+    }
+    setRetried(true)
+    try {
+      const resp = await fetch("/aws-exports.json")
+      const config = await resp.json()
+      const deckResp = await fetch(`${config.apiBaseUrl}decks/${deckId}`, {
+        headers: { Authorization: `Bearer ${idToken}` },
+      })
+      if (!deckResp.ok) return
+      const deck = await deckResp.json()
+      const slide = deck.slides?.find((s: { slideId: string; previewUrl?: string }) => s.slideId === slideId)
+      if (slide?.previewUrl) {
+        setCurrentSrc(slide.previewUrl)
+      }
+    } catch {
+      onError?.(e)
+    }
+  }, [deckId, slideId, idToken, retried, onError])
+
+  return <img {...props} src={currentSrc || src} onError={handleError} />
+}


### PR DESCRIPTION
## Overview

Serve slide previews, PPTX downloads, and JSON exports via CloudFront with signed URLs instead of S3 presigned URLs. Maintains deck-level authorization (owner/collaborator/viewer) while reducing latency via edge caching.

## Architecture

```
Before:  Browser → API Lambda (head_object + S3 presigned URL per resource) → S3 direct
After:   Browser → API Lambda (authz check + CF signed URL) → CloudFront edge (5s cache + ETag) → S3
```

## Design Decisions

- **Signed URLs** (not signed cookies): Generated per-resource after API verifies user role. Maintains deck-level RBAC.
- **ETag revalidation** with `Cache-Control: public, max-age=5`: After 5s TTL, CloudFront revalidates with S3 via ETag. Unchanged files get 304 (no body transfer).
- **CloudFront Key Group** with RSA key pair auto-generated via Custom Resource → SSM Parameter Store.
- **OAC via L1 escape hatch**: Avoids CDK cross-stack dependency cycle (aws/aws-cdk#31462) by defining S3 origin + OAC at CfnDistribution level.
- **PreviewImage component**: Auto-retries on 403 (expired signed URL) by fetching fresh URL from API.

## Implementation Plan

### 1. RSA Key Pair Provisioner (`infra/lambdas/cf-key-provisioner/index.py`) ✅
- [x] Custom Resource Lambda: generates RSA 2048 key pair via openssl
- [x] Stores private key in SSM (SecureString), public key in SSM (String)
- [x] Returns PublicKeyPem in CloudFormation Data for CDK reference
- [x] Handles Create/Update/Delete lifecycle

### 2. CDK Infrastructure (`infra/lib/web-ui-stack.ts`) ✅
- [x] CloudFront Public Key + Key Group from SSM-stored public key
- [x] CfnOriginAccessControl (L1) for S3 origin
- [x] L1 escape hatch: add S3 origin + OAC + cache behaviors to CfnDistribution
- [x] Cache behaviors: `previews/*` and `decks/*` with TrustedKeyGroups
- [x] Cache policy: max-age=5, gzip+brotli compression
- [x] API Lambda env vars: CF_DOMAIN, CF_KEY_PAIR_ID, CF_PRIVATE_KEY_PARAM
- [x] SSM read permission for API Lambda
- [x] API Gateway routes for upload process/status endpoints

### 3. CDK Data Stack (`infra/lib/data-stack.ts`) ✅
- [x] S3 bucket policy: allow CloudFront OAC to GetObject on `previews/*` and `decks/*`
- [x] Scoped to same account via `aws:SourceAccount` condition

### 4. API: Signed URL Generation (`api/index.py`) ✅
- [x] `_cf_signed_url()`: generates CloudFront signed URLs (15min TTL) via openssl subprocess
- [x] `_preview_url_for_slide()`: webp-preferred lookup with CF signed URL, S3 presigned fallback
- [x] `preview_url()`: CF signed URL for arbitrary S3 keys with fallback

### 5. API: Preview URLs (3 sites) ✅
- [x] `GET /decks` (list) — thumbnail via `_preview_url_for_slide`
- [x] `GET /decks/{id}` (detail) — per-slide preview via `_preview_url_for_slide`
- [x] `GET /slides/search` — search result preview via `_preview_url_for_slide`

### 6. API: PPTX Download URL ✅
- [x] `GET /decks/{id}` — `pptxUrl` field: CF signed URL with S3 presigned fallback

### 7. Frontend: PreviewImage Component (`web-ui/src/components/ui/PreviewImage.tsx`) ✅
- [x] `<img>` wrapper that retries on 403 (expired signed URL)
- [x] On error: fetches fresh deck data from API, updates src with new signed URL
- [x] Single retry guard to prevent infinite loops
- [x] Applied to SlideCarousel (grid + list views) and WorkspaceView

### 8. PNG Worker: Cache-Control Header (`png-worker/handlers/png.py`) ✅
- [x] `Cache-Control: public, max-age=5` on S3 PutObject for preview uploads

## Performance Impact

| Metric | Before (S3 presigned) | After (CloudFront signed URL) |
|---|---|---|
| Image latency (Japan → us-east-1) | ~150-200ms | ~10-30ms (Tokyo edge) + 5s cache |
| PPTX download latency | ~150-200ms | ~10-30ms (edge cache on repeat) |
| API calls per deck open | 2N (N slides × head_object + presigned_url) | N (head_object + cf_signed_url, no S3 round-trip for URL) |
| Cache hit (same slide <5s) | None | Edge cache, then ETag 304 |
| Signed URL expiry handling | Broken image | Auto-retry via PreviewImage component |

## Remaining Items

| # | Item | Priority |
|---|---|---|
| 1 | head_object optimization (store preview S3 keys in DynamoDB) | Low |
| 2 | openssl dependency (included in Lambda Python 3.13, note for custom runtimes) | Info |
| 3 | Upload image presigned URLs (`uploads/tmp/`) remain S3 direct (ephemeral data) | Low |
