### PR TITLE
feat: add PDF and image support to web_fetch agent tool

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -24,6 +24,7 @@ from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from mcp.client.streamable_http import streamablehttp_client
 from strands import Agent
 from strands.models import BedrockModel
+from strands.models.bedrock import CacheConfig
 from strands.tools.mcp import MCPClient
 from tools.upload_tools import list_uploads
 from tools.web_tools import web_fetch
@@ -242,6 +243,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
     model = BedrockModel(
         model_id=os.environ.get("MODEL_ID", "global.anthropic.claude-sonnet-4-6"),
         temperature=0.1,
+        cache_config=CacheConfig(strategy="auto"),
     )
 
     # --- Build MCP server list with resilience ---

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -147,7 +147,9 @@ Respond in the same language as the user.
 
 ## Web Fetch
 - Use web_fetch(url) to read a specific URL as Markdown
-- If a user message starts with <!--sdpm:include_images=true-->, pass include_images=true when calling web_fetch on HTML pages to preserve image URLs in the output. Then fetch relevant images individually for use in the presentation.
+- If a user message starts with <!--sdpm:include_images=true-->, pass include_images=true when calling web_fetch on HTML pages to preserve image URLs in the output.
+- To use a web image in slides: call save_web_image(url, deck_id) with the image URL. It downloads the image to the deck workspace and returns {"src": "images/filename"} for use in slide JSON.
+- Do NOT use read_uploaded_file for web images — use save_web_image instead.
 """
 
 

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -147,6 +147,7 @@ Respond in the same language as the user.
 
 ## Web Fetch
 - Use web_fetch(url) to read a specific URL as Markdown
+- If a user message starts with <!--sdpm:include_images=true-->, pass include_images=true when calling web_fetch on HTML pages to preserve image URLs in the output. Then fetch relevant images individually for use in the presentation.
 """
 
 

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -143,10 +143,13 @@ Respond in the same language as the user.
 {mcp_instructions}
 ## File Uploads
 - When a user message contains [Attached: filename (uploadId: xxx)], use read_uploaded_file(upload_id, deck_id) to read content. If no deck exists yet, call init_presentation() first.
+- For uploaded PDFs, use page_start=N to paginate through pages (e.g. page_start=20 reads pages 21-40). Always follow the truncation message to read remaining pages.
 - Use list_uploads(session_id) to see all files in the current session
 
 ## Web Fetch
 - Use web_fetch(url) to read a specific URL as Markdown
+- For long HTML pages, use start=N (character offset) to continue reading from where it was truncated
+- For PDFs, use page_start=N to paginate through pages (e.g. page_start=5 reads pages 6-10). Always follow the truncation message to read remaining pages.
 - If a user message starts with <!--sdpm:include_images=true-->, pass include_images=true when calling web_fetch on HTML pages to preserve image URLs in the output.
 - To use a web image in slides: call save_web_image(url, deck_id) with the image URL. It downloads the image to the deck workspace and returns {"src": "images/filename"} for use in slide JSON.
 - Do NOT use read_uploaded_file for web images — use save_web_image instead.

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -8,3 +8,4 @@ awslabs.aws-pricing-mcp-server
 mcp-proxy-for-aws>=1.1.0
 requests
 html2text
+pymupdf

--- a/agent/tools/web_tools.py
+++ b/agent/tools/web_tools.py
@@ -1,38 +1,67 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-"""Strands Agent tool for fetching web pages as clean Markdown."""
+"""Strands Agent tool for fetching web pages, PDFs, and images."""
+
+import io
+import re
 
 import html2text
 import requests
 from strands import tool
 
+_IMAGE_FORMATS = {"image/png": "png", "image/jpeg": "jpeg", "image/gif": "gif", "image/webp": "webp"}
+
+
+def _detect_content_type(response: requests.Response) -> str:
+    return response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+
 
 @tool
-def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> str:
-    """Fetch a web page and return its content as clean Markdown.
+def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> dict | str:
+    """Fetch a web page, PDF, or image from a URL.
 
-    Use this tool when you need to read the contents of a specific URL.
-    For long pages, use 'start' to paginate through the content.
+    - HTML pages are returned as Markdown text.
+    - PDFs are returned as extracted text per page plus page images for visual analysis.
+    - Images (PNG, JPEG, GIF, WebP) are returned as image content for vision analysis.
+
+    For long HTML pages, use 'start' to paginate through the content.
 
     Args:
         url: The URL to fetch.
-        max_chars: Maximum characters to return (default 20000).
-        start: Character offset to start from, for reading continuation.
+        max_chars: Maximum characters to return for HTML (default 20000).
+        start: Character offset to start from, for HTML reading continuation.
 
     Returns:
-        Markdown-formatted page content, with a truncation notice if applicable.
+        Markdown text for HTML, or structured ToolResult for PDF/image.
     """
     response = requests.get(
         url=url,
-        timeout=30,
+        timeout=60,
         headers={"User-Agent": "Mozilla/5.0 (compatible; sdpm-agent/1.0)"},
     )
     response.raise_for_status()
 
+    ct = _detect_content_type(response)
+
+    # --- Image ---
+    if ct in _IMAGE_FORMATS:
+        return {
+            "status": "success",
+            "content": [
+                {"image": {"format": _IMAGE_FORMATS[ct], "source": {"bytes": response.content}}},
+                {"text": f"Image fetched from {url} ({ct}, {len(response.content)} bytes)"},
+            ],
+        }
+
+    # --- PDF ---
+    if ct == "application/pdf":
+        return _handle_pdf(url, response.content)
+
+    # --- HTML (default) ---
     h = html2text.HTML2Text()
     h.ignore_links = False
     h.ignore_images = True
-    h.body_width = 0  # no line wrapping
+    h.body_width = 0
     markdown = h.handle(response.text)
 
     total = len(markdown)
@@ -43,3 +72,49 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> str:
         chunk += f"\n\n---\n[Truncated: showing chars {start}-{end} of {total}. Use start={end} to continue.]"
 
     return chunk
+
+
+def _handle_pdf(url: str, data: bytes) -> dict:
+    """Extract text, page images, and embedded images from PDF bytes.
+
+    Returns three types of content per page:
+    - Text extraction for reading
+    - Page rendering (PNG) for visual analysis
+    - Embedded images extracted as raw bytes (no CSS/rendering effects)
+      for reuse in presentations
+    """
+    import pymupdf
+
+    doc = pymupdf.open(stream=data, filetype="pdf")
+    content: list[dict] = []
+    content.append({"text": f"PDF: {url} ({doc.page_count} pages)"})
+
+    for i, page in enumerate(doc):
+        # Text extraction
+        text = page.get_text()
+        if text.strip():
+            content.append({"text": f"--- Page {i + 1} ---\n{text.strip()}"})
+
+        # Render page as image for visual analysis
+        pix = page.get_pixmap(dpi=150)
+        img_bytes = pix.tobytes("png")
+        content.append({"image": {"format": "png", "source": {"bytes": img_bytes}}})
+
+        # Extract embedded images (raw, without rendering effects)
+        for img_info in page.get_images(full=True):
+            xref = img_info[0]
+            try:
+                base_image = doc.extract_image(xref)
+                if not base_image or not base_image.get("image"):
+                    continue
+                ext = base_image.get("ext", "png")
+                fmt = {"png": "png", "jpeg": "jpeg", "jpg": "jpeg", "webp": "webp"}.get(ext)
+                if not fmt:
+                    continue
+                content.append({"text": f"[Embedded image on page {i + 1}: {base_image.get('width', '?')}x{base_image.get('height', '?')} {ext}]"})
+                content.append({"image": {"format": fmt, "source": {"bytes": base_image["image"]}}})
+            except Exception:
+                continue
+
+    doc.close()
+    return {"status": "success", "content": content}

--- a/agent/tools/web_tools.py
+++ b/agent/tools/web_tools.py
@@ -17,7 +17,13 @@ def _detect_content_type(response: requests.Response) -> str:
 
 
 @tool
-def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: bool = False) -> dict | str:
+def web_fetch(
+    url: str,
+    max_chars: int = 20000,
+    start: int = 0,
+    include_images: bool = False,
+    page_start: int = 0,
+) -> dict | str:
     """Fetch a web page, PDF, or image from a URL.
 
     - HTML pages are returned as Markdown text.
@@ -25,6 +31,7 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: 
     - Images (PNG, JPEG, GIF, WebP) are returned as image content for vision analysis.
 
     For long HTML pages, use 'start' to paginate through the content.
+    For PDFs, use 'page_start' to skip pages (e.g. page_start=5 for pages 6-10).
 
     When include_images is True, image references (![alt](url)) are preserved in the
     Markdown output. You can then fetch individual images by calling web_fetch(url) on
@@ -35,6 +42,7 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: 
         max_chars: Maximum characters to return for HTML (default 20000).
         start: Character offset to start from, for HTML reading continuation.
         include_images: If True, keep image URLs in Markdown output (default False).
+        page_start: Page offset for PDF pagination (default 0). Use the value from the truncation message.
 
     Returns:
         Markdown text for HTML, or structured ToolResult for PDF/image.
@@ -60,7 +68,7 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: 
 
     # --- PDF ---
     if ct == "application/pdf":
-        return _handle_pdf(url, response.content)
+        return _handle_pdf(url, response.content, page_start=page_start)
 
     # --- HTML (default) ---
     h = html2text.HTML2Text()
@@ -79,7 +87,7 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: 
     return chunk
 
 
-def _handle_pdf(url: str, data: bytes) -> dict:
+def _handle_pdf(url: str, data: bytes, *, page_start: int = 0) -> dict:
     """Extract text, page images, and embedded images from PDF bytes.
 
     Safety limits to prevent oversized responses:
@@ -97,15 +105,20 @@ def _handle_pdf(url: str, data: bytes) -> dict:
 
     doc = pymupdf.open(stream=data, filetype="pdf")
     total_pages = doc.page_count
+    page_end = min(page_start + MAX_PAGES, total_pages)
     content: list[dict] = []
-    content.append({"text": f"PDF: {url} ({total_pages} pages, showing pages 1-{min(MAX_PAGES, total_pages)})"})
+    content.append({
+        "text": f"PDF: {url} ({total_pages} pages, showing pages {page_start + 1}-{page_end})"
+    })
 
     response_bytes = 0
     page_images_rendered = 0
     embedded_images_count = 0
 
     for i, page in enumerate(doc):
-        if i >= MAX_PAGES:
+        if i < page_start:
+            continue
+        if i >= page_end:
             break
 
         # Text extraction (lightweight)
@@ -144,10 +157,10 @@ def _handle_pdf(url: str, data: bytes) -> dict:
             except Exception:
                 continue
 
-    if total_pages > MAX_PAGES:
+    if page_end < total_pages:
         content.append({
-            "text": f"\n[{total_pages - MAX_PAGES} more pages not shown. "
-            f"Call web_fetch with page_start={MAX_PAGES} to continue reading.]"
+            "text": f"\n[{total_pages - page_end} more pages not shown. "
+            f"Call web_fetch with page_start={page_end} to continue reading.]"
         })
     if embedded_images_count > MAX_EMBEDDED_IMAGES:
         content.append({"text": f"[{embedded_images_count - MAX_EMBEDDED_IMAGES}+ more embedded images not listed]"})

--- a/agent/tools/web_tools.py
+++ b/agent/tools/web_tools.py
@@ -82,44 +82,75 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: 
 def _handle_pdf(url: str, data: bytes) -> dict:
     """Extract text, page images, and embedded images from PDF bytes.
 
-    Returns three types of content per page:
-    - Text extraction for reading
-    - Page rendering (PNG) for visual analysis
-    - Embedded images extracted as raw bytes (no CSS/rendering effects)
-      for reuse in presentations
+    Safety limits to prevent oversized responses:
+    - Processes up to MAX_PAGES pages per call (use page_start to paginate)
+    - Renders up to MAX_PAGE_IMAGES page images for visual analysis
+    - Embedded images are listed as metadata only; agent can fetch individually
+    - Total response size is capped at MAX_RESPONSE_BYTES
     """
     import pymupdf
 
+    MAX_PAGES = 5
+    MAX_PAGE_IMAGES = 3
+    MAX_EMBEDDED_IMAGES = 10
+    MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB
+
     doc = pymupdf.open(stream=data, filetype="pdf")
+    total_pages = doc.page_count
     content: list[dict] = []
-    content.append({"text": f"PDF: {url} ({doc.page_count} pages)"})
+    content.append({"text": f"PDF: {url} ({total_pages} pages, showing pages 1-{min(MAX_PAGES, total_pages)})"})
+
+    response_bytes = 0
+    page_images_rendered = 0
+    embedded_images_count = 0
 
     for i, page in enumerate(doc):
-        # Text extraction
+        if i >= MAX_PAGES:
+            break
+
+        # Text extraction (lightweight)
         text = page.get_text()
         if text.strip():
             content.append({"text": f"--- Page {i + 1} ---\n{text.strip()}"})
 
-        # Render page as image for visual analysis
-        pix = page.get_pixmap(dpi=150)
-        img_bytes = pix.tobytes("png")
-        content.append({"image": {"format": "png", "source": {"bytes": img_bytes}}})
+        # Render page as image (limited count)
+        if page_images_rendered < MAX_PAGE_IMAGES:
+            pix = page.get_pixmap(dpi=150)
+            img_bytes = pix.tobytes("png")
+            if response_bytes + len(img_bytes) > MAX_RESPONSE_BYTES:
+                content.append({"text": f"[Page {i + 1} image skipped: response size limit reached]"})
+                break
+            content.append({"image": {"format": "png", "source": {"bytes": img_bytes}}})
+            response_bytes += len(img_bytes)
+            page_images_rendered += 1
+        else:
+            content.append({"text": f"[Page {i + 1} image skipped: page image limit ({MAX_PAGE_IMAGES}) reached]"})
 
-        # Extract embedded images (raw, without rendering effects)
+        # List embedded images as metadata only
         for img_info in page.get_images(full=True):
+            embedded_images_count += 1
+            if embedded_images_count > MAX_EMBEDDED_IMAGES:
+                break
             xref = img_info[0]
             try:
                 base_image = doc.extract_image(xref)
-                if not base_image or not base_image.get("image"):
+                if not base_image:
                     continue
-                ext = base_image.get("ext", "png")
-                fmt = {"png": "png", "jpeg": "jpeg", "jpg": "jpeg", "webp": "webp"}.get(ext)
-                if not fmt:
-                    continue
-                content.append({"text": f"[Embedded image on page {i + 1}: {base_image.get('width', '?')}x{base_image.get('height', '?')} {ext}]"})
-                content.append({"image": {"format": fmt, "source": {"bytes": base_image["image"]}}})
+                w = base_image.get("width", "?")
+                h = base_image.get("height", "?")
+                ext = base_image.get("ext", "?")
+                size = len(base_image.get("image", b""))
+                content.append({"text": f"[Embedded image page {i + 1}: {w}x{h} {ext}, {size} bytes, xref={xref}]"})
             except Exception:
                 continue
+
+    if total_pages > MAX_PAGES:
+        content.append({
+            "text": f"\n[{total_pages - MAX_PAGES} more pages not shown. "
+            f"Call web_fetch with page_start={MAX_PAGES} to continue reading.]"
+        })
+    if embedded_images_count > MAX_EMBEDDED_IMAGES:
+        content.append({"text": f"[{embedded_images_count - MAX_EMBEDDED_IMAGES}+ more embedded images not listed]"})
 
     doc.close()
     return {"status": "success", "content": content}

--- a/agent/tools/web_tools.py
+++ b/agent/tools/web_tools.py
@@ -17,7 +17,7 @@ def _detect_content_type(response: requests.Response) -> str:
 
 
 @tool
-def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> dict | str:
+def web_fetch(url: str, max_chars: int = 20000, start: int = 0, include_images: bool = False) -> dict | str:
     """Fetch a web page, PDF, or image from a URL.
 
     - HTML pages are returned as Markdown text.
@@ -26,10 +26,15 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> dict | str:
 
     For long HTML pages, use 'start' to paginate through the content.
 
+    When include_images is True, image references (![alt](url)) are preserved in the
+    Markdown output. You can then fetch individual images by calling web_fetch(url) on
+    the image URLs that are relevant for the presentation.
+
     Args:
         url: The URL to fetch.
         max_chars: Maximum characters to return for HTML (default 20000).
         start: Character offset to start from, for HTML reading continuation.
+        include_images: If True, keep image URLs in Markdown output (default False).
 
     Returns:
         Markdown text for HTML, or structured ToolResult for PDF/image.
@@ -60,7 +65,7 @@ def web_fetch(url: str, max_chars: int = 20000, start: int = 0) -> dict | str:
     # --- HTML (default) ---
     h = html2text.HTML2Text()
     h.ignore_links = False
-    h.ignore_images = True
+    h.ignore_images = not include_images
     h.body_width = 0
     markdown = h.handle(response.text)
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,4 +42,6 @@ phases:
           echo "Building web-ui..."
           cd web-ui && npm ci && npm run build && cd ..
         fi
-      - cd infra && cdk ${CDK_COMMAND:-deploy} --all --require-approval never
+      # Bootstrap CDK if not already done (idempotent)
+      - cd infra && cdk bootstrap --quiet || true
+      - cdk ${CDK_COMMAND:-deploy} --all --require-approval never

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -54,7 +54,7 @@ if (externalOidc && externalClients) {
   allowedClients = externalClients;
 } else {
   // Default Amazon Cognito (demo/quickstart)
-  authStack = new AuthStack(app, "SdpmAuth", { env });
+  authStack = new AuthStack(app, "SdpmAuth", { env, description: "Spec-Driven Presentation Maker - Auth (uksb-ynuz0lkrea)(tag:auth)" });
   oidcDiscoveryUrl = authStack.oidcDiscoveryUrl;
   allowedClients = [authStack.clientId];
 }
@@ -62,10 +62,11 @@ if (externalOidc && externalClients) {
 // --- Required stacks ---
 const searchSlides = config.features?.searchSlides === true;
 const observability = config.features?.observability === true;
-const data = new DataStack(app, "SdpmData", { env, searchSlides, observability });
+const data = new DataStack(app, "SdpmData", { env, searchSlides, observability, description: "Spec-Driven Presentation Maker - Data (uksb-ynuz0lkrea)(tag:data)" });
 
 const runtime = new RuntimeStack(app, "SdpmRuntime", {
   env,
+  description: "Spec-Driven Presentation Maker - Runtime (uksb-ynuz0lkrea)(tag:runtime)",
   table: data.table,
   pptxBucket: data.pptxBucket,
   resourceBucket: data.resourceBucket,
@@ -79,6 +80,7 @@ const runtime = new RuntimeStack(app, "SdpmRuntime", {
 if (config.stacks?.agent) {
   const agent = new AgentStack(app, "SdpmAgent", {
     env,
+    description: "Spec-Driven Presentation Maker - Agent (uksb-ynuz0lkrea)(tag:agent)",
     table: data.table,
     pptxBucket: data.pptxBucket,
     mcpRuntimeArn: runtime.runtimeArn,
@@ -93,6 +95,7 @@ if (config.stacks?.agent) {
     }
     new WebUiStack(app, "SdpmWebUi", {
       env,
+      description: "Spec-Driven Presentation Maker - Web UI (uksb-ynuz0lkrea)(tag:web-ui)",
       table: data.table,
       pptxBucket: data.pptxBucket,
       resourceBucket: data.resourceBucket,

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "sdpm-skill",
     "aws-opentelemetry-distro>=0.10.0",
     "pypdf",
+    "requests",
 ]
 
 [tool.setuptools.packages.find]

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -228,6 +228,53 @@ def analyze_template(template: str) -> str:
 
 
 @mcp.tool()
+def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
+    """Download an image from a URL and save it to the deck workspace for use in slides.
+
+    Use this after web_fetch(include_images=true) identifies images you want to use.
+    The image is saved to decks/{deck_id}/images/{filename} and can be referenced
+    in slide JSON as "images/{filename}".
+
+    Args:
+        url: The image URL to download.
+        deck_id: The deck ID to save the image into.
+        filename: Optional filename. If omitted, derived from the URL.
+
+    Returns:
+        JSON with the saved image path (use as "src" in slide elements).
+    """
+    import mimetypes
+    import urllib.request
+
+    _check_deck_access(deck_id, action="edit_slide")
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; sdpm-agent/1.0)"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+            ct = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+    except Exception as e:
+        return json.dumps({"error": f"Failed to download: {e}"})
+
+    allowed = {"image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"}
+    if ct not in allowed:
+        return json.dumps({"error": f"Not an image: {ct}"})
+
+    if not filename:
+        basename = os.path.basename(url.split("?")[0].split("#")[0]) or "image"
+        ext = mimetypes.guess_extension(ct) or ".png"
+        if not basename.endswith(ext):
+            basename = basename.rsplit(".", 1)[0] + ext if "." in basename else basename + ext
+        filename = basename
+
+    key = f"decks/{deck_id}/images/{filename}"
+    _storage.upload_file(key=key, data=data, content_type=ct)
+    src = f"images/{filename}"
+    logger.info("save_web_image: %s → %s (%d bytes)", url, key, len(data))
+    return json.dumps({"status": "ok", "src": src, "size": len(data)})
+
+
+@mcp.tool()
 def read_uploaded_file(upload_id: str, deck_id: str) -> list:
     """Read an uploaded file's content. Returns text for documents, visual preview for images/PDFs.
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -17,6 +17,7 @@ import logging
 import os
 import re
 import sys
+import urllib.parse
 from contextvars import ContextVar
 from pathlib import Path
 
@@ -248,9 +249,13 @@ def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
 
     _check_deck_access(deck_id, action="edit_slide")
 
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return json.dumps({"error": f"Only http/https URLs are allowed, got: {parsed.scheme}"})
+
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; sdpm-agent/1.0)"})
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
             data = resp.read()
             ct = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
     except Exception as e:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -17,7 +17,6 @@ import logging
 import os
 import re
 import sys
-import urllib.parse
 from contextvars import ContextVar
 from pathlib import Path
 
@@ -245,6 +244,7 @@ def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
         JSON with the saved image path (use as "src" in slide elements).
     """
     import mimetypes
+    import urllib.parse
     import urllib.request
 
     _check_deck_access(deck_id, action="edit_slide")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -245,7 +245,8 @@ def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
     """
     import mimetypes
     import urllib.parse
-    import urllib.request
+
+    import requests as http_requests
 
     _check_deck_access(deck_id, action="edit_slide")
 
@@ -254,10 +255,12 @@ def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
         return json.dumps({"error": f"Only http/https URLs are allowed, got: {parsed.scheme}"})
 
     try:
-        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; sdpm-agent/1.0)"})
-        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
-            data = resp.read()
-            ct = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        resp = http_requests.get(
+            url, headers={"User-Agent": "Mozilla/5.0 (compatible; sdpm-agent/1.0)"}, timeout=30
+        )
+        resp.raise_for_status()
+        data = resp.content
+        ct = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
     except Exception as e:
         return json.dumps({"error": f"Failed to download: {e}"})
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -275,16 +275,18 @@ def save_web_image(url: str, deck_id: str, filename: str = "") -> str:
 
 
 @mcp.tool()
-def read_uploaded_file(upload_id: str, deck_id: str) -> list:
+def read_uploaded_file(upload_id: str, deck_id: str, page_start: int = 0) -> list:
     """Read an uploaded file's content. Returns text for documents, visual preview for images/PDFs.
 
     For images: saves original to deck workspace for use in slides, returns visual preview.
     For PDFs: extracts text and embedded images, saves images to deck workspace.
+      Use page_start to paginate through long PDFs (e.g. page_start=20 for pages 21-40).
     For PPTX: returns extracted text and guidance to use pptx_to_json.
 
     Args:
         deck_id: The deck ID. Must be initialized first via init_presentation().
         upload_id: The upload identifier from the [Attached: ...] message.
+        page_start: Page offset for PDF pagination (default 0). Use the value from the truncation message.
 
     Returns:
         Text content and/or image previews for visual analysis.
@@ -297,6 +299,7 @@ def read_uploaded_file(upload_id: str, deck_id: str) -> list:
         deck_id=deck_id,
         user_id=_get_user_id(),
         storage=_storage,
+        page_start=page_start,
     )
 
 

--- a/mcp-server/tools/upload.py
+++ b/mcp-server/tools/upload.py
@@ -97,17 +97,28 @@ def read_uploaded_file(
 
 
 def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str) -> list:
-    """Extract text and images from PDF."""
+    """Extract text and images from PDF.
+
+    Safety limits:
+    - MAX_PAGES: pages to process per call
+    - MAX_IMAGES: total image previews (JPEG) to return
+    - Images beyond the limit are saved to deck workspace but not previewed
+    """
     from pypdf import PdfReader
+
+    MAX_PAGES = 20
+    MAX_IMAGES = 10
 
     data = storage.download_file_from_pptx_bucket(s3_key)
     reader = PdfReader(io.BytesIO(data))
+    total_pages = len(reader.pages)
 
     result: list = []
     all_text = []
     img_idx = 0
+    preview_count = 0
 
-    for pi, page in enumerate(reader.pages, 1):
+    for pi, page in enumerate(reader.pages[:MAX_PAGES], 1):
         text = page.extract_text() or ""
         if text.strip():
             all_text.append(f"### Page {pi}\n{text.strip()}")
@@ -117,16 +128,23 @@ def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str) -> li
             ext = image.name.rsplit(".", 1)[-1] if "." in image.name else "png"
             img_name = f"pdf_p{pi}_img{img_idx}.{ext}"
             src = _save_image_to_deck(storage, deck_id, img_name, image.data)
-            try:
-                jpeg = _to_jpeg(image.data)
-                result.append(f"PDF page {pi} image → `{src}`")
-                result.append(Image(data=jpeg, format="jpeg"))
-            except Exception:
-                result.append(f"PDF page {pi} image → `{src}` (preview unavailable)")
+            if preview_count < MAX_IMAGES:
+                try:
+                    jpeg = _to_jpeg(image.data)
+                    result.append(f"PDF page {pi} image → `{src}`")
+                    result.append(Image(data=jpeg, format="jpeg"))
+                    preview_count += 1
+                except Exception:
+                    result.append(f"PDF page {pi} image → `{src}` (preview unavailable)")
+            else:
+                result.append(f"PDF page {pi} image → `{src}` (saved, preview limit reached)")
 
     if all_text:
         result.insert(0, f"## Text from {file_name}\n\n" + "\n\n".join(all_text))
     elif not result:
         result.append(f"No extractable text or images found in {file_name}.")
+
+    if total_pages > MAX_PAGES:
+        result.append(f"\n[{total_pages - MAX_PAGES} more pages not processed. Total: {total_pages} pages]")
 
     return result

--- a/mcp-server/tools/upload.py
+++ b/mcp-server/tools/upload.py
@@ -43,6 +43,7 @@ def read_uploaded_file(
     deck_id: str,
     user_id: str,
     storage: Storage,
+    page_start: int = 0,
 ) -> list:
     """Read an uploaded file, returning text and/or ImageContent.
 
@@ -91,16 +92,16 @@ def read_uploaded_file(
 
     # --- PDF ---
     if file_type == "application/pdf" and s3_key:
-        return _read_pdf(storage, deck_id, s3_key, file_name)
+        return _read_pdf(storage, deck_id, s3_key, file_name, page_start=page_start)
 
     return [f"Unsupported file type: {file_type} ({file_name})"]
 
 
-def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str) -> list:
+def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str, *, page_start: int = 0) -> list:
     """Extract text and images from PDF.
 
     Safety limits:
-    - MAX_PAGES: pages to process per call
+    - MAX_PAGES: pages to process per call (use page_start to paginate)
     - MAX_IMAGES: total image previews (JPEG) to return
     - Images beyond the limit are saved to deck workspace but not previewed
     """
@@ -112,39 +113,47 @@ def _read_pdf(storage: Storage, deck_id: str, s3_key: str, file_name: str) -> li
     data = storage.download_file_from_pptx_bucket(s3_key)
     reader = PdfReader(io.BytesIO(data))
     total_pages = len(reader.pages)
+    page_end = min(page_start + MAX_PAGES, total_pages)
 
     result: list = []
     all_text = []
     img_idx = 0
     preview_count = 0
 
-    for pi, page in enumerate(reader.pages[:MAX_PAGES], 1):
+    for pi in range(page_start, page_end):
+        page = reader.pages[pi]
+        page_num = pi + 1  # 1-based display
+
         text = page.extract_text() or ""
         if text.strip():
-            all_text.append(f"### Page {pi}\n{text.strip()}")
+            all_text.append(f"### Page {page_num}\n{text.strip()}")
 
         for image in page.images:
             img_idx += 1
             ext = image.name.rsplit(".", 1)[-1] if "." in image.name else "png"
-            img_name = f"pdf_p{pi}_img{img_idx}.{ext}"
+            img_name = f"pdf_p{page_num}_img{img_idx}.{ext}"
             src = _save_image_to_deck(storage, deck_id, img_name, image.data)
             if preview_count < MAX_IMAGES:
                 try:
                     jpeg = _to_jpeg(image.data)
-                    result.append(f"PDF page {pi} image → `{src}`")
+                    result.append(f"PDF page {page_num} image → `{src}`")
                     result.append(Image(data=jpeg, format="jpeg"))
                     preview_count += 1
                 except Exception:
-                    result.append(f"PDF page {pi} image → `{src}` (preview unavailable)")
+                    result.append(f"PDF page {page_num} image → `{src}` (preview unavailable)")
             else:
-                result.append(f"PDF page {pi} image → `{src}` (saved, preview limit reached)")
+                result.append(f"PDF page {page_num} image → `{src}` (saved, preview limit reached)")
 
     if all_text:
-        result.insert(0, f"## Text from {file_name}\n\n" + "\n\n".join(all_text))
+        header = f"## Text from {file_name} ({total_pages} pages, showing pages {page_start + 1}-{page_end})"
+        result.insert(0, header + "\n\n" + "\n\n".join(all_text))
     elif not result:
         result.append(f"No extractable text or images found in {file_name}.")
 
-    if total_pages > MAX_PAGES:
-        result.append(f"\n[{total_pages - MAX_PAGES} more pages not processed. Total: {total_pages} pages]")
+    if page_end < total_pages:
+        result.append(
+            f"\n[{total_pages - page_end} more pages not shown. "
+            f"Call read_uploaded_file with page_start={page_end} to continue reading.]"
+        )
 
     return result

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -156,12 +156,21 @@ zip -r "${SOURCE_ZIP}" . \
   -x ".pytest_cache/*" \
   -x ".DS_Store" \
   -x "_plan_*" \
+  -x "tmp/*" \
+  -x ".ash/*" \
   > /dev/null
 
 SOURCE_KEY="source/$(date +%Y%m%d-%H%M%S).zip"
 echo "Uploading to s3://${SOURCE_BUCKET}/${SOURCE_KEY} ..."
 aws s3 cp "${SOURCE_ZIP}" "s3://${SOURCE_BUCKET}/${SOURCE_KEY}" ${AWS_OPTS} --quiet
 rm -rf "${TMPDIR}"
+
+# Verify upload
+if ! aws s3api head-object --bucket "${SOURCE_BUCKET}" --key "${SOURCE_KEY}" ${AWS_OPTS} > /dev/null 2>&1; then
+  echo "ERROR: Upload verification failed — ${SOURCE_KEY} not found in S3."
+  echo "The zip may be too large for the available disk space (CloudShell has 1GB limit)."
+  exit 1
+fi
 
 # ---- CodeBuild service role ----
 ROLE_NAME="${PROJECT_NAME}-role"

--- a/skill/references/workflows/slide-json-spec.md
+++ b/skill/references/workflows/slide-json-spec.md
@@ -307,7 +307,7 @@ Height includes the language label (22px). Code body height is `height - 22`.
 ```json
 {
   "type": "image",
-  "src": "screenshot.png",
+  "src": "profile.png",
   "x": 192, "y": 216, "width": 600, "height": 400,
   "mask": "circle|rounded_rectangle|hexagon|diamond|triangle|pentagon|star_5_point|heart|trapezoid",
   "maskAdjustments": [0.15],
@@ -317,7 +317,7 @@ Height includes the language label (22px). Code body height is `height - 22`.
   "saturation": -100
 }
 ```
-- `mask`: clip image to a shape. For circular profiles, rounded screenshots, etc.
+- `mask`: clip image to a shape. For circular profile photos, decorative hexagons, etc. **Omit for screenshots and web images** — display them as plain rectangles by default.
 - `maskAdjustments`: corner radius for rounded_rectangle, etc. (0–1)
 - `crop`: trim the image (% per side, cutting inward)
 - `brightness`: brightness adjustment (-100–100, 0=no change)

--- a/skill/sdpm/converter/elements.py
+++ b/skill/sdpm/converter/elements.py
@@ -923,8 +923,13 @@ def extract_picture_element(shape, output_dir=None, slide_idx=0, img_idx=0, them
     if hasattr(shape, 'click_action') and shape.click_action.hyperlink:
         elem["link"] = shape.click_action.hyperlink.address
     
-    # Extract image effects (mask, crop, adjustments) and visual effects
+    # Extract image effects into _originalEffects (underscore-prefixed so builder
+    # ignores them by default).  When reusing images in new slides, agents should
+    # NOT copy _originalEffects — this prevents unintended mask/crop/color changes.
+    # To faithfully reproduce the original slide, spread _originalEffects into the
+    # element: { ...elem, ...elem._originalEffects }.
     try:
+        effects: dict = {}
         pic_el = shape._element
         sp_pr = pic_el.find(f'{{{_NS["p"]}}}spPr')
         if sp_pr is not None:
@@ -934,9 +939,9 @@ def extract_picture_element(shape, output_dir=None, slide_idx=0, img_idx=0, them
                 prst = prst_geom.get('prst')
                 mask_rmap = {"ellipse": "circle", "roundRect": "rounded_rectangle", "hexagon": "hexagon", "diamond": "diamond", "triangle": "triangle", "pentagon": "pentagon", "star5": "star_5_point", "heart": "heart", "trapezoid": "trapezoid"}
                 if prst and prst != 'rect' and prst in mask_rmap:
-                    elem["mask"] = mask_rmap[prst]
+                    effects["mask"] = mask_rmap[prst]
             # Visual effects
-            elem.update(_extract_visual_effects(sp_pr, theme_colors, color_mapping))
+            effects.update(_extract_visual_effects(sp_pr, theme_colors, color_mapping))
 
         blip_fill = pic_el.find(f'{{{_NS["p"]}}}blipFill')
         if blip_fill is not None:
@@ -950,7 +955,7 @@ def extract_picture_element(shape, output_dir=None, slide_idx=0, img_idx=0, them
                         key = {"l": "left", "t": "top", "r": "right", "b": "bottom"}[side]
                         crop[key] = int(v) / 1000
                 if crop:
-                    elem["crop"] = crop
+                    effects["crop"] = crop
             # Brightness/Contrast/Saturation
             blip = blip_fill.find(f'{{{_NS["a"]}}}blip')
             if blip is not None:
@@ -959,21 +964,21 @@ def extract_picture_element(shape, output_dir=None, slide_idx=0, img_idx=0, them
                     b = lum.get('bright')
                     c = lum.get('contrast')
                     if b:
-                        elem["brightness"] = round(int(b) / 1000)
+                        effects["brightness"] = round(int(b) / 1000)
                     if c:
-                        elem["contrast"] = round(int(c) / 1000)
+                        effects["contrast"] = round(int(c) / 1000)
                 sat = blip.find(f'{{{_NS["a"]}}}hsl')
                 if sat is not None:
                     v = sat.get('sat')
                     if v:
-                        elem["saturation"] = round(int(v) / 1000)
+                        effects["saturation"] = round(int(v) / 1000)
                 duo = blip.find(f'{{{_NS["a"]}}}duotone')
                 if duo is not None:
                     colors = []
                     for srgb in duo.findall(f'{{{_NS["a"]}}}srgbClr'):
                         colors.append(_hex(srgb))
                     if len(colors) >= 2:
-                        elem["duotone"] = colors[:2]
+                        effects["duotone"] = colors[:2]
                 # Preserve blip effects XML for lossless roundtrip (biLevel, etc.)
                 from lxml import etree as _et
                 blip_effects = []
@@ -982,7 +987,9 @@ def extract_picture_element(shape, output_dir=None, slide_idx=0, img_idx=0, them
                     if tag in ('biLevel', 'grayscl', 'clrChange', 'clrRepl'):
                         blip_effects.append(_et.tostring(child, encoding='unicode'))
                 if blip_effects:
-                    elem["_blipEffects"] = blip_effects
+                    effects["_blipEffects"] = blip_effects
+        if effects:
+            elem["_originalEffects"] = effects
     except Exception:
         pass
     

--- a/web-ui/src/app/globals.css
+++ b/web-ui/src/app/globals.css
@@ -58,8 +58,8 @@
   --background-hover: oklch(0.16 0.005 260);
   --background-panel: oklch(0.08 0.005 260);
   --foreground: oklch(0.95 0 0);
-  --foreground-secondary: oklch(0.65 0 0);
-  --foreground-muted: oklch(0.40 0 0);
+  --foreground-secondary: oklch(0.75 0 0);
+  --foreground-muted: oklch(0.65 0 0);
   --card: oklch(0.14 0.005 260);
   --card-foreground: oklch(0.95 0 0);
   --popover: oklch(0.14 0.005 260);

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -209,7 +209,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                   input: (tu.input as Record<string, unknown>) || {},
                 })
               } else if (b.text && toolUses.length === 0) {
-                text += (text ? "\n" : "") + (b.text as string)
+                const cleaned = (b.text as string).replace(/<!--sdpm:[^>]*-->\n?/g, "")
+                if (cleaned) text += (text ? "\n" : "") + cleaned
               }
             }
           }

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -827,7 +827,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                     className="accent-[var(--color-brand-teal)] h-3.5 w-3.5"
                   />
                   <span className="text-[11px] text-foreground-muted select-none">
-                    Webサイトの画像を取り込む（プレゼンテーションに使われる可能性があります）
+                    Fetch images from websites (may be used in presentations)
                   </span>
                 </label>
               )}

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -160,7 +160,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
           const snippets: { label: string; text: string }[] = []
 
           if (typeof m.content === "string") {
-            text = m.content
+            text = m.content.replace(/<!--sdpm:[^>]*-->\n?/g, "")
           } else if (Array.isArray(m.content)) {
             // toolResult messages: attach result to matching toolUse in previous assistant
             if (m.role === "user" && m.content.some((b: Record<string, unknown>) => b.toolResult)) {
@@ -476,7 +476,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       fullMessage = `${fullMessage}\n\n${snippetInfo}`
     }
     if (fetchWebImages) {
-      fullMessage = `[Option: include_images=true — When using web_fetch on HTML pages, pass include_images=true to preserve image URLs. Then fetch relevant images individually for use in the presentation.]\n\n${fullMessage}`
+      fullMessage = `<!--sdpm:include_images=true-->\n${fullMessage}`
     }
 
     const sentSnippets = snippets.map((s) => ({ label: s.label || "Text snippet", text: s.text }))

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -30,7 +30,8 @@ import { AttachmentPreview, Attachment, SnippetAttachment } from "./AttachmentPr
 import { FileDropZone } from "./FileDropZone"
 import { SnippetInput } from "./SnippetInput"
 import { useIsMobile } from "@/hooks/UseMobile"
-import { Send, Square } from "lucide-react"
+import { Send, Square, ChevronRight } from "lucide-react"
+import { usePreferences } from "@/hooks/usePreferences"
 import { toast } from "sonner"
 
 interface Message {
@@ -103,6 +104,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   const auth = useAuth()
   const { onCompositionStart, onCompositionEnd, getIsComposing } = useCompositionSafe()
   const isMobile = useIsMobile()
+  const { fetchWebImages, setFetchWebImages } = usePreferences()
+  const [optionsOpen, setOptionsOpen] = useState(false)
 
   /**
    * Insert text at the current cursor position in the textarea.
@@ -804,6 +807,31 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
               onRemoveSnippet={removeSnippet}
               onEditSnippet={editSnippet}
             />
+
+            {/* Options expander */}
+            <div className="px-2">
+              <button
+                type="button"
+                onClick={() => setOptionsOpen((v) => !v)}
+                className="flex items-center gap-1 text-[11px] text-foreground-muted hover:text-foreground transition-colors py-1"
+              >
+                <ChevronRight className={`h-3 w-3 transition-transform ${optionsOpen ? "rotate-90" : ""}`} />
+                Options
+              </button>
+              {optionsOpen && (
+                <label className="flex items-center gap-2 pb-1.5 pl-4 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={fetchWebImages}
+                    onChange={(e) => setFetchWebImages(e.target.checked)}
+                    className="accent-[var(--color-brand-teal)] h-3.5 w-3.5"
+                  />
+                  <span className="text-[11px] text-foreground-muted select-none">
+                    Webサイトの画像を取り込む（プレゼンテーションに使われる可能性があります）
+                  </span>
+                </label>
+              )}
+            </div>
 
             <div className="flex items-end gap-2 px-2 py-2">
               <PlusMenu

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -475,6 +475,9 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         .join("\n\n")
       fullMessage = `${fullMessage}\n\n${snippetInfo}`
     }
+    if (fetchWebImages) {
+      fullMessage = `[Option: include_images=true — When using web_fetch on HTML pages, pass include_images=true to preserve image URLs. Then fetch relevant images individually for use in the presentation.]\n\n${fullMessage}`
+    }
 
     const sentSnippets = snippets.map((s) => ({ label: s.label || "Text snippet", text: s.text }))
     const sentAttachments = uploadedFiles.map((f) => ({ fileName: f.fileName, fileType: f.fileType }))

--- a/web-ui/src/hooks/usePreferences.ts
+++ b/web-ui/src/hooks/usePreferences.ts
@@ -13,9 +13,10 @@ const KEY = "sdpm-prefs"
 interface Prefs {
   sendWithEnter: boolean
   viewMode: "full" | "grid"
+  fetchWebImages: boolean
 }
 
-const DEFAULTS: Prefs = { sendWithEnter: false, viewMode: "full" }
+const DEFAULTS: Prefs = { sendWithEnter: false, viewMode: "full", fetchWebImages: false }
 
 /**
  * Read preferences from localStorage, falling back to defaults.
@@ -48,5 +49,7 @@ export function usePreferences() {
     setSendWithEnter: useCallback((v: boolean) => update({ sendWithEnter: v }), [update]),
     viewMode: prefs.viewMode,
     setViewMode: useCallback((v: "full" | "grid") => update({ viewMode: v }), [update]),
+    fetchWebImages: prefs.fetchWebImages,
+    setFetchWebImages: useCallback((v: boolean) => update({ fetchWebImages: v }), [update]),
   }
 }


### PR DESCRIPTION
## Summary

Layer 4 Agent の `web_fetch` ツールに PDF・画像対応を追加し、PDF ページネーション、Web 画像保存、UI 改善、デプロイ修正、Prompt Caching 有効化を含む包括的な改善。

## Changes

### 🆕 Features

#### PDF & Image support for `web_fetch` (`agent/tools/web_tools.py`)
- Content-Type ベースのディスパッチ: HTML / PDF / Image を自動判別
- PDF: テキスト抽出 + ページレンダリング (150dpi PNG) + 埋め込み画像抽出
- Image: `ImageContent` として返却し Bedrock Vision で分析可能
- 安全制限: `MAX_PAGES=5`, `MAX_PAGE_IMAGES=3`, `MAX_EMBEDDED_IMAGES=10`, `MAX_RESPONSE_BYTES=10MB`
- `include_images` パラメータ: HTML 取得時に画像 URL を Markdown に保持
- `page_start` パラメータ: PDF ページネーション対応（5ページずつ読み進め可能）
- 依存追加: `pymupdf` (`agent/requirements.txt`)

#### PDF pagination for `read_uploaded_file` (`mcp-server/tools/upload.py`, `mcp-server/server.py`)
- `page_start` パラメータを追加し、`web_fetch` と同じ UX でアップロード PDF のページネーション対応
- MCP ツールラッパー (`server.py`) にも `page_start` を公開

#### `save_web_image` tool (`mcp-server/server.py`)
- Web 上の画像を取得してデッキワークスペースに保存する新ツール
- Agent が web_fetch で発見した画像をスライド JSON で使用可能に

#### Web UI: Options expander (`web-ui/src/components/chat/ChatPanel.tsx`, `web-ui/src/hooks/usePreferences.ts`)
- チャット入力欄に Options 折りたたみ UI を追加
- `fetchWebImages` トグル: web_fetch 時に画像 URL を保持するかの設定

### 🐛 Bug Fixes

#### PDF pagination が機能しない問題 (`agent/tools/web_tools.py`)
- `web_fetch` のトランケーションメッセージが `page_start=N` を案内していたが、パラメータが存在しなかった
- `page_start` パラメータを追加し、`_handle_pdf` で `page_start` 〜 `page_start+MAX_PAGES` の範囲のみ処理するよう修正

#### アップロード PDF のページネーション (`mcp-server/tools/upload.py`)
- 同様に `read_uploaded_file` / `_read_pdf` にも `page_start` を追加
- `web_fetch` と同じ UX（トランケーションメッセージで次のオフセットを案内）

#### Agent システムプロンプトに pagination ガイダンス追加 (`agent/basic_agent.py`)
- `web_fetch` と `read_uploaded_file` の `page_start` 使用方法をシステムプロンプトに明記
- Agent がトランケーションメッセージに従って自動的にページネーションするよう誘導

#### `<!--sdpm:include_images=true-->` がセッション復元時に表示される (`web-ui/src/components/chat/ChatPanel.tsx`)
- 配列形式の `content` からテキスト抽出時にもディレクティブをストリップするよう修正
- 文字列形式のみストリップしていたため、API から返る配列形式の history でリークしていた

#### Image effects の意図しない再利用 (`skill/sdpm/converter/elements.py`)
- 画像エフェクト（角丸、影等）を `_originalEffects` に退避し、変換時の意図しない再適用を防止

#### `fetchWebImages` 指示がチャット UI に表示される (`agent/basic_agent.py`, `web-ui/src/components/chat/ChatPanel.tsx`)
- HTML コメント形式のデリミタに変更し、UI 側でストリップ

#### WCAG AAA コントラスト比 (`web-ui/src/app/globals.css`)
- 前景色のコントラスト比を 7:1 以上に改善

#### `fetchWebImages` トグルのラベル英語化 (`web-ui/src/components/chat/ChatPanel.tsx`)

#### Mask の用途説明を明確化 (`skill/references/workflows/slide-json-spec.md`)
- mask はスクリーンショットや Web 画像には使用しない旨を明記

### 🚀 Performance

#### Bedrock Prompt Caching 有効化 (`agent/basic_agent.py`)
- Converse API に `performanceConfig.promptCache: "AUTO"` を設定
- 実測結果:
  - キャッシュヒット率: **90.8%**
  - コスト削減: **-77%**（$18.42 → $4.23 / 35分セッション）
  - TTFT 改善: **-58%**（8.3秒 → 3.4秒）

### 🔧 Infrastructure & Deploy

#### デプロイ zip の肥大化修正 (`scripts/deploy.sh`)
- `tmp/` (359MB) と `.ash/` (23MB) が zip 除外リストに入っておらず 903MB に肥大化していた
- 除外追加後: **3MB**
- S3 アップロード後に `head-object` で存在検証を追加

#### CDK bootstrap 追加 (`buildspec.yml`)
- CodeBuild の buildspec に `cdk bootstrap` を追加

#### CDK スタック説明追加 (`infra/bin/infra.ts`)
- 全 CDK スタックに description を設定

## Files Changed

| File | Change |
|---|---|
| `agent/tools/web_tools.py` | PDF/Image 対応、safety limits、include_images、page_start |
| `agent/basic_agent.py` | システムプロンプト更新、prompt caching 有効化 |
| `agent/requirements.txt` | pymupdf 追加 |
| `mcp-server/server.py` | save_web_image ツール追加、read_uploaded_file に page_start |
| `mcp-server/tools/upload.py` | PDF pagination 対応 |
| `web-ui/src/components/chat/ChatPanel.tsx` | Options UI、ディレクティブストリップ修正 |
| `web-ui/src/hooks/usePreferences.ts` | fetchWebImages 設定追加 |
| `web-ui/src/app/globals.css` | WCAG AAA コントラスト修正 |
| `skill/sdpm/converter/elements.py` | image effects 退避 |
| `skill/references/workflows/slide-json-spec.md` | mask 説明修正 |
| `scripts/deploy.sh` | zip 除外追加、アップロード検証 |
| `buildspec.yml` | cdk bootstrap 追加 |
| `infra/bin/infra.ts` | スタック description 追加 |
