### PR TITLE
Integrate measure_slides into run_python — reduce tool call overhead

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -28,6 +28,7 @@ COPY mcp-server/pyproject.toml mcp-server/pyproject.toml
 COPY mcp-server/tools/ mcp-server/tools/
 COPY mcp-server/storage/ mcp-server/storage/
 COPY mcp-server/server.py mcp-server/server.py
+COPY mcp-server/server_utils.py mcp-server/server_utils.py
 RUN python3.13 -m pip install --no-cache-dir ./mcp-server
 
 ENV PYTHONPATH=/app

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -387,95 +387,70 @@ def get_preview(deck_id: str, slide_numbers: list[int], quality: str = "high") -
         raise
 
 
-@mcp.tool()
-def measure_slides(deck_id: str, slide_numbers: list[int] | None = None) -> str:
-    """Measure text bounding boxes for overflow detection.
-    Builds PPTX from presentation.json, generates SVG via LibreOffice, and extracts bbox data.
-    Does NOT require generate_pptx — works directly from workspace JSON.
-    After returning the measure report, generates draft WebP previews in the background.
+def _build_pptx(tmpdir: Path, slides: list[dict], build_kwargs: dict) -> Path:
+    """Build PPTX from slides JSON. Returns path to built file."""
+    from sdpm.builder import PPTXBuilder, resolve_override
 
-    Args:
-        deck_id: The deck ID to measure.
-        slide_numbers: Optional list of 1-based slide numbers. All slides if None.
+    builder = PPTXBuilder(**build_kwargs)
+    id_map: dict[str, dict] = {}
+    for s in slides:
+        if "id" in s:
+            id_map[s["id"]] = s
+    for s in slides:
+        builder.add_slide(resolve_override(s, id_map))
+    pptx_path = tmpdir / "measure.pptx"
+    builder.save(pptx_path)
+    return pptx_path
 
-    Returns:
-        Measure report as text.
-    """
-    _check_deck_access(deck_id, action="read")
-    import asyncio
-    import shutil
+
+def _run_measure(tmpdir: Path, pptx_path: Path, slide_numbers: list[int]) -> str:
+    """PPTX → SVG → bbox measurement → report string."""
     import subprocess
+
+    from sdpm.preview.measure import measure_from_svg, format_measure_report
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmpdir)
+    subprocess.run(  # nosec B603
+        ["soffice", "--headless", "--convert-to", "svg", "--outdir", str(tmpdir), str(pptx_path)],
+        env=env, capture_output=True, text=True, timeout=120, check=True,
+    )
+    svg_path = tmpdir / "measure.svg"
+    if not svg_path.exists():
+        return json.dumps({"error": "LibreOffice SVG export failed"})
+
+    results = measure_from_svg(svg_path=svg_path, slide_indices=slide_numbers)
+    return format_measure_report(results)
+
+
+async def _generate_webp_background(deck_id: str, pptx_path: Path, tmpdir: Path) -> None:
+    """Background WebP preview generation → S3 upload → tmpdir cleanup."""
+    import shutil
     import tempfile
-    import traceback
+
+    from tools.generate import generate_previews
 
     try:
-        from sdpm.builder import PPTXBuilder, resolve_override
-        from sdpm.preview.measure import measure_from_svg, format_measure_report
-        from tools.generate import _prepare_workspace, generate_previews
-
-        user_id = _get_user_id()
-        tmpdir, slides, build_kwargs = _prepare_workspace(deck_id, user_id, _storage)
-
-        # Build PPTX from JSON
-        builder = PPTXBuilder(**build_kwargs)
-        id_map: dict[str, dict] = {}
-        for s in slides:
-            if "id" in s:
-                id_map[s["id"]] = s
-        for s in slides:
-            builder.add_slide(resolve_override(s, id_map))
-        pptx_path = tmpdir / "measure.pptx"
-        builder.save(pptx_path)
-
-        # PPTX → SVG via LibreOffice (for bbox extraction)
-        env = os.environ.copy()
-        env["HOME"] = str(tmpdir)
-        subprocess.run(  # nosec B603
-            ["soffice", "--headless", "--convert-to", "svg", "--outdir", str(tmpdir), str(pptx_path)],
-            env=env, capture_output=True, text=True, timeout=120, check=True,
-        )
-        svg_path = tmpdir / "measure.svg"
-        if not svg_path.exists():
-            shutil.rmtree(tmpdir, ignore_errors=True)
-            return json.dumps({"error": "LibreOffice SVG export failed"})
-
-        # Measure bboxes
-        results = measure_from_svg(svg_path=svg_path, slide_indices=slide_numbers)
-        report = format_measure_report(results)
-
-        # Schedule background draft WebP generation (tmpdir cleanup in task)
-        async def _generate_draft_webp() -> None:
-            try:
-                preview_dir = Path(tempfile.mkdtemp())
-                try:
-                    old_keys = _storage.list_files(prefix=f"previews/{deck_id}/", bucket=_storage.pptx_bucket)
-                    epoch = int(__import__("time").time())
-                    webp_files = generate_previews(pptx_path, preview_dir)
-                    for i, webp_path in enumerate(webp_files):
-                        s3_key = f"previews/{deck_id}/slide_{i + 1:02d}_{epoch}.webp"
-                        _storage.upload_file(key=s3_key, data=webp_path.read_bytes(), content_type="image/webp")
-                    for key in old_keys:
-                        try:
-                            _storage._s3.delete_object(Bucket=_storage.pptx_bucket, Key=key)
-                        except Exception:
-                            logger.warning("Failed to delete old preview key: %s", key)
-                    logger.info("Measure WebP previews uploaded: %d slides for deck %s", len(webp_files), deck_id)
-                finally:
-                    shutil.rmtree(preview_dir, ignore_errors=True)
-            except Exception as e:
-                logger.warning("Draft WebP generation failed for deck %s: %s", deck_id, e)
-            finally:
-                shutil.rmtree(tmpdir, ignore_errors=True)
-
+        preview_dir = Path(tempfile.mkdtemp())
         try:
-            asyncio.get_event_loop().create_task(_generate_draft_webp())
-        except Exception:
-            shutil.rmtree(tmpdir, ignore_errors=True)
-
-        return report
+            old_keys = _storage.list_files(prefix=f"previews/{deck_id}/", bucket=_storage.pptx_bucket)
+            epoch = int(__import__("time").time())
+            webp_files = generate_previews(pptx_path, preview_dir)
+            for i, webp_path in enumerate(webp_files):
+                s3_key = f"previews/{deck_id}/slide_{i + 1:02d}_{epoch}.webp"
+                _storage.upload_file(key=s3_key, data=webp_path.read_bytes(), content_type="image/webp")
+            for key in old_keys:
+                try:
+                    _storage._s3.delete_object(Bucket=_storage.pptx_bucket, Key=key)
+                except Exception:
+                    logger.warning("Failed to delete old preview key: %s", key)
+            logger.info("WebP previews uploaded: %d slides for deck %s", len(webp_files), deck_id)
+        finally:
+            shutil.rmtree(preview_dir, ignore_errors=True)
     except Exception as e:
-        logger.exception("measure_slides failed: deck=%s", deck_id)
-        return json.dumps({"error": str(e), "traceback": traceback.format_exc()})
+        logger.warning("WebP generation failed for deck %s: %s", deck_id, e)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 # --- Asset Tools ---
@@ -676,7 +651,8 @@ def code_to_slide(deck_id: str, code: str, name: str,
 
 @mcp.tool()
 def run_python(code: str, deck_id: str | None = None, save: bool = False,
-               files: list[str] | None = None, purpose: str = "") -> str:
+               files: list[str] | None = None, measure: list[int] | None = None,
+               purpose: str = "") -> str:
     """Execute Python code in a secure sandbox.
 
     Use this tool to edit the deck workspace or for general computation.
@@ -691,33 +667,42 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
     All files are accessible via normal file I/O (open, read, write).
     If save=True, all modified/new workspace files are written back to S3.
 
+    If measure is provided (list of 1-based slide numbers), text bounding box
+    measurement is performed after code execution. Builds PPTX from the current
+    presentation.json, generates SVG via LibreOffice, and extracts bbox data.
+    Requires deck_id.
+
     If files are provided (S3 keys), they are downloaded and available by filename.
     Supported: text files (CSV, JSON, TXT, Markdown, Python). Binary files are not supported.
     Example: files=["uploads/tmp/user/abc/data.csv"] → accessible as "data.csv" in code.
 
     Examples:
-        Read:      run_python(code="import json; p=json.load(open('presentation.json')); print(len(p['slides']))", deck_id="abc")
-        Edit:      run_python(code="import json; p=json.load(open('presentation.json')); p['slides'].append({...}); json.dump(p, open('presentation.json','w'), ensure_ascii=False)", deck_id="abc", save=True)
-        Specs:     run_python(code="open('specs/brief.md','w').write('# Brief\\n...')", deck_id="abc", save=True)
-        Compute:   run_python(code="print(2**100)")
-        CSV:       run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",
-                              files=["uploads/tmp/user/x/data.csv"])
+        Edit + measure:  run_python(code="...", deck_id="abc", save=True, measure=[3, 5])
+        Edit only:       run_python(code="...", deck_id="abc", save=True)
+        Measure only:    run_python(code="print('ok')", deck_id="abc", measure=[1, 2])
+        Compute:         run_python(code="print(2**100)")
+        CSV:             run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",
+                                    files=["uploads/tmp/user/x/data.csv"])
 
     Args:
         code: Python code to execute.
         deck_id: Deck ID to load workspace from. Optional.
         save: If True, save modified workspace files back to S3. Requires deck_id.
         files: S3 keys of files to make available in the sandbox. Optional.
+        measure: List of 1-based slide numbers to measure after execution. Requires deck_id.
         purpose: Brief user-facing description of what this code does,
             written in the user's language (e.g. 'Analyzing slide structure',
             'Adding 3 comparison slides'). Shown in the UI.
 
     Returns:
-        Code execution output (stdout).
+        JSON string: {"output": "...", "measure": "...(if requested)"}
     """
+    if measure and not deck_id:
+        return json.dumps({"error": "measure requires deck_id"})
     if deck_id:
         _check_deck_access(deck_id, action="edit_slide" if save else "read")
-    return sandbox_mod.execute_in_sandbox(
+
+    output = sandbox_mod.execute_in_sandbox(
         code=code,
         storage=_storage,
         region=_region,
@@ -725,6 +710,43 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
         save=save,
         files=files,
     )
+
+    result: dict[str, str] = {"output": output}
+
+    # Post-processing: measure and/or WebP generation
+    if deck_id and (measure or save):
+        import asyncio
+        import shutil
+        import traceback
+
+        try:
+            from tools.generate import _prepare_workspace
+
+            user_id = _get_user_id()
+            tmpdir, slides, build_kwargs = _prepare_workspace(deck_id, user_id, _storage)
+            pptx_path = _build_pptx(tmpdir, slides, build_kwargs)
+
+            if measure:
+                try:
+                    result["measure"] = _run_measure(tmpdir, pptx_path, measure)
+                except Exception as e:
+                    result["measure"] = json.dumps({"error": str(e)})
+
+            if save:
+                try:
+                    asyncio.get_event_loop().create_task(
+                        _generate_webp_background(deck_id, pptx_path, tmpdir)
+                    )
+                except Exception:
+                    shutil.rmtree(tmpdir, ignore_errors=True)
+            else:
+                shutil.rmtree(tmpdir, ignore_errors=True)
+        except Exception as e:
+            logger.exception("run_python post-processing failed: deck=%s", deck_id)
+            if measure:
+                result["measure"] = json.dumps({"error": str(e), "traceback": traceback.format_exc()})
+
+    return json.dumps(result, ensure_ascii=False)
 
 
 @mcp.tool()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -423,36 +423,6 @@ def _run_measure(tmpdir: Path, pptx_path: Path, slide_numbers: list[int]) -> str
     return format_measure_report(results)
 
 
-async def _generate_webp_background(deck_id: str, pptx_path: Path, tmpdir: Path) -> None:
-    """Background WebP preview generation → S3 upload → tmpdir cleanup."""
-    import shutil
-    import tempfile
-
-    from tools.generate import generate_previews
-
-    try:
-        preview_dir = Path(tempfile.mkdtemp())
-        try:
-            old_keys = _storage.list_files(prefix=f"previews/{deck_id}/", bucket=_storage.pptx_bucket)
-            epoch = int(__import__("time").time())
-            webp_files = generate_previews(pptx_path, preview_dir)
-            for i, webp_path in enumerate(webp_files):
-                s3_key = f"previews/{deck_id}/slide_{i + 1:02d}_{epoch}.webp"
-                _storage.upload_file(key=s3_key, data=webp_path.read_bytes(), content_type="image/webp")
-            for key in old_keys:
-                try:
-                    _storage._s3.delete_object(Bucket=_storage.pptx_bucket, Key=key)
-                except Exception:
-                    logger.warning("Failed to delete old preview key: %s", key)
-            logger.info("WebP previews uploaded: %d slides for deck %s", len(webp_files), deck_id)
-        finally:
-            shutil.rmtree(preview_dir, ignore_errors=True)
-    except Exception as e:
-        logger.warning("WebP generation failed for deck %s: %s", deck_id, e)
-    finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
-
-
 # --- Asset Tools ---
 
 
@@ -651,7 +621,7 @@ def code_to_slide(deck_id: str, code: str, name: str,
 
 @mcp.tool()
 def run_python(code: str, deck_id: str | None = None, save: bool = False,
-               files: list[str] | None = None, measure: list[int] | None = None,
+               files: list[str] | None = None, check: list[int] | None = None,
                purpose: str = "") -> str:
     """Execute Python code in a secure sandbox.
 
@@ -667,38 +637,39 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
     All files are accessible via normal file I/O (open, read, write).
     If save=True, all modified/new workspace files are written back to S3.
 
-    If measure is provided (list of 1-based slide numbers), text bounding box
-    measurement is performed after code execution. Builds PPTX from the current
-    presentation.json, generates SVG via LibreOffice, and extracts bbox data.
-    Requires deck_id.
+    If check is provided (list of 1-based slide numbers), the following
+    validations run after code execution (requires deck_id):
+        - Text bbox measurement (overflow detection via LibreOffice SVG)
+        - Lint diagnostics (JSON schema validation)
+        - Layout bias detection
 
     If files are provided (S3 keys), they are downloaded and available by filename.
     Supported: text files (CSV, JSON, TXT, Markdown, Python). Binary files are not supported.
     Example: files=["uploads/tmp/user/abc/data.csv"] → accessible as "data.csv" in code.
 
     Examples:
-        Edit + measure:  run_python(code="...", deck_id="abc", save=True, measure=[3, 5])
-        Edit only:       run_python(code="...", deck_id="abc", save=True)
-        Measure only:    run_python(code="print('ok')", deck_id="abc", measure=[1, 2])
-        Compute:         run_python(code="print(2**100)")
-        CSV:             run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",
-                                    files=["uploads/tmp/user/x/data.csv"])
+        Edit + check:  run_python(code="...", deck_id="abc", save=True, check=[3, 5])
+        Edit only:     run_python(code="...", deck_id="abc", save=True)
+        Check only:    run_python(code="print('ok')", deck_id="abc", check=[1, 2])
+        Compute:       run_python(code="print(2**100)")
+        CSV:           run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",
+                                  files=["uploads/tmp/user/x/data.csv"])
 
     Args:
         code: Python code to execute.
         deck_id: Deck ID to load workspace from. Optional.
         save: If True, save modified workspace files back to S3. Requires deck_id.
         files: S3 keys of files to make available in the sandbox. Optional.
-        measure: List of 1-based slide numbers to measure after execution. Requires deck_id.
+        check: List of 1-based slide numbers to validate after execution. Requires deck_id.
         purpose: Brief user-facing description of what this code does,
             written in the user's language (e.g. 'Analyzing slide structure',
             'Adding 3 comparison slides'). Shown in the UI.
 
     Returns:
-        JSON string: {"output": "...", "measure": "...(if requested)"}
+        JSON string: {"output", "measure"?, "errors"?, "warnings"?}
     """
-    if measure and not deck_id:
-        return json.dumps({"error": "measure requires deck_id"})
+    if check and not deck_id:
+        return json.dumps({"error": "check requires deck_id"})
     if deck_id:
         _check_deck_access(deck_id, action="edit_slide" if save else "read")
 
@@ -711,11 +682,10 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
         files=files,
     )
 
-    result: dict[str, str] = {"output": output}
+    result: dict = {"output": output}
 
-    # Post-processing: measure and/or WebP generation
-    if deck_id and (measure or save):
-        import asyncio
+    # Post-processing: check and/or WebP generation
+    if deck_id and (check or save):
         import shutil
         import traceback
 
@@ -726,24 +696,40 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
             tmpdir, slides, build_kwargs = _prepare_workspace(deck_id, user_id, _storage)
             pptx_path = _build_pptx(tmpdir, slides, build_kwargs)
 
-            if measure:
+            if check:
+                # Measure
                 try:
-                    result["measure"] = _run_measure(tmpdir, pptx_path, measure)
+                    result["measure"] = _run_measure(tmpdir, pptx_path, check)
                 except Exception as e:
                     result["measure"] = json.dumps({"error": str(e)})
 
-            if save:
+                # Lint
                 try:
-                    asyncio.get_event_loop().create_task(
-                        _generate_webp_background(deck_id, pptx_path, tmpdir)
-                    )
-                except Exception:
-                    shutil.rmtree(tmpdir, ignore_errors=True)
+                    from sdpm.schema.lint import lint as lint_slides
+                    presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
+                    lint_diag = lint_slides(presentation)
+                    if lint_diag:
+                        result["errors"] = {"lintDiagnostics": lint_diag}
+                except Exception as e:
+                    logger.warning("Lint failed: %s", e)
+
+                # Layout bias
+                try:
+                    from sdpm.preview import check_layout_imbalance_data
+                    layout_bias = check_layout_imbalance_data(pptx_path, slide_defs=slides)
+                    if layout_bias:
+                        result["warnings"] = {"layoutBias": layout_bias}
+                except Exception as e:
+                    logger.warning("Layout bias check failed: %s", e)
+
+            if save:
+                from server_utils import schedule_webp_background
+                schedule_webp_background(deck_id, pptx_path, tmpdir, _storage)
             else:
                 shutil.rmtree(tmpdir, ignore_errors=True)
         except Exception as e:
             logger.exception("run_python post-processing failed: deck=%s", deck_id)
-            if measure:
+            if check:
                 result["measure"] = json.dumps({"error": str(e), "traceback": traceback.format_exc()})
 
     return json.dumps(result, ensure_ascii=False)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -637,19 +637,20 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
     All files are accessible via normal file I/O (open, read, write).
     If save=True, all modified/new workspace files are written back to S3.
 
-    If check is provided (list of 1-based slide numbers), the following
-    validations run after code execution (requires deck_id):
+    **Always specify check when editing slides.** check runs validation after
+    code execution (requires deck_id):
         - Text bbox measurement (overflow detection via LibreOffice SVG)
         - Lint diagnostics (JSON schema validation)
         - Layout bias detection
+    Pass the 1-based slide numbers you edited, e.g. check=[3, 5].
 
     If files are provided (S3 keys), they are downloaded and available by filename.
     Supported: text files (CSV, JSON, TXT, Markdown, Python). Binary files are not supported.
     Example: files=["uploads/tmp/user/abc/data.csv"] → accessible as "data.csv" in code.
 
     Examples:
-        Edit + check:  run_python(code="...", deck_id="abc", save=True, check=[3, 5])
-        Edit only:     run_python(code="...", deck_id="abc", save=True)
+        Edit slides:   run_python(code="...", deck_id="abc", save=True, check=[3, 5])
+        Edit specs:    run_python(code="open('specs/brief.md','w').write('...')", deck_id="abc", save=True)
         Check only:    run_python(code="print('ok')", deck_id="abc", check=[1, 2])
         Compute:       run_python(code="print(2**100)")
         CSV:           run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -621,7 +621,7 @@ def code_to_slide(deck_id: str, code: str, name: str,
 
 @mcp.tool()
 def run_python(code: str, deck_id: str | None = None, save: bool = False,
-               files: list[str] | None = None, check: list[int] | None = None,
+               files: list[str] | None = None, measure_slides: list[int] | None = None,
                purpose: str = "") -> str:
     """Execute Python code in a secure sandbox.
 
@@ -637,21 +637,21 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
     All files are accessible via normal file I/O (open, read, write).
     If save=True, all modified/new workspace files are written back to S3.
 
-    **Always specify check when editing slides.** check runs validation after
+    **Always specify measure_slides when editing slides.** Runs validation after
     code execution (requires deck_id):
         - Text bbox measurement (overflow detection via LibreOffice SVG)
         - Lint diagnostics (JSON schema validation)
         - Layout bias detection
-    Pass the 1-based slide numbers you edited, e.g. check=[3, 5].
+    Pass the 1-based slide numbers you edited, e.g. measure_slides=[3, 5].
 
     If files are provided (S3 keys), they are downloaded and available by filename.
     Supported: text files (CSV, JSON, TXT, Markdown, Python). Binary files are not supported.
     Example: files=["uploads/tmp/user/abc/data.csv"] → accessible as "data.csv" in code.
 
     Examples:
-        Edit slides:   run_python(code="...", deck_id="abc", save=True, check=[3, 5])
+        Edit slides:   run_python(code="...", deck_id="abc", save=True, measure_slides=[3, 5])
         Edit specs:    run_python(code="open('specs/brief.md','w').write('...')", deck_id="abc", save=True)
-        Check only:    run_python(code="print('ok')", deck_id="abc", check=[1, 2])
+        Measure only:  run_python(code="print('ok')", deck_id="abc", measure_slides=[1, 2])
         Compute:       run_python(code="print(2**100)")
         CSV:           run_python(code="import pandas as pd; print(pd.read_csv('data.csv'))",
                                   files=["uploads/tmp/user/x/data.csv"])
@@ -661,7 +661,7 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
         deck_id: Deck ID to load workspace from. Optional.
         save: If True, save modified workspace files back to S3. Requires deck_id.
         files: S3 keys of files to make available in the sandbox. Optional.
-        check: List of 1-based slide numbers to validate after execution. Requires deck_id.
+        measure_slides: List of 1-based slide numbers to measure after execution. Requires deck_id.
         purpose: Brief user-facing description of what this code does,
             written in the user's language (e.g. 'Analyzing slide structure',
             'Adding 3 comparison slides'). Shown in the UI.
@@ -669,8 +669,8 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
     Returns:
         JSON string: {"output", "measure"?, "errors"?, "warnings"?}
     """
-    if check and not deck_id:
-        return json.dumps({"error": "check requires deck_id"})
+    if measure_slides and not deck_id:
+        return json.dumps({"error": "measure_slides requires deck_id"})
     if deck_id:
         _check_deck_access(deck_id, action="edit_slide" if save else "read")
 
@@ -685,9 +685,9 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
 
     result: dict = {"output": output}
 
-    # Post-processing: check triggers PPTX build → measure/lint/bias
-    # WebP preview generation runs when check is present and save=True
-    if deck_id and check:
+    # Post-processing: measure_slides triggers PPTX build → measure/lint/bias
+    # WebP preview generation runs when measure_slides is present and save=True
+    if deck_id and measure_slides:
         import shutil
         import traceback
 
@@ -700,25 +700,25 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
 
             # Measure
             try:
-                result["measure"] = _run_measure(tmpdir, pptx_path, check)
+                result["measure"] = _run_measure(tmpdir, pptx_path, measure_slides)
             except Exception as e:
                 result["measure"] = json.dumps({"error": str(e)})
 
-            # Lint (filter to checked slides; lint uses 0-based index)
+            # Lint (filter to measured slides; lint uses 0-based index)
             try:
                 from sdpm.schema.lint import lint as lint_slides
                 presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
-                check_set = set(check)
-                lint_diag = [d for d in lint_slides(presentation) if d.get("slide") + 1 in check_set]
+                slide_set = set(measure_slides)
+                lint_diag = [d for d in lint_slides(presentation) if d.get("slide") + 1 in slide_set]
                 if lint_diag:
                     result["errors"] = {"lintDiagnostics": lint_diag}
             except Exception as e:
                 logger.warning("Lint failed: %s", e)
 
-            # Layout bias (filter to checked slides; bias uses 1-based)
+            # Layout bias (filter to measured slides; bias uses 1-based)
             try:
                 from sdpm.preview import check_layout_imbalance_data
-                layout_bias = [b for b in check_layout_imbalance_data(pptx_path, slide_defs=slides) if b.get("slide") in check_set]
+                layout_bias = [b for b in check_layout_imbalance_data(pptx_path, slide_defs=slides) if b.get("slide") in slide_set]
                 if layout_bias:
                     result["warnings"] = {"layoutBias": layout_bias}
             except Exception as e:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -684,8 +684,9 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
 
     result: dict = {"output": output}
 
-    # Post-processing: check and/or WebP generation
-    if deck_id and (check or save):
+    # Post-processing: check triggers PPTX build → measure/lint/bias
+    # WebP preview generation runs when check is present and save=True
+    if deck_id and check:
         import shutil
         import traceback
 
@@ -696,32 +697,31 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
             tmpdir, slides, build_kwargs = _prepare_workspace(deck_id, user_id, _storage)
             pptx_path = _build_pptx(tmpdir, slides, build_kwargs)
 
-            if check:
-                # Measure
-                try:
-                    result["measure"] = _run_measure(tmpdir, pptx_path, check)
-                except Exception as e:
-                    result["measure"] = json.dumps({"error": str(e)})
+            # Measure
+            try:
+                result["measure"] = _run_measure(tmpdir, pptx_path, check)
+            except Exception as e:
+                result["measure"] = json.dumps({"error": str(e)})
 
-                # Lint (filter to checked slides; lint uses 0-based index)
-                try:
-                    from sdpm.schema.lint import lint as lint_slides
-                    presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
-                    check_set = set(check)
-                    lint_diag = [d for d in lint_slides(presentation) if d.get("slide") + 1 in check_set]
-                    if lint_diag:
-                        result["errors"] = {"lintDiagnostics": lint_diag}
-                except Exception as e:
-                    logger.warning("Lint failed: %s", e)
+            # Lint (filter to checked slides; lint uses 0-based index)
+            try:
+                from sdpm.schema.lint import lint as lint_slides
+                presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
+                check_set = set(check)
+                lint_diag = [d for d in lint_slides(presentation) if d.get("slide") + 1 in check_set]
+                if lint_diag:
+                    result["errors"] = {"lintDiagnostics": lint_diag}
+            except Exception as e:
+                logger.warning("Lint failed: %s", e)
 
-                # Layout bias (filter to checked slides; bias uses 1-based)
-                try:
-                    from sdpm.preview import check_layout_imbalance_data
-                    layout_bias = [b for b in check_layout_imbalance_data(pptx_path, slide_defs=slides) if b.get("slide") in check_set]
-                    if layout_bias:
-                        result["warnings"] = {"layoutBias": layout_bias}
-                except Exception as e:
-                    logger.warning("Layout bias check failed: %s", e)
+            # Layout bias (filter to checked slides; bias uses 1-based)
+            try:
+                from sdpm.preview import check_layout_imbalance_data
+                layout_bias = [b for b in check_layout_imbalance_data(pptx_path, slide_defs=slides) if b.get("slide") in check_set]
+                if layout_bias:
+                    result["warnings"] = {"layoutBias": layout_bias}
+            except Exception as e:
+                logger.warning("Layout bias check failed: %s", e)
 
             if save:
                 from server_utils import schedule_webp_background
@@ -730,8 +730,7 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
                 shutil.rmtree(tmpdir, ignore_errors=True)
         except Exception as e:
             logger.exception("run_python post-processing failed: deck=%s", deck_id)
-            if check:
-                result["measure"] = json.dumps({"error": str(e), "traceback": traceback.format_exc()})
+            result["measure"] = json.dumps({"error": str(e), "traceback": traceback.format_exc()})
 
     return json.dumps(result, ensure_ascii=False)
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -703,20 +703,21 @@ def run_python(code: str, deck_id: str | None = None, save: bool = False,
                 except Exception as e:
                     result["measure"] = json.dumps({"error": str(e)})
 
-                # Lint
+                # Lint (filter to checked slides; lint uses 0-based index)
                 try:
                     from sdpm.schema.lint import lint as lint_slides
                     presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
-                    lint_diag = lint_slides(presentation)
+                    check_set = set(check)
+                    lint_diag = [d for d in lint_slides(presentation) if d.get("slide") + 1 in check_set]
                     if lint_diag:
                         result["errors"] = {"lintDiagnostics": lint_diag}
                 except Exception as e:
                     logger.warning("Lint failed: %s", e)
 
-                # Layout bias
+                # Layout bias (filter to checked slides; bias uses 1-based)
                 try:
                     from sdpm.preview import check_layout_imbalance_data
-                    layout_bias = check_layout_imbalance_data(pptx_path, slide_defs=slides)
+                    layout_bias = [b for b in check_layout_imbalance_data(pptx_path, slide_defs=slides) if b.get("slide") in check_set]
                     if layout_bias:
                         result["warnings"] = {"layoutBias": layout_bias}
                 except Exception as e:

--- a/mcp-server/server_utils.py
+++ b/mcp-server/server_utils.py
@@ -3,9 +3,7 @@
 """Shared server utilities for background tasks."""
 
 import asyncio
-import json
 import logging
-import os
 import shutil
 import tempfile
 from pathlib import Path

--- a/mcp-server/server_utils.py
+++ b/mcp-server/server_utils.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Shared server utilities for background tasks."""
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from storage import Storage
+
+logger = logging.getLogger("sdpm.mcp")
+
+
+async def _generate_webp_background(
+    deck_id: str, pptx_path: Path, tmpdir: Path, storage: Storage,
+) -> None:
+    """Background WebP preview generation → S3 upload → tmpdir cleanup."""
+    from tools.generate import generate_previews
+
+    try:
+        preview_dir = Path(tempfile.mkdtemp())
+        try:
+            old_keys = storage.list_files(prefix=f"previews/{deck_id}/", bucket=storage.pptx_bucket)
+            epoch = int(__import__("time").time())
+            webp_files = generate_previews(pptx_path, preview_dir)
+            for i, webp_path in enumerate(webp_files):
+                s3_key = f"previews/{deck_id}/slide_{i + 1:02d}_{epoch}.webp"
+                storage.upload_file(key=s3_key, data=webp_path.read_bytes(), content_type="image/webp")
+            for key in old_keys:
+                try:
+                    storage._s3.delete_object(Bucket=storage.pptx_bucket, Key=key)
+                except Exception:
+                    logger.warning("Failed to delete old preview key: %s", key)
+            logger.info("WebP previews uploaded: %d slides for deck %s", len(webp_files), deck_id)
+        finally:
+            shutil.rmtree(preview_dir, ignore_errors=True)
+    except Exception as e:
+        logger.warning("WebP generation failed for deck %s: %s", deck_id, e)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def schedule_webp_background(
+    deck_id: str, pptx_path: Path, tmpdir: Path, storage: Storage,
+) -> None:
+    """Schedule background WebP generation. Falls back to tmpdir cleanup on error."""
+    try:
+        asyncio.get_event_loop().create_task(
+            _generate_webp_background(deck_id, pptx_path, tmpdir, storage)
+        )
+    except Exception:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/mcp-server/tools/generate.py
+++ b/mcp-server/tools/generate.py
@@ -20,7 +20,6 @@ import re
 import shutil
 import subprocess
 import tempfile
-import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -241,27 +240,12 @@ def generate_pptx(
             "pptxS3Key": pptx_key, "updatedAt": now, "slideCount": len(slides),
         })
 
-        # Preview: epoch-keyed WebP + delete all old keys
-        try:
-            preview_dir = Path(tempfile.mkdtemp())
-            old_keys = storage.list_files(prefix=f"previews/{deck_id}/", bucket=storage.pptx_bucket)
-            epoch = int(time.time())
-            webp_files = generate_previews(out, preview_dir)
-            for i, webp_path in enumerate(webp_files):
-                s3_key = f"previews/{deck_id}/slide_{i + 1:02d}_{epoch}.webp"
-                storage.upload_file(key=s3_key, data=webp_path.read_bytes(), content_type="image/webp")
-            for key in old_keys:
-                try:
-                    storage._s3.delete_object(Bucket=storage.pptx_bucket, Key=key)
-                except Exception:
-                    logger.warning("Failed to delete old preview key: %s", key)
-            logger.info("Preview generation complete: %d pages for deck %s", len(webp_files), deck_id)
-        except Exception as e:
-            logger.warning("Preview generation failed for deck %s: %s", deck_id, e)
-        finally:
-            shutil.rmtree(preview_dir, ignore_errors=True)
-    finally:
+        # Preview: epoch-keyed WebP (background)
+        from server_utils import schedule_webp_background
+        schedule_webp_background(deck_id, out, tmpdir, storage)
+    except Exception:
         shutil.rmtree(tmpdir, ignore_errors=True)
+        raise
 
     # KB sync
     kb_error: str | None = None

--- a/mcp-server/tools/generate.py
+++ b/mcp-server/tools/generate.py
@@ -204,11 +204,6 @@ def generate_pptx(
     try:
         builder = PPTXBuilder(**build_kwargs)
 
-        # Lint slide JSON
-        from sdpm.schema.lint import lint as lint_slides
-        presentation = json.loads((tmpdir / "presentation.json").read_text(encoding="utf-8"))
-        lint_diagnostics = lint_slides(presentation)
-
         # Build id_map for resolve_override
         id_map: dict[str, dict] = {}
         for s in slides:
@@ -221,10 +216,6 @@ def generate_pptx(
 
         out = tmpdir / "output.pptx"
         builder.save(out)
-
-        # Detect layout bias
-        from sdpm.preview import check_layout_imbalance_data
-        layout_bias = check_layout_imbalance_data(out, slide_defs=slides)
 
         # Upload PPTX to S3
         pptx_key = f"pptx/{deck_id}/{uuid.uuid4()}.pptx"
@@ -261,12 +252,6 @@ def generate_pptx(
         except Exception as e:
             kb_error = str(e)
 
-    warnings: dict = {}
-    if layout_bias:
-        warnings["layoutBias"] = layout_bias
-    if kb_error:
-        warnings["kbSyncFailed"] = kb_error
-
     result: dict = {
         "status": "completed",
         "slideCount": len(slides),
@@ -275,8 +260,6 @@ def generate_pptx(
             for i, s in enumerate(slides, 1)
         ],
     }
-    if warnings:
-        result["warnings"] = warnings
-    if lint_diagnostics:
-        result["errors"] = {"lintDiagnostics": lint_diagnostics}
+    if kb_error:
+        result["warnings"] = {"kbSyncFailed": kb_error}
     return result

--- a/web-ui/next.config.ts
+++ b/web-ui/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  bundler: "webpack",
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

Merge the measure_slides tool into run_python as a measure_slides parameter, eliminating the extra tool call that was required after
every slide edit. Also background-ifies WebP preview generation in generate_pptx and removes redundant lint/layout-bias checks from the
generation pipeline.

## Motivation

- Editing a slide always required two sequential tool calls: run_python(save=True) → measure_slides(). The round-trip overhead was
significant.
- generate_pptx ran WebP preview generation synchronously, delaying the response unnecessarily.
- Lint and layout bias were only surfaced at generate_pptx time — too late to fix cheaply.

## Changes

| File | Change |
|------|--------|
| mcp-server/server.py | Add measure_slides param to run_python; remove measure_slides tool; extract _build_pptx, _run_measure helpers;
JSON-structured response |
| mcp-server/server_utils.py | New shared module: schedule_webp_background for async WebP generation |
| mcp-server/tools/generate.py | Background WebP generation; remove lint/layout-bias (now in run_python) |
| mcp-server/Dockerfile | Add COPY server_utils.py |
| web-ui/next.config.ts | Use webpack bundler for ARM64 CodeBuild compatibility (Next.js 16 Turbopack fix) |

## run_python new behavior

| save | measure_slides | behavior |
|------|---------------|----------|
| False | None | Code execution only |
| False | [3,5] | Code execution + measure + lint + layout bias |
| True | None | Code execution + save |
| True | [3,5] | Code execution + save + measure + lint + bias + WebP (background) |

## Response format

json
{"output": "stdout", "measure": "report", "errors": {"lintDiagnostics": [...]}, "warnings": {"layoutBias": [...]}}


Keys measure, errors, warnings are present only when measure_slides is specified and relevant data exists.

## Testing

Deployed to ap-northeast-1 and verified end-to-end.