### PR TITLE
feat: add optional WAF IP address restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ regulatory and compliance requirements before deployment.
 
 1. Enable AWS CloudTrail for audit logging
 2. Configure VPC endpoints for S3 and DynamoDB if running in a VPC
-3. Set up AWS WAF rules on CloudFront and API Gateway (built-in support: set `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` in `config.yaml`)
+3. Set up AWS WAF rules on CloudFront and API Gateway (built-in support: set `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` in `config.yaml` — accepts multiple CIDR ranges, or use `--waf-ipv4` / `--waf-ipv6` with `deploy.sh`)
 4. Review and tighten CORS configuration for your domain
 5. Enable S3 access logging on all buckets
 6. Configure Cognito advanced security features (MFA, compromised credentials)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ See [Architecture](docs/en/architecture.md) for details.
 - **Authorization**: Resource-level RBAC enforced at API and storage layers
 - **Encryption**: S3 server-side encryption (SSE-S3), DynamoDB encryption at rest
 - **Network**: CloudFront with OAI for static assets, API Gateway with Cognito authorizer
+- **WAF**: Optional IP address restriction via AWS WAF (IPv4/IPv6) on CloudFront and API Gateway
 
 ---
 
@@ -191,7 +192,7 @@ regulatory and compliance requirements before deployment.
 
 1. Enable AWS CloudTrail for audit logging
 2. Configure VPC endpoints for S3 and DynamoDB if running in a VPC
-3. Set up AWS WAF rules on CloudFront and API Gateway
+3. Set up AWS WAF rules on CloudFront and API Gateway (built-in support: set `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` in `config.yaml`)
 4. Review and tighten CORS configuration for your domain
 5. Enable S3 access logging on all buckets
 6. Configure Cognito advanced security features (MFA, compromised credentials)

--- a/README_ja.md
+++ b/README_ja.md
@@ -190,7 +190,7 @@ This project has adopted the [Amazon Open Source Code of Conduct](https://aws.gi
 
 1. 監査ログ用に AWS CloudTrail を有効化
 2. VPC 内で実行する場合は S3・DynamoDB の VPC エンドポイントを設定
-3. CloudFront と API Gateway に AWS WAF ルールを設定（組み込みサポート: `config.yaml` で `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` を設定）
+3. CloudFront と API Gateway に AWS WAF ルールを設定（組み込みサポート: `config.yaml` で `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` を設定 — 複数 CIDR 範囲指定可、または `deploy.sh` の `--waf-ipv4` / `--waf-ipv6` を使用）
 4. ドメインに合わせて CORS 設定を見直し
 5. 全バケットで S3 アクセスログを有効化
 6. Cognito の高度なセキュリティ機能（MFA、漏洩認証情報検出）を設定

--- a/README_ja.md
+++ b/README_ja.md
@@ -109,6 +109,7 @@ npm install && npx cdk deploy --all
 - **認可**: API・ストレージ層でのリソースレベル RBAC
 - **暗号化**: S3 サーバーサイド暗号化（SSE-S3）、DynamoDB 保存時暗号化
 - **ネットワーク**: CloudFront + OAI による静的アセット配信、API Gateway + Cognito 認可
+- **WAF**: AWS WAF による IP アドレス制限（IPv4/IPv6）を CloudFront・API Gateway にオプション適用
 
 ---
 
@@ -189,7 +190,7 @@ This project has adopted the [Amazon Open Source Code of Conduct](https://aws.gi
 
 1. 監査ログ用に AWS CloudTrail を有効化
 2. VPC 内で実行する場合は S3・DynamoDB の VPC エンドポイントを設定
-3. CloudFront と API Gateway に AWS WAF ルールを設定
+3. CloudFront と API Gateway に AWS WAF ルールを設定（組み込みサポート: `config.yaml` で `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` を設定）
 4. ドメインに合わせて CORS 設定を見直し
 5. 全バケットで S3 アクセスログを有効化
 6. Cognito の高度なセキュリティ機能（MFA、漏洩認証情報検出）を設定

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,6 +22,24 @@ phases:
           observability: ${FEATURE_OBSERVABILITY:-false}
         EOF
       - |
+        if [ -n "${WAF_IPV4}" ] || [ -n "${WAF_IPV6}" ]; then
+          echo "        waf:" >> infra/config.yaml
+          if [ -n "${WAF_IPV4}" ]; then
+            echo "          allowedIpV4AddressRanges:" >> infra/config.yaml
+            IFS=',' read -ra CIDRS <<< "${WAF_IPV4}"
+            for c in "${CIDRS[@]}"; do
+              echo "            - \"${c}\"" >> infra/config.yaml
+            done
+          fi
+          if [ -n "${WAF_IPV6}" ]; then
+            echo "          allowedIpV6AddressRanges:" >> infra/config.yaml
+            IFS=',' read -ra CIDRS <<< "${WAF_IPV6}"
+            for c in "${CIDRS[@]}"; do
+              echo "            - \"${c}\"" >> infra/config.yaml
+            done
+          fi
+        fi
+      - |
         if [ -n "${AUTH_OIDC_URL}" ] && [ -n "${AUTH_ALLOWED_CLIENTS}" ]; then
           cat >> infra/config.yaml <<EOF
         auth:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,34 +21,36 @@ phases:
           searchSlides: ${FEATURE_SEARCH_SLIDES:-false}
           observability: ${FEATURE_OBSERVABILITY:-false}
         EOF
+        sed -i 's/^        //' infra/config.yaml
       - |
         if [ -n "${WAF_IPV4}" ] || [ -n "${WAF_IPV6}" ]; then
-          echo "        waf:" >> infra/config.yaml
+          echo "waf:" >> infra/config.yaml
           if [ -n "${WAF_IPV4}" ]; then
-            echo "          allowedIpV4AddressRanges:" >> infra/config.yaml
+            echo "  allowedIpV4AddressRanges:" >> infra/config.yaml
             IFS=',' read -ra CIDRS <<< "${WAF_IPV4}"
             for c in "${CIDRS[@]}"; do
-              echo "            - \"${c}\"" >> infra/config.yaml
+              echo "    - \"${c}\"" >> infra/config.yaml
             done
           fi
           if [ -n "${WAF_IPV6}" ]; then
-            echo "          allowedIpV6AddressRanges:" >> infra/config.yaml
+            echo "  allowedIpV6AddressRanges:" >> infra/config.yaml
             IFS=',' read -ra CIDRS <<< "${WAF_IPV6}"
             for c in "${CIDRS[@]}"; do
-              echo "            - \"${c}\"" >> infra/config.yaml
+              echo "    - \"${c}\"" >> infra/config.yaml
             done
           fi
         fi
       - |
         if [ -n "${AUTH_OIDC_URL}" ] && [ -n "${AUTH_ALLOWED_CLIENTS}" ]; then
-          cat >> infra/config.yaml <<EOF
+          cat >> infra/config.yaml <<AUTHEOF
         auth:
           oidcDiscoveryUrl: "${AUTH_OIDC_URL}"
           allowedClients:
-        EOF
+        AUTHEOF
+          sed -i '/^auth:/,$ s/^        //' infra/config.yaml
           IFS=',' read -ra CLIENTS <<< "${AUTH_ALLOWED_CLIENTS}"
           for c in "${CLIENTS[@]}"; do
-            echo "    - \"${c}\"" >> infra/config.yaml
+            echo "  - \"${c}\"" >> infra/config.yaml
           done
         fi
       - cat infra/config.yaml

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -261,6 +261,7 @@ To add custom roles (e.g., team-based access), modify the `resolve_role` functio
 | SdpmAgent | Strands Agent (Amazon Bedrock AgentCore Runtime) | `stacks.agent` |
 | SdpmWebUi | S3 + Amazon CloudFront + Amazon API Gateway + Lambda | `stacks.webUi` |
 | SdpmAuth | Amazon Cognito User Pool (auto-created when agent or webUi enabled) | (auto) |
+| SdpmCloudFrontWaf | AWS WAF WebACL for CloudFront (us-east-1) | `waf.*` |
 
 ---
 

--- a/docs/en/deploy-cloudshell.md
+++ b/docs/en/deploy-cloudshell.md
@@ -67,6 +67,22 @@ Choose options based on your use case.
   --allowed-clients "client-id-1,client-id-2"
 ```
 
+**With WAF IP address restriction:**
+
+```bash
+./scripts/deploy.sh --region us-east-1 --waf-ipv4 "203.0.113.0/24,198.51.100.0/24"
+```
+
+**Using `infra/config.yaml`:**
+
+If `infra/config.yaml` exists, `deploy.sh` loads it as defaults. CLI arguments override config file values. This is useful for persisting settings across deployments without repeating CLI flags.
+
+```bash
+cp infra/config.example.yaml infra/config.yaml
+# Edit config.yaml to set stacks, features, WAF, etc.
+./scripts/deploy.sh --region us-east-1
+```
+
 **Destroy all stacks:**
 
 ```bash
@@ -181,6 +197,8 @@ echo "Open the URL above to sign in."
 | `--observability` | Enable Bedrock Model Invocation Logging | Disabled |
 | `--oidc-url URL` | External IdP OIDC Discovery URL | — |
 | `--allowed-clients IDS` | Comma-separated JWT allowed client IDs | — |
+| `--waf-ipv4 CIDRS` | Comma-separated IPv4 CIDR ranges for WAF | — |
+| `--waf-ipv6 CIDRS` | Comma-separated IPv6 CIDR ranges for WAF | — |
 | `--destroy` | Destroy all stacks | — |
 
 ## Troubleshooting

--- a/docs/en/deploy-cloudshell.md
+++ b/docs/en/deploy-cloudshell.md
@@ -70,8 +70,16 @@ Choose options based on your use case.
 **With WAF IP address restriction:**
 
 ```bash
+# IPv4 only (⚠️ this blocks all IPv6 access — see note below)
 ./scripts/deploy.sh --region us-east-1 --waf-ipv4 "203.0.113.0/24,198.51.100.0/24"
+
+# IPv4 + IPv6 (recommended for dual-stack networks)
+./scripts/deploy.sh --region us-east-1 \
+  --waf-ipv4 "203.0.113.0/24" \
+  --waf-ipv6 "2001:db8::/32"
 ```
+
+> **⚠️ IPv6 Note:** If you specify only `--waf-ipv4` without `--waf-ipv6`, all IPv6 access is blocked. Modern browsers often prefer IPv6, which can cause the Web UI to appear stuck. Always specify both if your network uses dual-stack.
 
 **Using `infra/config.yaml`:**
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -283,6 +283,8 @@ When configured, CDK creates:
 
 Default action is **Block** — only the listed IP ranges are allowed. When the `waf` section is omitted, no WAF resources are created.
 
+> **⚠️ IPv6 Note:** If you specify only `allowedIpV4AddressRanges` without `allowedIpV6AddressRanges`, all IPv6 access is blocked. Modern browsers often prefer IPv6 when available, which can cause the Web UI to hang on "Loading authentication configuration..." even if your IPv4 address is allowed. Always specify both IPv4 and IPv6 ranges if your network uses dual-stack.
+
 ### Semantic Slide Search
 
 Set `features.searchSlides: true` to create a Amazon Bedrock Knowledge Base for cross-deck semantic search.

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -264,6 +264,25 @@ If you change the stack configuration, run `npx cdk deploy SdpmWebUi`.
 
 ## Optional Features
 
+### WAF IP Address Restriction
+
+Set `waf.allowedIpV4AddressRanges` and/or `waf.allowedIpV6AddressRanges` in `config.yaml` to restrict access to CloudFront and API Gateway by IP address.
+
+```yaml
+waf:
+  allowedIpV4AddressRanges:
+    - "10.0.0.0/8"
+    - "192.168.0.0/16"
+  allowedIpV6AddressRanges:
+    - "2001:db8::/32"
+```
+
+When configured, CDK creates:
+- **SdpmCloudFrontWaf** stack in `us-east-1` (WAFv2 CLOUDFRONT scope requirement) — attached to CloudFront
+- **Regional WAF** in the deploy region — attached to API Gateway
+
+Default action is **Block** — only the listed IP ranges are allowed. When the `waf` section is omitted, no WAF resources are created.
+
 ### Semantic Slide Search
 
 Set `features.searchSlides: true` to create a Amazon Bedrock Knowledge Base for cross-deck semantic search.

--- a/docs/ja/architecture.md
+++ b/docs/ja/architecture.md
@@ -260,6 +260,7 @@ spec-driven-presentation-maker は OIDC 準拠の任意の IdP（Identity Provid
 | SdpmAgent | Strands Agent（Amazon Bedrock AgentCore Runtime） | `stacks.agent` |
 | SdpmWebUi | S3 + Amazon CloudFront + Amazon API Gateway + Lambda | `stacks.webUi` |
 | SdpmAuth | Amazon Cognito User Pool（agent または webUi 有効時に自動作成） | （自動） |
+| SdpmCloudFrontWaf | CloudFront 用 AWS WAF WebACL（us-east-1） | `waf.*` |
 
 ---
 

--- a/docs/ja/deploy-cloudshell.md
+++ b/docs/ja/deploy-cloudshell.md
@@ -67,6 +67,22 @@ chmod +x scripts/deploy.sh
   --allowed-clients "client-id-1,client-id-2"
 ```
 
+**WAF IP アドレス制限を有効にする場合:**
+
+```bash
+./scripts/deploy.sh --region us-east-1 --waf-ipv4 "203.0.113.0/24,198.51.100.0/24"
+```
+
+**`infra/config.yaml` を使う場合:**
+
+`infra/config.yaml` が存在する場合、`deploy.sh` はその内容をデフォルト値として読み込みます。CLI 引数は config ファイルの値を上書きします。デプロイのたびに CLI フラグを繰り返す必要がなくなります。
+
+```bash
+cp infra/config.example.yaml infra/config.yaml
+# config.yaml を編集して stacks, features, WAF 等を設定
+./scripts/deploy.sh --region us-east-1
+```
+
 **スタックの削除:**
 
 ```bash
@@ -181,6 +197,8 @@ echo "上記 URL にアクセスしてログインしてください。"
 | `--observability` | Bedrock Model Invocation Logging を有効化 | 無効 |
 | `--oidc-url URL` | 外部 IdP の OIDC Discovery URL | — |
 | `--allowed-clients IDS` | JWT の許可クライアント ID（カンマ区切り） | — |
+| `--waf-ipv4 CIDRS` | WAF 用 IPv4 CIDR 範囲（カンマ区切り） | — |
+| `--waf-ipv6 CIDRS` | WAF 用 IPv6 CIDR 範囲（カンマ区切り） | — |
 | `--destroy` | 全スタックを削除 | — |
 
 ## トラブルシューティング

--- a/docs/ja/deploy-cloudshell.md
+++ b/docs/ja/deploy-cloudshell.md
@@ -70,8 +70,16 @@ chmod +x scripts/deploy.sh
 **WAF IP アドレス制限を有効にする場合:**
 
 ```bash
+# IPv4 のみ（⚠️ IPv6 アクセスはすべてブロックされます — 下記の注意を参照）
 ./scripts/deploy.sh --region us-east-1 --waf-ipv4 "203.0.113.0/24,198.51.100.0/24"
+
+# IPv4 + IPv6（デュアルスタック環境では推奨）
+./scripts/deploy.sh --region us-east-1 \
+  --waf-ipv4 "203.0.113.0/24" \
+  --waf-ipv6 "2001:db8::/32"
 ```
+
+> **⚠️ IPv6 に関する注意:** `--waf-ipv4` のみ指定し `--waf-ipv6` を省略した場合、IPv6 によるアクセスはすべてブロックされます。最近のブラウザは IPv6 を優先するため、Web UI が停止しているように見えることがあります。デュアルスタック環境では必ず両方を指定してください。
 
 **`infra/config.yaml` を使う場合:**
 

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -264,6 +264,25 @@ bash scripts/deploy_webui.sh
 
 ## オプション機能
 
+### WAF IP アドレス制限
+
+`config.yaml` で `waf.allowedIpV4AddressRanges` および/または `waf.allowedIpV6AddressRanges` を設定すると、CloudFront と API Gateway へのアクセスを IP アドレスで制限できます。
+
+```yaml
+waf:
+  allowedIpV4AddressRanges:
+    - "10.0.0.0/8"
+    - "192.168.0.0/16"
+  allowedIpV6AddressRanges:
+    - "2001:db8::/32"
+```
+
+設定すると、CDK は以下を作成します:
+- **SdpmCloudFrontWaf** スタック（`us-east-1`、WAFv2 CLOUDFRONT スコープの要件）— CloudFront に関連付け
+- **リージョナル WAF**（デプロイリージョン）— API Gateway に関連付け
+
+デフォルトアクションは **Block** で、指定された IP 範囲のみアクセスが許可されます。`waf` セクションを省略した場合、WAF リソースは作成されません。
+
 ### セマンティックスライド検索
 
 `features.searchSlides: true` を設定すると、Amazon Bedrock Knowledge Base が作成され、デッキ横断のセマンティック検索が利用可能になります。

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -283,6 +283,8 @@ waf:
 
 デフォルトアクションは **Block** で、指定された IP 範囲のみアクセスが許可されます。`waf` セクションを省略した場合、WAF リソースは作成されません。
 
+> **⚠️ IPv6 に関する注意:** `allowedIpV4AddressRanges` のみ指定し `allowedIpV6AddressRanges` を省略した場合、IPv6 によるアクセスはすべてブロックされます。最近のブラウザは IPv6 を優先的に使用するため、IPv4 アドレスが許可されていても Web UI が「Loading authentication configuration...」のまま停止することがあります。デュアルスタック環境では必ず IPv4 と IPv6 の両方を指定してください。
+
 ### セマンティックスライド検索
 
 `features.searchSlides: true` を設定すると、Amazon Bedrock Knowledge Base が作成され、デッキ横断のセマンティック検索が利用可能になります。

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -25,6 +25,7 @@ import { AuthStack } from "../lib/auth-stack";
 import { RuntimeStack } from "../lib/runtime-stack";
 import { AgentStack } from "../lib/agent-stack";
 import { WebUiStack } from "../lib/web-ui-stack";
+import { CloudFrontWafStack } from "../lib/cloudfront-waf-stack";
 
 // Load deployment configuration
 const configPath = path.join(__dirname, "../config.yaml");
@@ -77,6 +78,22 @@ const runtime = new RuntimeStack(app, "SdpmRuntime", {
   vectorIndexName: data.vectorIndexName || undefined,
 });
 
+// --- WAF IP restriction (optional) ---
+const allowedIpV4AddressRanges: string[] | undefined = config.waf?.allowedIpV4AddressRanges;
+const allowedIpV6AddressRanges: string[] | undefined = config.waf?.allowedIpV6AddressRanges;
+const wafEnabled = !!(allowedIpV4AddressRanges || allowedIpV6AddressRanges);
+
+// CloudFront WAF must be in us-east-1
+const cloudFrontWafStack = wafEnabled
+  ? new CloudFrontWafStack(app, "SdpmCloudFrontWaf", {
+      env: { account: env.account, region: "us-east-1" },
+      crossRegionReferences: true,
+      description: "Spec-Driven Presentation Maker - CloudFront WAF (uksb-ynuz0lkrea)(tag:waf)",
+      allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges,
+    })
+  : undefined;
+
 if (config.stacks?.agent) {
   const agent = new AgentStack(app, "SdpmAgent", {
     env,
@@ -95,6 +112,7 @@ if (config.stacks?.agent) {
     }
     new WebUiStack(app, "SdpmWebUi", {
       env,
+      crossRegionReferences: wafEnabled,
       description: "Spec-Driven Presentation Maker - Web UI (uksb-ynuz0lkrea)(tag:web-ui)",
       table: data.table,
       pptxBucket: data.pptxBucket,
@@ -106,6 +124,9 @@ if (config.stacks?.agent) {
       kbId: searchSlides ? data.kbSsmParamName : undefined,
       vectorBucketName: data.vectorBucketName || undefined,
       vectorIndexName: data.vectorIndexName || undefined,
+      webAclId: cloudFrontWafStack?.webAclArn,
+      allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges,
     });
   }
 }

--- a/infra/config.example.yaml
+++ b/infra/config.example.yaml
@@ -27,3 +27,12 @@ features:
 model:
   modelId: "global.anthropic.claude-sonnet-4-6"
   # modelId: "global.anthropic.claude-opus-4-6-v1"
+
+# WAF IP address restriction (optional).
+# When specified, only the listed IP ranges can access CloudFront and API Gateway.
+# waf:
+#   allowedIpV4AddressRanges:
+#     - "192.168.0.0/16"
+#     - "10.0.0.0/8"
+#   allowedIpV6AddressRanges:
+#     - "2001:db8::/32"

--- a/infra/lib/cloudfront-waf-stack.ts
+++ b/infra/lib/cloudfront-waf-stack.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * CloudFront WAF Stack — deployed in us-east-1.
+ *
+ * WAF v2 WebACLs with scope CLOUDFRONT must reside in us-east-1.
+ * This stack is only created when IP address restrictions are configured.
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { CommonWebAcl } from "./construct/common-web-acl";
+
+interface CloudFrontWafStackProps extends cdk.StackProps {
+  readonly allowedIpV4AddressRanges?: string[];
+  readonly allowedIpV6AddressRanges?: string[];
+}
+
+export class CloudFrontWafStack extends cdk.Stack {
+  public readonly webAclArn: string;
+
+  constructor(scope: Construct, id: string, props: CloudFrontWafStackProps) {
+    super(scope, id, props);
+
+    const webAcl = new CommonWebAcl(this, "CloudFrontWebAcl", {
+      scope: "CLOUDFRONT",
+      allowedIpV4AddressRanges: props.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: props.allowedIpV6AddressRanges,
+    });
+
+    this.webAclArn = webAcl.webAclArn;
+
+    new cdk.CfnOutput(this, "WebAclArn", { value: webAcl.webAclArn });
+  }
+}

--- a/infra/lib/construct/common-web-acl.ts
+++ b/infra/lib/construct/common-web-acl.ts
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * Reusable WAF WebACL construct for IP-based access restriction.
+ * Based on the pattern from generative-ai-use-cases-jp.
+ *
+ * Usage:
+ *   scope: 'CLOUDFRONT' — must be deployed in us-east-1
+ *   scope: 'REGIONAL'   — deployed in the same region as the resource
+ */
+
+import { Lazy, Names } from "aws-cdk-lib";
+import { CfnIPSet, CfnWebACL, CfnWebACLProps } from "aws-cdk-lib/aws-wafv2";
+import { Construct } from "constructs";
+
+export interface CommonWebAclProps {
+  readonly scope: "REGIONAL" | "CLOUDFRONT";
+  readonly allowedIpV4AddressRanges?: string[];
+  readonly allowedIpV6AddressRanges?: string[];
+}
+
+export class CommonWebAcl extends Construct {
+  public readonly webAclArn: string;
+
+  constructor(scope: Construct, id: string, props: CommonWebAclProps) {
+    super(scope, id);
+
+    const suffix = Lazy.string({ produce: () => Names.uniqueId(this) });
+    const rules: CfnWebACLProps["rules"] = [];
+
+    const ruleProps = (name: string) => ({
+      name,
+      action: { allow: {} },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: name,
+      },
+    });
+
+    if (props.allowedIpV4AddressRanges && props.allowedIpV4AddressRanges.length > 0) {
+      const ipSet = new CfnIPSet(this, "IPv4Set", {
+        ipAddressVersion: "IPV4",
+        scope: props.scope,
+        addresses: props.allowedIpV4AddressRanges,
+      });
+      rules.push({
+        priority: 1,
+        ...ruleProps("IpV4SetRule"),
+        statement: { ipSetReferenceStatement: { arn: ipSet.attrArn } },
+      });
+    }
+
+    if (props.allowedIpV6AddressRanges && props.allowedIpV6AddressRanges.length > 0) {
+      const ipSet = new CfnIPSet(this, "IPv6Set", {
+        ipAddressVersion: "IPV6",
+        scope: props.scope,
+        addresses: props.allowedIpV6AddressRanges,
+      });
+      rules.push({
+        priority: 2,
+        ...ruleProps("IpV6SetRule"),
+        statement: { ipSetReferenceStatement: { arn: ipSet.attrArn } },
+      });
+    }
+
+    const webAcl = new CfnWebACL(this, "WebAcl", {
+      defaultAction: { block: {} },
+      name: `WebAcl-${suffix}`,
+      scope: props.scope,
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        sampledRequestsEnabled: true,
+        metricName: `WebAcl-${suffix}`,
+      },
+      rules,
+    });
+    this.webAclArn = webAcl.attrArn;
+  }
+}

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -76,8 +76,6 @@ export class WebUiStack extends cdk.Stack {
     });
 
     // --- Amazon CloudFront ---
-    const oai = new cloudfront.OriginAccessIdentity(this, "OAI");
-    siteBucket.grantRead(oai);
 
     // CloudFront Function to rewrite directory requests to index.html
     // (S3 REST API does not support index documents for subdirectories)
@@ -158,7 +156,7 @@ function handler(event) {
 
     const distribution = new cloudfront.Distribution(this, "Distribution", {
       defaultBehavior: {
-        origin: new origins.S3Origin(siteBucket, { originAccessIdentity: oai }),
+        origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         functionAssociations: [{
           function: urlRewrite,
@@ -166,9 +164,11 @@ function handler(event) {
         }],
       },
       defaultRootObject: "index.html",
+      // 404 → /index.html for SPA client-side routing.
+      // With OAC, S3 returns 404 (not 403) for missing keys, so this
+      // fallback handles SPA routing without interfering with WAF blocks.
       errorResponses: [
         { httpStatus: 404, responseHttpStatus: 200, responsePagePath: "/index.html" },
-        { httpStatus: 403, responseHttpStatus: 200, responsePagePath: "/index.html" },
       ],
     });
 

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -25,8 +25,10 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import { CfnWebACLAssociation } from "aws-cdk-lib/aws-wafv2";
 import { Construct } from "constructs";
 import * as path from "path";
+import { CommonWebAcl } from "./construct/common-web-acl";
 
 interface WebUiStackProps extends cdk.StackProps {
   /** Amazon DynamoDB table from DataStack. */
@@ -49,6 +51,12 @@ interface WebUiStackProps extends cdk.StackProps {
   vectorBucketName?: string;
   /** S3 Vector Index name (empty if KB not enabled). */
   vectorIndexName?: string;
+  /** CloudFront WAF WebACL ARN (from CloudFrontWafStack in us-east-1). */
+  webAclId?: string;
+  /** Allowed IPv4 CIDR ranges for regional WAF. */
+  allowedIpV4AddressRanges?: string[];
+  /** Allowed IPv6 CIDR ranges for regional WAF. */
+  allowedIpV6AddressRanges?: string[];
 }
 
 export class WebUiStack extends cdk.Stack {
@@ -427,6 +435,24 @@ function handler(event) {
         }),
       ]),
     });
+
+    // --- WAF: CloudFront WebACL (from us-east-1 stack) ---
+    if (props.webAclId) {
+      cfnDist.addPropertyOverride("DistributionConfig.WebACLId", props.webAclId);
+    }
+
+    // --- WAF: Regional WAF for API Gateway ---
+    if (props.allowedIpV4AddressRanges || props.allowedIpV6AddressRanges) {
+      const regionalWaf = new CommonWebAcl(this, "RegionalWaf", {
+        scope: "REGIONAL",
+        allowedIpV4AddressRanges: props.allowedIpV4AddressRanges,
+        allowedIpV6AddressRanges: props.allowedIpV6AddressRanges,
+      });
+      new CfnWebACLAssociation(this, "ApiWafAssociation", {
+        resourceArn: api.deploymentStage.stageArn,
+        webAclArn: regionalWaf.webAclArn,
+      });
+    }
 
     // --- Outputs ---
     new cdk.CfnOutput(this, "SiteUrl", { value: this.siteUrl });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -31,6 +31,26 @@ WAF_IPV6=""
 CDK_COMMAND="deploy"
 PROJECT_NAME="sdpm-deploy"
 
+# ---- Load defaults from infra/config.yaml if present ----
+# CLI arguments below will override these values.
+CONFIG_FILE="infra/config.yaml"
+if [ -f "${CONFIG_FILE}" ]; then
+  _agent=$(grep -E "^\s*agent:" "${CONFIG_FILE}" | head -1 | awk '{print $2}' | tr -d '"' || true)
+  _webui=$(grep -E "^\s*webUi:" "${CONFIG_FILE}" | head -1 | awk '{print $2}' | tr -d '"' || true)
+  if [ "${_agent}" = "false" ] && [ "${_webui}" = "false" ]; then
+    LAYER="3"
+  fi
+  _search=$(grep -E "^\s*searchSlides:" "${CONFIG_FILE}" | head -1 | awk '{print $2}' | tr -d '"' || true)
+  [ -n "${_search}" ] && SEARCH_SLIDES="${_search}"
+  _obs=$(grep -E "^\s*observability:" "${CONFIG_FILE}" | head -1 | awk '{print $2}' | tr -d '"' || true)
+  [ -n "${_obs}" ] && OBSERVABILITY="${_obs}"
+  # WAF IPv4/IPv6: collect list items under each key
+  WAF_IPV4=$(awk '/allowedIpV4AddressRanges:/{f=1;next} f && /^[[:space:]]*-/{gsub(/["]/,"",$2); printf "%s,", $2; next} f && !/^[[:space:]]*-/{f=0}' "${CONFIG_FILE}" | sed 's/,$//')
+  WAF_IPV6=$(awk '/allowedIpV6AddressRanges:/{f=1;next} f && /^[[:space:]]*-/{gsub(/["]/,"",$2); printf "%s,", $2; next} f && !/^[[:space:]]*-/{f=0}' "${CONFIG_FILE}" | sed 's/,$//')
+  _oidc=$(grep -E "^\s*oidcDiscoveryUrl:" "${CONFIG_FILE}" | head -1 | sed -E 's/^[^:]+:\s*"?([^"]*)"?\s*$/\1/' || true)
+  [ -n "${_oidc}" ] && OIDC_URL="${_oidc}"
+fi
+
 # ---- Parse arguments ----
 usage() {
   cat <<EOF
@@ -100,6 +120,8 @@ echo "Region:  ${REGION}"
 echo "Layer:   ${LAYER}"
 echo "Search:  ${SEARCH_SLIDES}"
 echo "Observ:  ${OBSERVABILITY}"
+echo "WAF v4:  ${WAF_IPV4:-(none)}"
+echo "WAF v6:  ${WAF_IPV6:-(none)}"
 echo "Command: ${CDK_COMMAND}"
 echo ""
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,6 +26,8 @@ SEARCH_SLIDES="false"
 OBSERVABILITY="false"
 OIDC_URL=""
 ALLOWED_CLIENTS=""
+WAF_IPV4=""
+WAF_IPV6=""
 CDK_COMMAND="deploy"
 PROJECT_NAME="sdpm-deploy"
 
@@ -48,6 +50,9 @@ Options:
   --oidc-url URL           External IdP OIDC Discovery URL
   --allowed-clients IDS    Comma-separated JWT allowed client IDs
 
+  --waf-ipv4 CIDRS         Comma-separated IPv4 CIDR ranges for WAF (e.g. "1.2.3.4/32,10.0.0.0/8")
+  --waf-ipv6 CIDRS         Comma-separated IPv6 CIDR ranges for WAF
+
   --destroy                Destroy all stacks
 
   -h, --help               Show this help
@@ -65,6 +70,8 @@ while [[ $# -gt 0 ]]; do
     --observability)  OBSERVABILITY="true"; shift ;;
     --oidc-url)       OIDC_URL="$2"; shift 2 ;;
     --allowed-clients) ALLOWED_CLIENTS="$2"; shift 2 ;;
+    --waf-ipv4)       WAF_IPV4="$2"; shift 2 ;;
+    --waf-ipv6)       WAF_IPV6="$2"; shift 2 ;;
     --destroy)        CDK_COMMAND="destroy"; shift ;;
     -h|--help)        usage ;;
     *)                echo "Unknown option: $1"; usage ;;
@@ -209,6 +216,8 @@ ENV_VARS_JSON=$(cat <<EOF
   {"name":"FEATURE_OBSERVABILITY", "value":"${OBSERVABILITY}",     "type":"PLAINTEXT"},
   {"name":"AUTH_OIDC_URL",         "value":"${OIDC_URL}",          "type":"PLAINTEXT"},
   {"name":"AUTH_ALLOWED_CLIENTS",  "value":"${ALLOWED_CLIENTS}",   "type":"PLAINTEXT"},
+  {"name":"WAF_IPV4",              "value":"${WAF_IPV4}",          "type":"PLAINTEXT"},
+  {"name":"WAF_IPV6",              "value":"${WAF_IPV6}",          "type":"PLAINTEXT"},
   {"name":"CDK_COMMAND",           "value":"${CDK_COMMAND}",       "type":"PLAINTEXT"}
 ]
 EOF

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,6 +18,10 @@
 
 set -euo pipefail
 
+# Ensure we run from the repository root regardless of where the script is invoked
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
 # ---- Defaults ----
 REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 PROFILE=""

--- a/web-ui/src/components/auth/AuthProvider.tsx
+++ b/web-ui/src/components/auth/AuthProvider.tsx
@@ -22,6 +22,7 @@ interface CognitoAuthConfig {
 const AuthProvider = ({ children }: PropsWithChildren) => {
   const [authConfig, setAuthConfig] = useState<CognitoAuthConfig | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const initRef = useRef(false)
 
   useEffect(() => {
@@ -35,6 +36,12 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
         setAuthConfig(config)
       } catch (error) {
         console.error("Failed to load auth configuration:", error)
+        const msg = error instanceof Error ? error.message : String(error)
+        if (msg.includes("403")) {
+          setError("Access denied. Your network may not be permitted to access this application. Please contact your administrator.")
+        } else {
+          setError(msg)
+        }
       } finally {
         setLoading(false)
       }
@@ -54,7 +61,10 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
   if (!authConfig) {
     return (
       <div className="flex items-center justify-center min-h-screen text-xl">
-        Failed to load authentication configuration
+        <div className="text-center max-w-lg">
+          <p className="font-semibold">Failed to load authentication configuration</p>
+          {error && <p className="mt-2 text-sm text-gray-500">{error}</p>}
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Add optional WAF IP address restriction to CloudFront and API Gateway.

### Changes

- **`infra/lib/construct/common-web-acl.ts`** — Reusable WAF WebACL construct (REGIONAL/CLOUDFRONT scope)
- **`infra/lib/cloudfront-waf-stack.ts`** — CloudFront WAF stack deployed in us-east-1 (WAFv2 CLOUDFRONT scope requirement)
- **`infra/bin/infra.ts`** — Conditional WAF stack creation when IP ranges are configured
- **`infra/lib/web-ui-stack.ts`** — CloudFront WebACLId + API Gateway regional WAF association
- **`infra/config.example.yaml`** — Document `waf.allowedIpV4AddressRanges` / `waf.allowedIpV6AddressRanges` options

### Usage

```yaml
# config.yaml
waf:
  allowedIpV4AddressRanges:
    - "10.0.0.0/8"
    - "192.168.0.0/16"
  allowedIpV6AddressRanges:
    - "2001:db8::/32"
```

When `waf` section is omitted or commented out, no WAF is created (backward compatible).

### Design

Based on the [generative-ai-use-cases-jp](https://github.com/aws-samples/generative-ai-use-cases-jp) WAF pattern:
- CloudFront WAF must be in us-east-1 → separate `SdpmCloudFrontWaf` stack with `crossRegionReferences`
- API Gateway WAF is regional → created in `WebUiStack` via `CfnWebACLAssociation`
- Default action is **Block** — only listed IP ranges are allowed

### Testing

- `npx cdk synth` passes with WAF disabled (no config)
- `npx cdk synth` passes with WAF enabled (IPv4 range configured)
- Generated CloudFormation template verified: IPSet + WebACL resources correct