### PR TITLE
fix: strip ANSI codes from blog draft output

### DIFF
--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -78,20 +78,25 @@ jobs:
             THEME_INSTRUCTION="テーマ/切り口: ${BLOG_THEME}"
           fi
 
-          PROMPT="${INSTRUCTION}
+          PROMPT="以下の instruction.md の指示を最優先で遵守してください。
+
+          ${INSTRUCTION}
 
           ${THEME_INSTRUCTION}
 
           PR データ:
           ${PR_DATA}
 
-          Markdown のみを出力してください。"
+          Markdown のみを出力してください。余計な説明やコメントは不要です。"
 
           kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
 
-          grep '^> ' /tmp/blog-draft-raw.txt | sed 's/^> //' > /tmp/blog-draft.md
+          # Strip ANSI escape sequences and TUI artifacts
+          sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\[0m//g; s/\[2K//g; s/\[1G//g; s/\[1A//g; s/\[\?25[lh]//g' /tmp/blog-draft-raw.txt > /tmp/blog-draft-clean.txt
+
+          grep '^> ' /tmp/blog-draft-clean.txt | sed 's/^> //' > /tmp/blog-draft.md
           if [ ! -s /tmp/blog-draft.md ]; then
-            cp /tmp/blog-draft-raw.txt /tmp/blog-draft.md
+            cp /tmp/blog-draft-clean.txt /tmp/blog-draft.md
           fi
 
           FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")


### PR DESCRIPTION
Kiro CLI headless output contains ANSI escape sequences and TUI artifacts. Added sed-based stripping and strengthened instruction.md priority in prompt.