### PR TITLE
🐛 fix(textbox-default-margin): set default left/right margin to 0 for…

### DIFF
--- a/skill/sdpm/builder/elements/textbox.py
+++ b/skill/sdpm/builder/elements/textbox.py
@@ -56,6 +56,8 @@ class TextboxMixin:
                 txBody.insert(1, new_lst)  # after bodyPr
         
         tf = textbox.text_frame
+        tf.margin_left = 0
+        tf.margin_right = 0
         if elem.get("_noAutofit"):
             # Clean bodyPr to match original (no autofit, no wrap override)
             from pptx.oxml.ns import qn

--- a/skill/sdpm/converter/elements.py
+++ b/skill/sdpm/converter/elements.py
@@ -521,12 +521,13 @@ def extract_textbox_element(shape, theme_colors=None, color_mapping=None, theme_
         pass
     
     # Extract margins (EMU → px)
+    # Builder default for textbox: left/right=0, top/bottom=PowerPoint default
     tf = shape.text_frame
-    if tf.margin_left is not None and tf.margin_left != 91440:
+    if tf.margin_left is not None and tf.margin_left != 0:
         elem["marginLeft"] = round(tf.margin_left / EMU_PER_PX)
     if tf.margin_top is not None and tf.margin_top != 45720:
         elem["marginTop"] = round(tf.margin_top / EMU_PER_PX)
-    if tf.margin_right is not None and tf.margin_right != 91440:
+    if tf.margin_right is not None and tf.margin_right != 0:
         elem["marginRight"] = round(tf.margin_right / EMU_PER_PX)
     if tf.margin_bottom is not None and tf.margin_bottom != 45720:
         elem["marginBottom"] = round(tf.margin_bottom / EMU_PER_PX)


### PR DESCRIPTION
## Summary

Set default left/right text frame margins to 0 for textbox elements to prevent unwanted text wrapping in narrow textboxes.

## Problem

Textbox elements inherited python-pptx's default left/right margins (91,440 EMU ≈ 0.1 inch each, ~0.2 inch total). Since sdpm controls textbox positioning and sizing explicitly via JSON, this hidden margin caused unexpected text wrapping, especially in narrow textboxes.

## Changes

- **Builder** (`textbox.py`): Set `margin_left=0` and `margin_right=0` immediately after textframe creation
- **Converter** (`elements.py`): Update textbox left/right margin comparison baseline from `91440` to `0` for correct round-trip conversion

## Scope

- **Textbox only** — Shape/freeform margins are unchanged (padding inside shapes is desirable)
- **Top/bottom margins** — Unchanged (python-pptx default ~3.6pt retained)
- **Explicit override** — `marginLeft` / `marginRight` in JSON still works as before