### PR TITLE
fix: blog draft — file output instead of stdout parsing

### DIFF
--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -78,20 +78,25 @@ jobs:
             THEME_INSTRUCTION="テーマ/切り口: ${BLOG_THEME}"
           fi
 
-          PROMPT="${INSTRUCTION}
+          PROMPT="以下の instruction.md の指示を最優先で遵守してください。
+
+          ${INSTRUCTION}
 
           ${THEME_INSTRUCTION}
 
           PR データ:
           ${PR_DATA}
 
-          Markdown のみを出力してください。"
+          Markdown のみを出力してください。余計な説明やコメントは不要です。"
 
           kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
 
-          grep '^> ' /tmp/blog-draft-raw.txt | sed 's/^> //' > /tmp/blog-draft.md
+          # Strip ANSI escape sequences and TUI artifacts
+          sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\[0m//g; s/\[2K//g; s/\[1G//g; s/\[1A//g; s/\[\?25[lh]//g' /tmp/blog-draft-raw.txt > /tmp/blog-draft-clean.txt
+
+          grep '^> ' /tmp/blog-draft-clean.txt | sed 's/^> //' > /tmp/blog-draft.md
           if [ ! -s /tmp/blog-draft.md ]; then
-            cp /tmp/blog-draft-raw.txt /tmp/blog-draft.md
+            cp /tmp/blog-draft-clean.txt /tmp/blog-draft.md
           fi
 
           FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -54,6 +54,8 @@ jobs:
           KIRO_API_KEY: ${{ secrets.KIRO_API_KEY }}
           PR_NUMBERS: ${{ inputs.pr_numbers }}
           BLOG_THEME: ${{ inputs.blog_theme }}
+          NO_COLOR: "1"
+          TERM: dumb
         run: |
           INSTRUCTION=""
           if [ -f /tmp/zenn-blog/instruction.md ]; then
@@ -91,13 +93,20 @@ jobs:
 
           kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
 
+          # Debug: show raw output size
+          echo "Raw output: $(wc -c < /tmp/blog-draft-raw.txt) bytes, $(wc -l < /tmp/blog-draft-raw.txt) lines"
+
           # Strip ANSI escape sequences and TUI artifacts
           sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\[0m//g; s/\[2K//g; s/\[1G//g; s/\[1A//g; s/\[\?25[lh]//g' /tmp/blog-draft-raw.txt > /tmp/blog-draft-clean.txt
+          echo "Clean output: $(wc -c < /tmp/blog-draft-clean.txt) bytes"
 
           grep '^> ' /tmp/blog-draft-clean.txt | sed 's/^> //' > /tmp/blog-draft.md
+          echo "Grep > lines: $(wc -c < /tmp/blog-draft.md) bytes"
           if [ ! -s /tmp/blog-draft.md ]; then
+            echo "No > lines found, using clean output as-is"
             cp /tmp/blog-draft-clean.txt /tmp/blog-draft.md
           fi
+          echo "Final output: $(wc -c < /tmp/blog-draft.md) bytes"
 
           FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")
           if [ -z "$FILENAME" ]; then

--- a/.github/workflows/blog-draft.yml
+++ b/.github/workflows/blog-draft.yml
@@ -89,24 +89,17 @@ jobs:
           PR データ:
           ${PR_DATA}
 
-          Markdown のみを出力してください。余計な説明やコメントは不要です。"
+          出力先: /tmp/blog-draft.md にMarkdownファイルとして書き出してください。
+          ファイルの1行目に filename: sdpm-xxx.md の形式でファイル名を記載してください。"
 
-          kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" > /tmp/blog-draft-raw.txt 2>/dev/null
+          kiro-cli chat --no-interactive --trust-all-tools "$PROMPT" 2>/dev/null
 
-          # Debug: show raw output size
-          echo "Raw output: $(wc -c < /tmp/blog-draft-raw.txt) bytes, $(wc -l < /tmp/blog-draft-raw.txt) lines"
+          echo "Output file: $(wc -c < /tmp/blog-draft.md 2>/dev/null || echo 'NOT FOUND') bytes"
 
-          # Strip ANSI escape sequences and TUI artifacts
-          sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g; s/\x1b\][^\x07]*\x07//g; s/\[0m//g; s/\[2K//g; s/\[1G//g; s/\[1A//g; s/\[\?25[lh]//g' /tmp/blog-draft-raw.txt > /tmp/blog-draft-clean.txt
-          echo "Clean output: $(wc -c < /tmp/blog-draft-clean.txt) bytes"
-
-          grep '^> ' /tmp/blog-draft-clean.txt | sed 's/^> //' > /tmp/blog-draft.md
-          echo "Grep > lines: $(wc -c < /tmp/blog-draft.md) bytes"
           if [ ! -s /tmp/blog-draft.md ]; then
-            echo "No > lines found, using clean output as-is"
-            cp /tmp/blog-draft-clean.txt /tmp/blog-draft.md
+            echo "::error::Kiro CLI did not produce /tmp/blog-draft.md"
+            exit 1
           fi
-          echo "Final output: $(wc -c < /tmp/blog-draft.md) bytes"
 
           FILENAME=$(head -5 /tmp/blog-draft.md | grep -oP 'filename:\s*\K\S+' || echo "")
           if [ -z "$FILENAME" ]; then


### PR DESCRIPTION
Kiro CLI stdout was empty or full of ANSI artifacts. Changed approach: instruct Kiro to write /tmp/blog-draft.md directly as a file.