### PR TITLE
feat: add blog draft CI — label enforcement + Kiro CLI headless generation

### DIFF
--- a/.ash.yaml
+++ b/.ash.yaml
@@ -218,3 +218,15 @@ global_settings:
         Uses public.ecr.aws/docker/library/python:3.13-slim from
         ECR Public Gallery. This is the official Python image mirror on ECR.
       expiration: "2027-03-29"
+
+    # --- GitHub Actions workflow_dispatch inputs ---
+    # blog-draft.yml requires user-provided PR numbers to select which PRs
+    # to generate a blog draft from. This is by design, not a supply chain risk.
+
+    - rule_id: "CKV_GHA_7"
+      path: ".github/workflows/blog-draft.yml"
+      reason: >
+        workflow_dispatch inputs (pr_numbers, blog_theme) are required for
+        PR selection. Inputs are used only via env: variables to prevent
+        shell injection. Not a supply chain concern.
+      expiration: "2027-03-29"

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -1,4 +1,3 @@
-# checkov:skip=CKV_GHA_7: workflow_dispatch inputs are required for PR number selection
 name: Blog draft
 
 on:

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -44,13 +44,25 @@ jobs:
           echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
           echo "Branch: ${BRANCH_NAME}"
 
+      - name: Clone zenn-blog (instruction + push target)
+        env:
+          BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${BLOG_REPO_TOKEN}@github.com/okamoto-aws/zenn-blog.git" /tmp/zenn-blog
+
       - name: Generate blog draft with Kiro CLI
         env:
           KIRO_API_KEY: ${{ secrets.KIRO_API_KEY }}
           PR_NUMBERS: ${{ inputs.pr_numbers }}
           BLOG_THEME: ${{ inputs.blog_theme }}
         run: |
-          # Build prompt
+          # Load instruction from private repo (if exists)
+          INSTRUCTION=""
+          if [ -f /tmp/zenn-blog/instruction.md ]; then
+            INSTRUCTION=$(cat /tmp/zenn-blog/instruction.md)
+          fi
+
+          # Build PR data
           PR_DATA=""
           for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
             META=$(cat "/tmp/pr-data/pr-${pr}-meta.json")
@@ -69,18 +81,9 @@ jobs:
             THEME_INSTRUCTION="テーマ/切り口: ${BLOG_THEME}"
           fi
 
-          PROMPT="あなたはAWS Solutions Architectのテックブロガーです。
-          以下のPRの内容をもとに、Zenn (zenn.dev/aws_japan) 向けの日本語ブログ記事をドラフトしてください。
+          PROMPT="${INSTRUCTION}
 
           ${THEME_INSTRUCTION}
-
-          要件:
-          - Zennのfrontmatter (title, emoji, type, topics, published: false, publication_name: aws_japan) を含める
-          - 技術的に正確で、具体的なユースケースを交えて説明する
-          - コードブロックや設定例があれば含める
-          - 「この記事は個人の見解であり、所属する組織の公式見解ではありません。」を冒頭に入れる
-          - 画像が必要な箇所は <!-- TODO: [📸 画像プレースホルダ] 説明 --> で示す
-          - ファイル名は slug 形式で出力の最初の行に記載: filename: sdpm-xxx.md
 
           PR データ:
           ${PR_DATA}
@@ -118,8 +121,6 @@ jobs:
           FILENAME=$(cat /tmp/blog-filename.txt)
           REPO="okamoto-aws/zenn-blog"
 
-          # Clone zenn-blog
-          git clone "https://x-access-token:${BLOG_REPO_TOKEN}@github.com/${REPO}.git" /tmp/zenn-blog
           cd /tmp/zenn-blog
           git checkout publish
           git checkout -b "$BRANCH_NAME"

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -1,0 +1,180 @@
+name: Blog draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: 'PR numbers (comma-separated, e.g. 42,57,63)'
+        required: true
+      blog_theme:
+        description: 'Blog theme/angle (optional)'
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Kiro CLI
+        run: curl -fsSL https://cli.kiro.dev/install | bash
+
+      - name: Collect PR data
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+        run: |
+          mkdir -p /tmp/pr-data
+          BRANCH_PARTS=""
+          for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
+            echo "--- Collecting PR #${pr} ---"
+            gh pr view "$pr" --json title,body,number --jq '{title,body,number}' > "/tmp/pr-data/pr-${pr}-meta.json"
+            gh pr diff "$pr" > "/tmp/pr-data/pr-${pr}.diff"
+            BRANCH_PARTS="${BRANCH_PARTS}${pr}-"
+          done
+          # Generate branch name slug from first PR title
+          FIRST_PR=$(echo "$PR_NUMBERS" | cut -d',' -f1)
+          SLUG=$(gh pr view "$FIRST_PR" --json title --jq '.title' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 40)
+          BRANCH_NAME="sdpm/pr${BRANCH_PARTS}${SLUG}"
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Branch: ${BRANCH_NAME}"
+
+      - name: Generate blog draft with Kiro CLI
+        env:
+          KIRO_API_KEY: ${{ secrets.KIRO_API_KEY }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+          BLOG_THEME: ${{ inputs.blog_theme }}
+        run: |
+          # Build prompt
+          PR_DATA=""
+          for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
+            META=$(cat "/tmp/pr-data/pr-${pr}-meta.json")
+            DIFF=$(head -c 50000 "/tmp/pr-data/pr-${pr}.diff")
+            PR_DATA="${PR_DATA}
+          === PR #${pr} ===
+          ${META}
+
+          Diff (truncated):
+          ${DIFF}
+          "
+          done
+
+          THEME_INSTRUCTION=""
+          if [ -n "$BLOG_THEME" ]; then
+            THEME_INSTRUCTION="テーマ/切り口: ${BLOG_THEME}"
+          fi
+
+          PROMPT="あなたはAWS Solutions Architectのテックブロガーです。
+          以下のPRの内容をもとに、Zenn (zenn.dev/aws_japan) 向けの日本語ブログ記事をドラフトしてください。
+
+          ${THEME_INSTRUCTION}
+
+          要件:
+          - Zennのfrontmatter (title, emoji, type, topics, published: false, publication_name: aws_japan) を含める
+          - 技術的に正確で、具体的なユースケースを交えて説明する
+          - コードブロックや設定例があれば含める
+          - 「この記事は個人の見解であり、所属する組織の公式見解ではありません。」を冒頭に入れる
+          - 画像が必要な箇所は <!-- TODO: [📸 画像プレースホルダ] 説明 --> で示す
+          - ファイル名は slug 形式で出力の最初の行に記載: filename: sdpm-xxx.md
+
+          PR データ:
+          ${PR_DATA}
+
+          Markdown のみを出力してください。"
+
+          kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
+
+          # Extract markdown content (lines starting with "> " are the response)
+          grep '^> ' /tmp/blog-draft-raw.txt | sed 's/^> //' > /tmp/blog-draft.md
+          # Continuation lines (no "> " prefix)
+          # Use the full stdout as fallback if grep finds nothing
+          if [ ! -s /tmp/blog-draft.md ]; then
+            cp /tmp/blog-draft-raw.txt /tmp/blog-draft.md
+          fi
+
+          # Extract filename from first line if present
+          FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")
+          if [ -z "$FILENAME" ]; then
+            FILENAME="sdpm-draft-$(date +%Y%m%d).md"
+          fi
+          echo "$FILENAME" > /tmp/blog-filename.txt
+
+          # Remove the filename directive line from content
+          sed -i '/^filename:/d' /tmp/blog-draft.md
+
+          echo "Generated: $FILENAME ($(wc -c < /tmp/blog-draft.md) bytes)"
+
+      - name: Push to zenn-blog and create PR
+        env:
+          BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
+          BRANCH_NAME: ${{ steps.collect.outputs.branch_name }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+        run: |
+          FILENAME=$(cat /tmp/blog-filename.txt)
+          REPO="okamoto-aws/zenn-blog"
+
+          # Clone zenn-blog
+          git clone "https://x-access-token:${BLOG_REPO_TOKEN}@github.com/${REPO}.git" /tmp/zenn-blog
+          cd /tmp/zenn-blog
+          git checkout publish
+          git checkout -b "$BRANCH_NAME"
+
+          # Copy draft
+          cp /tmp/blog-draft.md "articles/${FILENAME}"
+          git add "articles/${FILENAME}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          PR_LIST=$(echo "$PR_NUMBERS" | tr ',' ' ' | xargs -I{} echo "- https://github.com/${{ github.repository }}/pull/{}")
+          git commit -m "📝 Blog draft: ${FILENAME}
+
+          Source PRs:
+          ${PR_LIST}"
+
+          git push origin "$BRANCH_NAME"
+
+          # Create PR
+          PR_URL=$(gh pr create \
+            --repo "$REPO" \
+            --base publish \
+            --head "$BRANCH_NAME" \
+            --title "📝 Blog draft: ${FILENAME}" \
+            --body "Auto-generated blog draft from SDPM CI.
+
+          **Source PRs:**
+          ${PR_LIST}
+
+          **Theme:** ${{ inputs.blog_theme }}
+
+          ---
+          Review, edit, and merge to publish on Zenn." \
+            2>&1)
+
+          echo "$PR_URL" > /tmp/blog-pr-url.txt
+          echo "PR created: $PR_URL"
+
+      - name: Label source PRs as blog:done
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
+        run: |
+          for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
+            gh pr edit "$pr" --remove-label "blog:pending" --add-label "blog:done" 2>/dev/null || true
+            echo "Labeled PR #${pr} as blog:done"
+          done
+
+      - name: Notify Slack
+        if: always() && secrets.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          PR_URL=$(cat /tmp/blog-pr-url.txt 2>/dev/null || echo "N/A")
+          SUBJECT="📝 Blog draft ready: PR ${{ inputs.pr_numbers }}"
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "{\"subject\":\"${SUBJECT}\",\"url\":\"${PR_URL}\"}"

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -1,3 +1,4 @@
+# checkov:skip=CKV_GHA_7: workflow_dispatch inputs are required for PR number selection
 name: Blog draft
 
 on:
@@ -37,14 +38,12 @@ jobs:
             gh pr diff "$pr" > "/tmp/pr-data/pr-${pr}.diff"
             BRANCH_PARTS="${BRANCH_PARTS}${pr}-"
           done
-          # Generate branch name slug from first PR title
           FIRST_PR=$(echo "$PR_NUMBERS" | cut -d',' -f1)
           SLUG=$(gh pr view "$FIRST_PR" --json title --jq '.title' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 40)
           BRANCH_NAME="sdpm/pr${BRANCH_PARTS}${SLUG}"
           echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Branch: ${BRANCH_NAME}"
 
-      - name: Clone blog repo (instruction + push target)
+      - name: Clone blog repo
         env:
           BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
           BLOG_REPO: ${{ secrets.BLOG_REPO }}
@@ -57,13 +56,11 @@ jobs:
           PR_NUMBERS: ${{ inputs.pr_numbers }}
           BLOG_THEME: ${{ inputs.blog_theme }}
         run: |
-          # Load instruction from private repo (if exists)
           INSTRUCTION=""
           if [ -f /tmp/zenn-blog/instruction.md ]; then
             INSTRUCTION=$(cat /tmp/zenn-blog/instruction.md)
           fi
 
-          # Build PR data
           PR_DATA=""
           for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
             META=$(cat "/tmp/pr-data/pr-${pr}-meta.json")
@@ -93,32 +90,27 @@ jobs:
 
           kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
 
-          # Extract markdown content (lines starting with "> " are the response)
           grep '^> ' /tmp/blog-draft-raw.txt | sed 's/^> //' > /tmp/blog-draft.md
-          # Continuation lines (no "> " prefix)
-          # Use the full stdout as fallback if grep finds nothing
           if [ ! -s /tmp/blog-draft.md ]; then
             cp /tmp/blog-draft-raw.txt /tmp/blog-draft.md
           fi
 
-          # Extract filename from first line if present
           FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")
           if [ -z "$FILENAME" ]; then
             FILENAME="sdpm-draft-$(date +%Y%m%d).md"
           fi
           echo "$FILENAME" > /tmp/blog-filename.txt
-
-          # Remove the filename directive line from content
           sed -i '/^filename:/d' /tmp/blog-draft.md
-
-          echo "Generated: $FILENAME ($(wc -c < /tmp/blog-draft.md) bytes)"
 
       - name: Push to blog repo and create PR
         env:
           BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
           BLOG_REPO: ${{ secrets.BLOG_REPO }}
           BRANCH_NAME: ${{ steps.collect.outputs.branch_name }}
           PR_NUMBERS: ${{ inputs.pr_numbers }}
+          BLOG_THEME: ${{ inputs.blog_theme }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           FILENAME=$(cat /tmp/blog-filename.txt)
 
@@ -126,13 +118,12 @@ jobs:
           git checkout publish
           git checkout -b "$BRANCH_NAME"
 
-          # Copy draft
           cp /tmp/blog-draft.md "articles/${FILENAME}"
           git add "articles/${FILENAME}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          PR_LIST=$(echo "$PR_NUMBERS" | tr ',' ' ' | xargs -I{} echo "- https://github.com/${{ github.repository }}/pull/{}")
+          PR_LIST=$(echo "$PR_NUMBERS" | tr ',' ' ' | xargs -I{} echo "- https://github.com/${GITHUB_REPOSITORY}/pull/{}")
           git commit -m "📝 Blog draft: ${FILENAME}
 
           Source PRs:
@@ -140,7 +131,6 @@ jobs:
 
           git push origin "$BRANCH_NAME"
 
-          # Create PR
           PR_URL=$(gh pr create \
             --repo "$BLOG_REPO" \
             --base publish \
@@ -151,14 +141,13 @@ jobs:
           **Source PRs:**
           ${PR_LIST}
 
-          **Theme:** ${{ inputs.blog_theme }}
+          **Theme:** ${BLOG_THEME}
 
           ---
-          Review, edit, and merge to publish on Zenn." \
+          Review, edit, and merge to publish." \
             2>&1)
 
           echo "$PR_URL" > /tmp/blog-pr-url.txt
-          echo "PR created: $PR_URL"
 
       - name: Label source PRs as blog:done
         env:
@@ -167,16 +156,17 @@ jobs:
         run: |
           for pr in $(echo "$PR_NUMBERS" | tr ',' ' '); do
             gh pr edit "$pr" --remove-label "blog:pending" --add-label "blog:done" 2>/dev/null || true
-            echo "Labeled PR #${pr} as blog:done"
           done
 
       - name: Notify Slack
-        if: always() && secrets.SLACK_WEBHOOK_URL != ''
+        if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_NUMBERS: ${{ inputs.pr_numbers }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then exit 0; fi
           PR_URL=$(cat /tmp/blog-pr-url.txt 2>/dev/null || echo "N/A")
-          SUBJECT="📝 Blog draft ready: PR ${{ inputs.pr_numbers }}"
+          SUBJECT="📝 Blog draft ready: PR ${PR_NUMBERS}"
           curl -s -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{\"subject\":\"${SUBJECT}\",\"url\":\"${PR_URL}\"}"

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -44,11 +44,12 @@ jobs:
           echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
           echo "Branch: ${BRANCH_NAME}"
 
-      - name: Clone zenn-blog (instruction + push target)
+      - name: Clone blog repo (instruction + push target)
         env:
           BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
+          BLOG_REPO: ${{ secrets.BLOG_REPO }}
         run: |
-          git clone "https://x-access-token:${BLOG_REPO_TOKEN}@github.com/okamoto-aws/zenn-blog.git" /tmp/zenn-blog
+          git clone "https://x-access-token:${BLOG_REPO_TOKEN}@github.com/${BLOG_REPO}.git" /tmp/zenn-blog
 
       - name: Generate blog draft with Kiro CLI
         env:
@@ -112,14 +113,14 @@ jobs:
 
           echo "Generated: $FILENAME ($(wc -c < /tmp/blog-draft.md) bytes)"
 
-      - name: Push to zenn-blog and create PR
+      - name: Push to blog repo and create PR
         env:
           BLOG_REPO_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
+          BLOG_REPO: ${{ secrets.BLOG_REPO }}
           BRANCH_NAME: ${{ steps.collect.outputs.branch_name }}
           PR_NUMBERS: ${{ inputs.pr_numbers }}
         run: |
           FILENAME=$(cat /tmp/blog-filename.txt)
-          REPO="okamoto-aws/zenn-blog"
 
           cd /tmp/zenn-blog
           git checkout publish
@@ -141,7 +142,7 @@ jobs:
 
           # Create PR
           PR_URL=$(gh pr create \
-            --repo "$REPO" \
+            --repo "$BLOG_REPO" \
             --base publish \
             --head "$BRANCH_NAME" \
             --title "📝 Blog draft: ${FILENAME}" \

--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize]
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -1,0 +1,42 @@
+name: Require blog label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    # Skip for dependabot / renovate
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
+    steps:
+      - name: Check blog label
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -qE '"blog:(pending|skip)"'; then
+            echo "✅ Blog label found"
+          else
+            echo "::error::PR に blog:pending または blog:skip ラベルを付けてください"
+            exit 1
+          fi
+
+  auto-skip-bots:
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'renovate[bot]'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['blog:skip']
+            });


### PR DESCRIPTION
## Summary

PRマージ時のブログラベル必須化と、Kiro CLI headless によるブログドラフト自動生成ワークフロー。

## Changes

### `.github/workflows/require-blog-label.yml`
- PRに `blog:pending` または `blog:skip` ラベルがないとマージ不可
- dependabot/renovate の bot PR には自動で `blog:skip` を付与

### `.github/workflows/blog-draft.yml`
- `workflow_dispatch` で PR 番号をカンマ区切りで入力
- 各 PR の diff/title/body を収集し、Kiro CLI headless でブログドラフトを生成
- 生成したドラフトを別リポジトリにブランチ＆PRとして作成
- 元 PR に `blog:done` ラベルを付与
- Slack Webhook で通知

## Required Secrets
- `KIRO_API_KEY` — Kiro CLI headless 認証
- `BLOG_REPO_TOKEN` — ブログリポジトリへの push 用 Fine-grained PAT
- `SLACK_WEBHOOK_URL` — Slack 通知用