### PR TITLE
feat: Move read_uploaded_file to MCP with multimodal support (PDF/image)

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -25,7 +25,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from strands import Agent
 from strands.models import BedrockModel
 from strands.tools.mcp import MCPClient
-from tools.upload_tools import list_uploads, read_uploaded_file
+from tools.upload_tools import list_uploads
 from tools.web_tools import web_fetch
 
 logger = logging.getLogger("sdpm.agent")
@@ -142,7 +142,7 @@ Follow the instructions provided by each MCP server to use their tools effective
 Respond in the same language as the user.
 {mcp_instructions}
 ## File Uploads
-- When a user message contains [Attached: filename (uploadId: xxx)], use read_uploaded_file(upload_id) to read content
+- When a user message contains [Attached: filename (uploadId: xxx)], use read_uploaded_file(upload_id, deck_id) to read content. If no deck exists yet, call init_presentation() first.
 - Use list_uploads(session_id) to see all files in the current session
 
 ## Web Fetch
@@ -259,7 +259,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
 
     # Agent.__init__ triggers MCP client connections.
     # If optional MCP servers fail during init, retry with required-only.
-    tools = [*mcp_servers, read_uploaded_file, list_uploads, web_fetch]
+    tools = [*mcp_servers, list_uploads, web_fetch]
     try:
         agent = Agent(
             name="SdpmAgent",
@@ -290,7 +290,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
         agent = Agent(
             name="SdpmAgent",
             system_prompt="",
-            tools=[*mcp_servers, read_uploaded_file, list_uploads, web_fetch],
+            tools=[*mcp_servers, list_uploads, web_fetch],
             model=model,
             session_manager=session_manager,
             trace_attributes={"user.id": user_id, "session.id": session_id},

--- a/agent/tools/upload_tools.py
+++ b/agent/tools/upload_tools.py
@@ -1,11 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-"""Agent tools for reading uploaded files.
+"""Agent tools for listing uploads in a session.
 
-Uploaded files are stored in S3 with server-side encryption and scoped per user.
-Presigned URLs provide time-limited access.
-
-Agent tools for reading uploaded files and listing uploads in a session."""
+File reading is handled by the MCP server's read_uploaded_file tool,
+which supports multimodal responses (ImageContent for images/PDFs)."""
 
 import json
 import os
@@ -18,112 +16,12 @@ _current_user_id: str = ""
 
 
 def _get_table():
-    """Get the DynamoDB Table resource for decks.
-
-    Returns:
-        boto3 DynamoDB Table resource.
-
-    Raises:
-        ValueError: If DECKS_TABLE environment variable is not set.
-    """
+    """Get the DynamoDB Table resource for decks."""
     table_name = os.environ.get("DECKS_TABLE")
     if not table_name:
         raise ValueError("DECKS_TABLE environment variable is not set")
     region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     return boto3.resource("dynamodb", region_name=region).Table(table_name)
-
-
-@tool
-def read_uploaded_file(upload_id: str) -> str:
-    """Read the extracted text content from an uploaded file.
-
-    Use this when the user has attached a file and you need to read its contents.
-    For images (PNG), this returns a presigned URL for Bedrock Vision analysis.
-
-    Args:
-        upload_id: The upload identifier provided in the [Attached: ...] message.
-
-    Returns:
-        Extracted text content, or an error/status message.
-    """
-    table = _get_table()
-    resp = table.get_item(Key={"PK": f"USER#{_current_user_id}", "SK": f"UPLOAD#{upload_id}"})
-    item = resp.get("Item")
-
-    if not item:
-        return f"Error: Upload {upload_id} not found."
-
-    status = item.get("status", "unknown")
-    if status == "processing":
-        return "File is still being processed. Please wait a moment and try again."
-    if status == "failed":
-        return "File processing failed. The user may need to re-upload."
-    if status == "uploading":
-        return "File is still uploading."
-
-    # Return inline extracted text if available
-    # For PPTX uploads, prefer slide JSON structure over plain text
-    slide_json_key = item.get("slideJsonS3Key")
-    if slide_json_key:
-        try:
-            bucket = os.environ.get("PPTX_BUCKET")
-            region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-            s3_client = boto3.client("s3", region_name=region)
-            obj = s3_client.get_object(Bucket=bucket, Key=slide_json_key)
-            slide_json = obj["Body"].read().decode("utf-8")
-            file_name = item.get("fileName", "unknown")
-            return f"## Slide JSON of {file_name}\n\n{slide_json}"
-        except Exception:
-            pass  # Fall through to text extraction
-
-    extracted_text = item.get("extractedText")
-    if extracted_text:
-        file_name = item.get("fileName", "unknown")
-        file_type = item.get("fileType", "")
-        _PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        if file_type == _PPTX_MIME:
-            return (
-                f"## Content of {file_name}\n\n{extracted_text}\n\n"
-                f"---\nTo edit this PPTX, use pptx_to_json(deck_id=..., upload_id=\"{upload_id}\") to convert to editable JSON."
-            )
-        return f"## Content of {file_name}\n\n{extracted_text}"
-
-    # For binary files, return guidance based on type
-    file_type = item.get("fileType", "")
-    file_name = item.get("fileName", "unknown")
-
-    _PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-    if file_type == _PPTX_MIME:
-        return (
-            f"PPTX file: {file_name} (uploadId: {upload_id}). "
-            f"Use pptx_to_json(deck_id=..., upload_id=\"{upload_id}\") to convert to editable JSON."
-        )
-
-    if file_type.startswith("image/"):
-        s3_key = item.get("s3KeyRaw")
-        if s3_key:
-            bucket = os.environ.get("PPTX_BUCKET")
-            region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-            s3_client = boto3.client("s3", region_name=region)
-            url = s3_client.generate_presigned_url(
-                "get_object",
-                Params={"Bucket": bucket, "Key": s3_key},
-                ExpiresIn=900,
-            )
-            return f"Image file: {file_name}. Presigned URL: {url}"
-
-    # Try reading from S3 extracted key
-    s3_key_extracted = item.get("s3KeyExtracted")
-    if s3_key_extracted:
-        bucket = os.environ.get("PPTX_BUCKET")
-        region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-        s3_client = boto3.client("s3", region_name=region)
-        obj = s3_client.get_object(Bucket=bucket, Key=s3_key_extracted)
-        text = obj["Body"].read().decode("utf-8")
-        file_name = item.get("fileName", "unknown")
-        return f"## Content of {file_name}\n\n{text}"
-
-    return f"No extracted content available for upload {upload_id}."
 
 
 @tool
@@ -140,7 +38,6 @@ def list_uploads(session_id: str) -> str:
     """
     table = _get_table()
 
-    # Query all uploads for this user and filter by sessionId
     resp = table.query(
         KeyConditionExpression="PK = :pk AND begins_with(SK, :prefix)",
         ExpressionAttributeValues={

--- a/api/index.py
+++ b/api/index.py
@@ -805,7 +805,7 @@ ALLOWED_CONTENT_TYPES = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "image/png",
+    "image/png", "image/jpeg", "image/webp", "image/gif", "image/svg+xml",
 }
 
 

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "boto3",
     "sdpm-skill",
     "aws-opentelemetry-distro>=0.10.0",
+    "pypdf",
 ]
 
 [tool.setuptools.packages.find]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -240,6 +240,32 @@ def analyze_template(template: str) -> str:
 
 
 @mcp.tool()
+def read_uploaded_file(upload_id: str, deck_id: str) -> list:
+    """Read an uploaded file's content. Returns text for documents, visual preview for images/PDFs.
+
+    For images: saves original to deck workspace for use in slides, returns visual preview.
+    For PDFs: extracts text and embedded images, saves images to deck workspace.
+    For PPTX: returns extracted text and guidance to use pptx_to_json.
+
+    Args:
+        deck_id: The deck ID. Must be initialized first via init_presentation().
+        upload_id: The upload identifier from the [Attached: ...] message.
+
+    Returns:
+        Text content and/or image previews for visual analysis.
+    """
+    from tools.upload import read_uploaded_file as _read
+
+    _check_deck_access(deck_id, action="edit_slide")
+    return _read(
+        upload_id=upload_id,
+        deck_id=deck_id,
+        user_id=_get_user_id(),
+        storage=_storage,
+    )
+
+
+@mcp.tool()
 def pptx_to_json(deck_id: str, upload_id: str) -> str:
     """Convert an uploaded PPTX file to JSON representation for editing.
     Downloads the PPTX from S3, converts via Engine, and saves presentation.json to the deck workspace.

--- a/mcp-server/tools/upload.py
+++ b/mcp-server/tools/upload.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Read uploaded files with multimodal support (images, PDF)."""
+
+import io
+import mimetypes
+
+from mcp.server.fastmcp.utilities.types import Image
+from PIL import Image as PILImage
+
+from storage import Storage
+
+_JPEG_QUALITY = 80
+_MAX_LONG_EDGE = 1280
+
+_PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+_TEXT_TYPES = {"text/plain", "text/markdown", "application/json"}
+
+
+def _to_jpeg(data: bytes) -> bytes:
+    """Resize image to fit within max edge and convert to JPEG."""
+    img = PILImage.open(io.BytesIO(data))
+    w, h = img.size
+    if max(w, h) > _MAX_LONG_EDGE:
+        scale = _MAX_LONG_EDGE / max(w, h)
+        img = img.resize((int(w * scale), int(h * scale)), PILImage.LANCZOS)
+    img = img.convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=_JPEG_QUALITY)
+    return buf.getvalue()
+
+
+def _save_image_to_deck(storage: Storage, deck_id: str, filename: str, data: bytes) -> str:
+    """Save image to deck workspace and return relative src path."""
+    ct = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    key = f"decks/{deck_id}/images/{filename}"
+    storage.upload_file(key=key, data=data, content_type=ct)
+    return f"images/{filename}"
+
+
+def read_uploaded_file(
+    upload_id: str,
+    deck_id: str,
+    user_id: str,
+    storage: Storage,
+) -> list:
+    """Read an uploaded file, returning text and/or ImageContent.
+
+    Returns a list of str and Image objects for MCP content serialization.
+    """
+    resp = storage.table.get_item(Key={"PK": f"USER#{user_id}", "SK": f"UPLOAD#{upload_id}"})
+    item = resp.get("Item")
+    if not item:
+        return [f"Error: Upload {upload_id} not found."]
+
+    status = item.get("status", "unknown")
+    if status not in ("completed",):
+        return [f"Upload is still {status}. Please wait and try again."]
+
+    file_type = item.get("fileType", "")
+    file_name = item.get("fileName", "unknown")
+    s3_key = item.get("s3KeyRaw", "")
+
+    # --- Text-based files ---
+    if file_type in _TEXT_TYPES:
+        text = item.get("extractedText")
+        if not text and s3_key:
+            text = storage.download_file_from_pptx_bucket(s3_key).decode("utf-8")
+        return [f"## Content of {file_name}\n\n{text or '(empty)'}"]
+
+    # --- PPTX ---
+    if file_type == _PPTX_MIME:
+        text = item.get("extractedText", "")
+        hint = f'Use pptx_to_json(deck_id="{deck_id}", upload_id="{upload_id}") to convert to editable JSON.'
+        parts = []
+        if text:
+            parts.append(f"## Content of {file_name}\n\n{text}\n\n---\n{hint}")
+        else:
+            parts.append(f"PPTX file: {file_name}. {hint}")
+        return parts
+
+    # --- Image ---
+    if file_type.startswith("image/") and s3_key:
+        data = storage.download_file_from_pptx_bucket(s3_key)
+        src = _save_image_to_deck(storage, deck_id, file_name, data)
+        jpeg = _to_jpeg(data)
+        return [
+            f"Image saved to deck workspace as `{src}`. Use this path in slide JSON image elements.",
+            Image(data=jpeg, format="jpeg"),
+        ]
+
+    # --- PDF ---
+    if file_type == "application/pdf" and s3_key:
+        return _read_pdf(storage, deck_id, s3_key, file_name)
+
+    return [f"Unsupported file type: {file_type} ({file_name})"]
+
+
+def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str) -> list:
+    """Extract text and images from PDF."""
+    from pypdf import PdfReader
+
+    data = storage.download_file_from_pptx_bucket(s3_key)
+    reader = PdfReader(io.BytesIO(data))
+
+    result: list = []
+    all_text = []
+    img_idx = 0
+
+    for pi, page in enumerate(reader.pages, 1):
+        text = page.extract_text() or ""
+        if text.strip():
+            all_text.append(f"### Page {pi}\n{text.strip()}")
+
+        for image in page.images:
+            img_idx += 1
+            ext = image.name.rsplit(".", 1)[-1] if "." in image.name else "png"
+            img_name = f"pdf_p{pi}_img{img_idx}.{ext}"
+            src = _save_image_to_deck(storage, deck_id, img_name, image.data)
+            try:
+                jpeg = _to_jpeg(image.data)
+                result.append(f"PDF page {pi} image → `{src}`")
+                result.append(Image(data=jpeg, format="jpeg"))
+            except Exception:
+                result.append(f"PDF page {pi} image → `{src}` (preview unavailable)")
+
+    if all_text:
+        result.insert(0, f"## Text from {file_name}\n\n" + "\n\n".join(all_text))
+    elif not result:
+        result.append(f"No extractable text or images found in {file_name}.")
+
+    return result


### PR DESCRIPTION
Closes #43, Closes #44

## Summary
Move `read_uploaded_file` from Strands Agent tool to MCP server tool, enabling multimodal responses (`ImageContent`) for image and PDF uploads.

## Changes

### MCP Server
- **`mcp-server/tools/upload.py`** (new): `read_uploaded_file` implementation with file-type dispatch
  - Text/JSON/MD: return extractedText
  - PPTX: return extractedText + pptx_to_json guidance
  - Image: copy original to `decks/{deck_id}/images/` for slide use, return resized JPEG as `ImageContent` for Vision analysis
  - PDF: extract text + embedded images via `pypdf`, save images to deck workspace, return text + `ImageContent`
- **`mcp-server/server.py`**: Register `read_uploaded_file(upload_id, deck_id)` as MCP tool
- **`mcp-server/pyproject.toml`**: Add `pypdf` dependency

### Agent
- **`agent/tools/upload_tools.py`**: Remove `read_uploaded_file` (now served by MCP), keep `list_uploads`
- **`agent/basic_agent.py`**: Remove `read_uploaded_file` from Strands tools, update system prompt to include `deck_id` parameter

### API
- **`api/index.py`**: Expand `ALLOWED_CONTENT_TYPES` with JPEG, WebP, GIF, SVG

## Why MCP?
MCP tools can return `ImageContent` blocks (via FastMCP `Image`), enabling the model to visually analyze uploaded images and PDF figures. Strands Agent tools can only return text strings. This follows the same pattern as `get_preview`.

## Design
`read_uploaded_file` requires `deck_id` so images can be saved to the deck workspace for later use in slides. If no deck exists, the agent should call `init_presentation()` first.