### PR TITLE
fix: resolve Layer 4 fresh-deploy errors (webui bundling, agentcore logs, aws-mcp region)

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -93,16 +93,19 @@ def _mcp_aws_knowledge() -> MCPClient:
     Primary: IAM-authenticated endpoint (higher rate limits).
     Fallback: Public unauthenticated endpoint.
 
+    Note: AWS MCP Server is currently only available in us-east-1.
+    We hard-code the endpoint region regardless of the agent's region.
+
     Returns:
         MCPClient for AWS Knowledge MCP.
     """
-    region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
     try:
         from mcp_proxy_for_aws.client import aws_iam_streamablehttp_client
         return MCPClient(
             lambda: aws_iam_streamablehttp_client(
-                endpoint=f"https://aws-mcp.{region}.api.aws/mcp",
+                endpoint="https://aws-mcp.us-east-1.api.aws/mcp",
                 aws_service="aws-mcp",
+                aws_region="us-east-1",
             ),
         )
     except Exception:

--- a/infra/lib/agent-stack.ts
+++ b/infra/lib/agent-stack.ts
@@ -65,6 +65,20 @@ export class AgentStack extends cdk.Stack {
     props.table.grantReadWriteData(role);
     props.pptxBucket.grantReadWrite(role);
 
+    // CloudWatch Logs (AgentCore writes stdout/stderr directly via execution role)
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:CreateLogGroup", "logs:DescribeLogStreams"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock-agentcore/runtimes/*`],
+    }));
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:DescribeLogGroups"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:*`],
+    }));
+    role.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:CreateLogStream", "logs:PutLogEvents"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*`],
+    }));
+
     // AWS Pricing API (used by aws-pricing-mcp-server, stdio MCP)
     role.addToPolicy(
       new iam.PolicyStatement({

--- a/infra/lib/runtime-stack.ts
+++ b/infra/lib/runtime-stack.ts
@@ -66,6 +66,20 @@ export class RuntimeStack extends cdk.Stack {
         resources: [props.pptxBucket.bucketArn, props.resourceBucket.bucketArn],
       })
     );
+
+    // CloudWatch Logs (AgentCore writes stdout/stderr directly via execution role)
+    runtimeRole.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:CreateLogGroup", "logs:DescribeLogStreams"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock-agentcore/runtimes/*`],
+    }));
+    runtimeRole.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:DescribeLogGroups"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:*`],
+    }));
+    runtimeRole.addToPolicy(new iam.PolicyStatement({
+      actions: ["logs:CreateLogStream", "logs:PutLogEvents"],
+      resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*`],
+    }));
     runtimeRole.addToPolicy(
       new iam.PolicyStatement({
         actions: [

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -325,8 +325,35 @@ function handler(event) {
     styles.addResource("{name}").addMethod("GET", integration, auth);
 
     // --- Deploy web-ui static files to S3 ---
+    // Bundle the web-ui at synth time so changes are auto-picked up without a
+    // manual `npm run build`. Prefers local Node.js; falls back to Docker.
+    const webUiDir = path.join(__dirname, "../../web-ui");
     const deployment = new s3deploy.BucketDeployment(this, "DeploySite", {
-      sources: [s3deploy.Source.asset(path.join(__dirname, "../../web-ui/build"))],
+      sources: [
+        s3deploy.Source.asset(webUiDir, {
+          bundling: {
+            image: cdk.DockerImage.fromRegistry("node:20-slim"),
+            command: [
+              "bash", "-c",
+              "npm ci && npm run build && cp -r build/. /asset-output/",
+            ],
+            local: {
+              tryBundle(outputDir: string): boolean {
+                const { execSync } = require("child_process");
+                try {
+                  execSync("npm --version", { stdio: "ignore" });
+                } catch {
+                  return false;
+                }
+                execSync("npm ci", { cwd: webUiDir, stdio: "inherit" });
+                execSync("npm run build", { cwd: webUiDir, stdio: "inherit" });
+                execSync(`cp -r ${webUiDir}/build/. ${outputDir}/`, { stdio: "inherit" });
+                return true;
+              },
+            },
+          },
+        }),
+      ],
       destinationBucket: siteBucket,
       distribution,
       distributionPaths: ["/*"],


### PR DESCRIPTION
## Summary

Fixes three issues encountered when deploying Layer 4 from a fresh clone. They are bundled into a single PR because they all block the same user journey — first-time `cdk deploy --all` followed by the first chat on the Web UI.

## Problems & Fixes

### 1. `web-ui` not built automatically → `CannotFindAsset`

**Problem**: Running `cdk deploy --all` on a fresh clone fails because `web-ui/build` does not exist. `scripts/deploy.sh` handles this by invoking `npm ci && npm run build` from `buildspec.yml`, but the local `cdk deploy` path does not.

**Fix**: `infra/lib/web-ui-stack.ts` now wraps the `BucketDeployment` source with `s3deploy.Source.asset(webUiDir, { bundling: { local: { tryBundle }, ... } })`. Local Node.js is preferred, falling back to `node:20-slim` Docker. Now any change under `web-ui/` is picked up automatically on `cdk deploy`.

### 2. AgentCore Runtime has no `logs:*` permissions → stdout/stderr lost

**Problem**: Neither `AgentRole` nor `RuntimeRole` had CloudWatch Logs permissions. AgentCore Runtime writes stdout/stderr to `/aws/bedrock-agentcore/runtimes/*` directly via the execution role, so nothing reached CloudWatch and live troubleshooting was impossible.

**Fix**: Added the log-group and log-stream permissions from the [official execution-role example](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-permissions.html) to both `agent-stack.ts` and `runtime-stack.ts`:
- `logs:CreateLogGroup`, `logs:DescribeLogStreams` on `log-group:/aws/bedrock-agentcore/runtimes/*`
- `logs:DescribeLogGroups` on `log-group:*`
- `logs:CreateLogStream`, `logs:PutLogEvents` on `log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*`

Note: `@aws-cdk/aws-bedrock-agentcore-alpha` adds these permissions automatically; this project uses L1 `CfnRuntime` so they must be added explicitly.

### 3. AWS Knowledge MCP → 401 Unauthorized when deployed outside `us-east-1`

**Problem**: `_mcp_aws_knowledge()` derived both the endpoint host and the SigV4 signing region from `AWS_REGION`. The AWS MCP Server is only offered at `aws-mcp.us-east-1.api.aws`, so for any non-`us-east-1` deployment either DNS resolution failed (other regions don't exist) or SigV4 was signed with the wrong region (401).

**Fix**: Hard-code both the endpoint and `aws_region` to `us-east-1`. The public fallback `knowledge-mcp.global.api.aws` remains as a backup.

## Testing

- Deployed all stacks to `us-west-2` with `cdk deploy --all`
- Verified AgentCore Runtime logs now flow to `/aws/bedrock-agentcore/runtimes/sdpm_agent-*-DEFAULT/`
- Confirmed AWS Knowledge / AWS Pricing MCP clients initialize successfully (previously one or both failed with `MCPClientInitializationError`)
- Verified Web UI still builds and the chat roundtrip works end-to-end

## Scope

Only addresses the three issues that block a fresh Layer 4 deployment. Lower-priority gaps (ApiLambda log retention, API Gateway access logs, CloudFront access logs) are intentionally left out.
