### PR TITLE
fix: add cdk bootstrap to buildspec before deploy

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,4 +42,6 @@ phases:
           echo "Building web-ui..."
           cd web-ui && npm ci && npm run build && cd ..
         fi
-      - cd infra && cdk ${CDK_COMMAND:-deploy} --all --require-approval never
+      # Bootstrap CDK if not already done (idempotent)
+      - cd infra && cdk bootstrap --quiet || true
+      - cdk ${CDK_COMMAND:-deploy} --all --require-approval never


### PR DESCRIPTION
Ensures CDKToolkit stack exists before `cdk deploy`. Runs `cdk bootstrap --quiet` unconditionally (idempotent, upgrades if needed).

Without this, first-time deployments to a new account/region fail because CDKToolkit is missing.