### PR TITLE
fix: add blog:done label to require-blog-label workflow

### DIFF
--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -18,10 +18,10 @@ jobs:
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
-          if echo "$LABELS" | grep -qE '"blog:(pending|skip)"'; then
+          if echo "$LABELS" | grep -qE '"blog:(pending|skip|done)"'; then
             echo "✅ Blog label found"
           else
-            echo "::error::PR に blog:pending または blog:skip ラベルを付けてください"
+            echo "::error::PR に blog:pending または blog:skip または blog:done ラベルを付けてください"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Add `blog:done` to the accepted labels in the `require-blog-label` workflow.

## Changes

- Updated grep pattern to accept `blog:done` in addition to `blog:pending` and `blog:skip`
- Updated error message to include `blog:done` as a valid option