### PR TITLE
✨ Add structured interview (hearing) tool for Layer 4 agent

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -477,7 +477,8 @@ async def agent_stream(payload, context):
                 from partial_json_parser import loads as partial_loads
                 parsed = partial_loads(raw)
                 return parsed if isinstance(parsed, dict) and parsed else None
-            except Exception:
+            except Exception as exc:
+                logger.debug("Partial JSON parse failed (len=%d): %s", len(raw), exc)
                 return None
 
         def _tool_payload(tu: dict) -> dict:
@@ -523,7 +524,9 @@ async def agent_stream(payload, context):
                             yield {"toolStart": {"name": tu.get("name", ""), "toolUseId": tu_id}}
                         last_tool_use = dict(tu)
                         # Early-emit partial input so UI can render incrementally
-                        parsed = _try_partial_parse(tu.get("input", ""))
+                        raw_input = tu.get("input", "")
+                        logger.debug("current_tool_use input type=%s len=%s", type(raw_input).__name__, len(raw_input) if isinstance(raw_input, str) else "n/a")
+                        parsed = _try_partial_parse(raw_input)
                         if parsed and parsed != last_yielded_input:
                             last_yielded_input = parsed
                             yield {"toolUse": {"name": tu.get("name", ""), "toolUseId": tu_id, "input": parsed}}

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -525,7 +525,6 @@ async def agent_stream(payload, context):
                         last_tool_use = dict(tu)
                         # Early-emit partial input so UI can render incrementally
                         raw_input = tu.get("input", "")
-                        logger.info("current_tool_use input type=%s len=%s", type(raw_input).__name__, len(raw_input) if isinstance(raw_input, str) else "n/a")
                         parsed = _try_partial_parse(raw_input)
                         if parsed and parsed != last_yielded_input:
                             last_yielded_input = parsed

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -28,6 +28,7 @@ from strands.models.bedrock import CacheConfig
 from strands.tools.mcp import MCPClient
 from tools.upload_tools import list_uploads
 from tools.web_tools import web_fetch
+from tools.hearing_tool import hearing
 
 logger = logging.getLogger("sdpm.agent")
 
@@ -270,7 +271,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
 
     # Agent.__init__ triggers MCP client connections.
     # If optional MCP servers fail during init, retry with required-only.
-    tools = [*mcp_servers, list_uploads, web_fetch]
+    tools = [*mcp_servers, list_uploads, web_fetch, hearing]
     try:
         agent = Agent(
             name="SdpmAgent",
@@ -301,7 +302,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
         agent = Agent(
             name="SdpmAgent",
             system_prompt="",
-            tools=[*mcp_servers, list_uploads, web_fetch],
+            tools=[*mcp_servers, list_uploads, web_fetch, hearing],
             model=model,
             session_manager=session_manager,
             trace_attributes={"user.id": user_id, "session.id": session_id},

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -525,7 +525,7 @@ async def agent_stream(payload, context):
                         last_tool_use = dict(tu)
                         # Early-emit partial input so UI can render incrementally
                         raw_input = tu.get("input", "")
-                        logger.debug("current_tool_use input type=%s len=%s", type(raw_input).__name__, len(raw_input) if isinstance(raw_input, str) else "n/a")
+                        logger.info("current_tool_use input type=%s len=%s", type(raw_input).__name__, len(raw_input) if isinstance(raw_input, str) else "n/a")
                         parsed = _try_partial_parse(raw_input)
                         if parsed and parsed != last_yielded_input:
                             last_yielded_input = parsed

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -483,10 +483,9 @@ async def agent_stream(payload, context):
 
         def _tool_payload(tu: dict) -> dict:
             """Build toolUse SSE payload from accumulated tool use data."""
-            import json as _json
             raw = tu.get("input", "")
             try:
-                parsed = _json.loads(raw) if isinstance(raw, str) and raw else raw
+                parsed = json.loads(raw) if isinstance(raw, str) and raw else raw
             except (ValueError, TypeError):
                 parsed = {}
             return {"toolUse": {"name": tu.get("name", ""), "toolUseId": tu.get("toolUseId", ""), "input": parsed if isinstance(parsed, dict) else {}}}

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -29,6 +29,7 @@ from strands.tools.mcp import MCPClient
 from tools.upload_tools import list_uploads
 from tools.web_tools import web_fetch
 from tools.hearing_tool import hearing
+from partial_json_parser import loads as _partial_loads
 
 logger = logging.getLogger("sdpm.agent")
 
@@ -474,8 +475,7 @@ async def agent_stream(payload, context):
             if not isinstance(raw, str) or not raw:
                 return None
             try:
-                from partial_json_parser import loads as partial_loads
-                parsed = partial_loads(raw)
+                parsed = _partial_loads(raw)
                 return parsed if isinstance(parsed, dict) and parsed else None
             except Exception as exc:
                 logger.debug("Partial JSON parse failed (len=%d): %s", len(raw), exc)

--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -463,8 +463,22 @@ async def agent_stream(payload, context):
         pending = None
         last_tool_use = None
         last_tool_use_id = ""
+        last_yielded_input: dict = {}  # track last emitted partial input
         tool_name_map: dict[str, str] = {}  # toolUseId → tool name
         in_tool_execution = False  # True between toolUse emission and toolResult receipt
+
+        def _try_partial_parse(raw) -> dict | None:
+            """Attempt partial JSON parse for incremental toolUse streaming."""
+            if isinstance(raw, dict):
+                return raw if raw else None
+            if not isinstance(raw, str) or not raw:
+                return None
+            try:
+                from partial_json_parser import loads as partial_loads
+                parsed = partial_loads(raw)
+                return parsed if isinstance(parsed, dict) and parsed else None
+            except Exception:
+                return None
 
         def _tool_payload(tu: dict) -> dict:
             """Build toolUse SSE payload from accumulated tool use data."""
@@ -503,10 +517,16 @@ async def agent_stream(payload, context):
                             if last_tool_use:
                                 yield _tool_payload(last_tool_use)
                             last_tool_use_id = tu_id
+                            last_yielded_input = {}
                             tool_name_map[tu_id] = tu.get("name", "")
                             in_tool_execution = True
                             yield {"toolStart": {"name": tu.get("name", ""), "toolUseId": tu_id}}
                         last_tool_use = dict(tu)
+                        # Early-emit partial input so UI can render incrementally
+                        parsed = _try_partial_parse(tu.get("input", ""))
+                        if parsed and parsed != last_yielded_input:
+                            last_yielded_input = parsed
+                            yield {"toolUse": {"name": tu.get("name", ""), "toolUseId": tu_id, "input": parsed}}
                     elif isinstance(event, dict) and event.get("type") == "tool_result":
                         # ToolResultEvent — not yielded by stream_async (is_callback_event=False)
                         # Handled via ToolResultMessageEvent below instead

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -9,3 +9,4 @@ mcp-proxy-for-aws>=1.1.0
 requests
 html2text
 pymupdf
+partial-json-parser

--- a/agent/tools/hearing_tool.py
+++ b/agent/tools/hearing_tool.py
@@ -21,8 +21,11 @@ def hearing(
 ) -> str:
     """Present structured questions to the user via a rich UI card.
 
-    Use this tool when you need specific input from the user and want to
-    provide clear options rather than asking open-ended questions.
+    ALWAYS use this tool when you need the user to make a choice or
+    judgment — not just for initial interviews but also for mid-workflow
+    decisions, confirmations with options, and next-step selections.
+    Only skip this tool for simple yes/no confirmations.
+
     Always include your reasoning or hypothesis in the inference field
     to help the user think — never ask blank questions.
     Limit to 5 questions per call. If you need more, call again after

--- a/agent/tools/hearing_tool.py
+++ b/agent/tools/hearing_tool.py
@@ -16,6 +16,8 @@ def hearing(
     q0: dict,
     q1: dict = None,
     q2: dict = None,
+    q3: dict = None,
+    q4: dict = None,
 ) -> str:
     """Present structured questions to the user via a rich UI card.
 
@@ -23,7 +25,7 @@ def hearing(
     provide clear options rather than asking open-ended questions.
     Always include your reasoning or hypothesis in the inference field
     to help the user think — never ask blank questions.
-    Limit to 3 questions per call. If you need more, call again after
+    Limit to 5 questions per call. If you need more, call again after
     the user responds.
 
     The Web UI renders a dedicated selection card. The user's answers
@@ -41,6 +43,8 @@ def hearing(
             - placeholder (str, optional): Hint text for free_text type
         q1: Second question (optional, same schema as q0).
         q2: Third question (optional, same schema as q0).
+        q3: Fourth question (optional, same schema as q0).
+        q4: Fifth question (optional, same schema as q0).
 
     Returns:
         Confirmation that the questions were displayed. Wait for the

--- a/agent/tools/hearing_tool.py
+++ b/agent/tools/hearing_tool.py
@@ -11,13 +11,20 @@ from strands import tool
 
 
 @tool
-def hearing(inference: str, questions: list[dict]) -> str:
+def hearing(
+    inference: str,
+    q0: dict,
+    q1: dict = None,
+    q2: dict = None,
+) -> str:
     """Present structured questions to the user via a rich UI card.
 
     Use this tool when you need specific input from the user and want to
     provide clear options rather than asking open-ended questions.
     Always include your reasoning or hypothesis in the inference field
     to help the user think — never ask blank questions.
+    Limit to 3 questions per call. If you need more, call again after
+    the user responds.
 
     The Web UI renders a dedicated selection card. The user's answers
     are returned as a normal chat message in the next turn.
@@ -26,13 +33,14 @@ def hearing(inference: str, questions: list[dict]) -> str:
         inference: Your reasoning or hypothesis to share with the user.
             This is displayed prominently above the questions to provide
             context and stimulate the user's thinking.
-        questions: List of question objects. Each question has:
-            - id (str): Unique question identifier (e.g. "q1")
+        q0: First question object with keys:
             - type (str): "single_select", "multi_select", or "free_text"
             - text (str): The question text
             - options (list[str], optional): Choices for select types
             - recommended (str or list[str], optional): Suggested choice(s)
             - placeholder (str, optional): Hint text for free_text type
+        q1: Second question (optional, same schema as q0).
+        q2: Third question (optional, same schema as q0).
 
     Returns:
         Confirmation that the questions were displayed. Wait for the

--- a/agent/tools/hearing_tool.py
+++ b/agent/tools/hearing_tool.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Strands Agent tool for structured user interviews.
+
+The hearing tool displays a structured question UI in the Web UI,
+enabling the agent to gather user input through selection-based
+and free-text questions instead of plain chat.
+"""
+
+from strands import tool
+
+
+@tool
+def hearing(inference: str, questions: list[dict]) -> str:
+    """Present structured questions to the user via a rich UI card.
+
+    Use this tool when you need specific input from the user and want to
+    provide clear options rather than asking open-ended questions.
+    Always include your reasoning or hypothesis in the inference field
+    to help the user think — never ask blank questions.
+
+    The Web UI renders a dedicated selection card. The user's answers
+    are returned as a normal chat message in the next turn.
+
+    Args:
+        inference: Your reasoning or hypothesis to share with the user.
+            This is displayed prominently above the questions to provide
+            context and stimulate the user's thinking.
+        questions: List of question objects. Each question has:
+            - id (str): Unique question identifier (e.g. "q1")
+            - type (str): "single_select", "multi_select", or "free_text"
+            - text (str): The question text
+            - options (list[str], optional): Choices for select types
+            - recommended (str or list[str], optional): Suggested choice(s)
+            - placeholder (str, optional): Hint text for free_text type
+
+    Returns:
+        Confirmation that the questions were displayed. Wait for the
+        user's response in the next message.
+    """
+    return "Questions displayed to user. Wait for their response."

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -249,7 +249,10 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
                 <HearingCard
                   key={block.tool.toolUseId}
                   inference={String(block.tool.input.inference)}
-                  questions={(block.tool.input.questions as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]) || []}
+                  questions={
+                    (block.tool.input.questions as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[])
+                    || ["q0","q1","q2"].map((k, i) => block.tool.input?.[k] ? { id: k, ...block.tool.input[k] as object } : null).filter(Boolean) as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]
+                  }
                   disabled={hearingDisabled}
                   onSubmit={(text) => onSend?.(text)}
                   onCancel={() => onSend?.("")}

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -23,6 +23,7 @@ import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import { ChevronRight, Sparkles, FileText as FileTextIcon, Image as ImageIcon } from "lucide-react"
 import { ToolCard, ToolCardCompact } from "./ToolCard"
+import { HearingCard } from "./HearingCard"
 import { SnippetBlock } from "./SnippetBlock"
 import { batchGetSlidePreviewUrls } from "@/services/deckService"
 
@@ -142,9 +143,13 @@ interface ChatMessageProps {
   isStreaming?: boolean
   /** Cognito ID token for fetching slide previews. */
   idToken?: string
+  /** Callback to send a message (used by HearingCard). */
+  onSend?: (text: string) => void
+  /** Whether hearing cards should be disabled (a new message was sent). */
+  hearingDisabled?: boolean
 }
 
-export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [], attachments = [], isStreaming = false, idToken }: ChatMessageProps) {
+export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [], attachments = [], isStreaming = false, idToken, onSend, hearingDisabled = false }: ChatMessageProps) {
   const isUser = role === "user"
   const [expanded, setExpanded] = useState(false)
   const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({})
@@ -240,6 +245,15 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
             {blocks.map((block, i) =>
               block.type === "text" ? (
                 <div key={`t-${i}`}>{renderTextBlock(block.text, i === blocks.length - 1)}</div>
+              ) : block.tool.name === "hearing" && block.tool.input?.inference ? (
+                <HearingCard
+                  key={block.tool.toolUseId}
+                  inference={String(block.tool.input.inference)}
+                  questions={(block.tool.input.questions as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]) || []}
+                  disabled={hearingDisabled}
+                  onSubmit={(text) => onSend?.(text)}
+                  onCancel={() => onSend?.("")}
+                />
               ) : (
                 <ToolCard
                   key={block.tool.toolUseId}

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -251,7 +251,7 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
                   inference={String(block.tool.input.inference)}
                   questions={
                     (block.tool.input.questions as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[])
-                    || ["q0","q1","q2"].map((k, i) => block.tool.input?.[k] ? { id: k, ...block.tool.input[k] as object } : null).filter(Boolean) as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]
+                    || ["q0","q1","q2","q3","q4"].map((k, i) => block.tool.input?.[k] ? { id: k, ...block.tool.input[k] as object } : null).filter(Boolean) as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]
                   }
                   disabled={hearingDisabled}
                   onSubmit={(text) => onSend?.(text)}

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -255,7 +255,7 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
                   }
                   disabled={hearingDisabled}
                   onSubmit={(text) => onSend?.(text)}
-                  onCancel={() => onSend?.("")}
+                  onCancel={() => onSend?.("（スキップ）")}
                 />
               ) : (
                 <ToolCard

--- a/web-ui/src/components/chat/ChatMessage.tsx
+++ b/web-ui/src/components/chat/ChatMessage.tsx
@@ -27,6 +27,15 @@ import { HearingCard } from "./HearingCard"
 import { SnippetBlock } from "./SnippetBlock"
 import { batchGetSlidePreviewUrls } from "@/services/deckService"
 
+type HearingQuestion = { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }
+
+function extractQuestions(input: Record<string, unknown>): HearingQuestion[] {
+  if (Array.isArray(input.questions)) return input.questions as HearingQuestion[]
+  return ["q0","q1","q2","q3","q4"]
+    .map((k) => input[k] ? { id: k, ...(input[k] as object) } : null)
+    .filter(Boolean) as HearingQuestion[]
+}
+
 const MENTION_RE = /(@Page\s\d+|@\[[^\]]+\])/g
 const SLIDE_PREVIEW_RE = /\[slide-preview:([a-f0-9]+):([a-z0-9_]+)\]/g
 const COLOR_CODE_RE = /(#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{3}))\b/g
@@ -249,13 +258,9 @@ export function ChatMessage({ role, content, toolUses = [], blocks, snippets = [
                 <HearingCard
                   key={block.tool.toolUseId}
                   inference={String(block.tool.input.inference)}
-                  questions={
-                    (block.tool.input.questions as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[])
-                    || ["q0","q1","q2","q3","q4"].map((k, i) => block.tool.input?.[k] ? { id: k, ...block.tool.input[k] as object } : null).filter(Boolean) as { id: string; type: "single_select" | "multi_select" | "free_text"; text: string; options?: string[]; recommended?: string | string[]; placeholder?: string }[]
-                  }
+                  questions={extractQuestions(block.tool.input as Record<string, unknown>)}
                   disabled={hearingDisabled}
                   onSubmit={(text) => onSend?.(text)}
-                  onCancel={() => onSend?.("（スキップ）")}
                 />
               ) : (
                 <ToolCard

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -791,6 +791,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                     attachments={msg.attachments}
                     isStreaming={isLoading && i === messages.length - 1}
                     idToken={auth.user?.id_token}
+                    onSend={handleSend}
+                    hearingDisabled={messages.slice(i + 1).some((m) => m.role === "user")}
                   />
                 </div>
               ))}

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -775,7 +775,9 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
             </div>
           ) : (
             <div className="space-y-4">
-              {messages.map((msg, i) => (
+              {(() => {
+                const lastUserIdx = messages.findLastIndex((m) => m.role === "user")
+                return messages.map((msg, i) => (
                 <div key={i}>
                   {msg.mcpStatus && (
                     <div className="mb-2 ml-10">
@@ -792,10 +794,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                     isStreaming={isLoading && i === messages.length - 1}
                     idToken={auth.user?.id_token}
                     onSend={handleSend}
-                    hearingDisabled={messages.slice(i + 1).some((m) => m.role === "user")}
+                    hearingDisabled={i < lastUserIdx}
                   />
                 </div>
-              ))}
+              ))
+              })()}
               <div ref={messagesEndRef} />
             </div>
           )}

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -101,21 +101,21 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
       className={`rounded-xl transition-all duration-300 ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
       style={{
         border: `1px solid ${isDisabled ? "oklch(1 0 0 / 5%)" : ACCENT_BORDER}`,
-        background: isDisabled ? "oklch(1 0 0 / 2%)" : ACCENT_GLOW,
-        boxShadow: isDisabled ? "none" : `0 0 24px -6px ${ACCENT_GLOW}`,
+        background: isDisabled ? "oklch(1 0 0 / 2%)" : "oklch(0.74 0.16 305 / 5%)",
+        boxShadow: isDisabled ? "none" : `0 0 30px -4px oklch(0.74 0.16 305 / 10%)`,
       }}
     >
       {/* Inference */}
       <div className="flex items-start gap-2.5 px-4 pt-3.5 pb-2">
         <Lightbulb className="h-4 w-4 mt-0.5 flex-none" style={{ color: ACCENT }} />
-        <p className="text-[13px] leading-relaxed" style={{ color: `${ACCENT}dd` }}>{inference}</p>
+        <p className="text-[13px] leading-relaxed" style={{ color: "oklch(0.78 0.12 305)" }}>{inference}</p>
       </div>
 
       {/* Questions */}
       <div className="px-4 pb-3 space-y-4" role="group">
         {questions.map((q) => (
           <fieldset key={q.id} className="space-y-2.5">
-            <legend className="text-[13px] font-medium text-foreground/80">{q.text}</legend>
+            <legend className="text-[13px] font-medium text-foreground/90">{q.text}</legend>
 
             {/* Chip-based select */}
             {(q.type === "single_select" || q.type === "multi_select") && q.options && (
@@ -136,8 +136,8 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                         className="relative px-3 py-1.5 rounded-full text-[12px] transition-all duration-150 active:scale-[0.96] focus:outline-none"
                         style={{
                           background: selected ? ACCENT : "oklch(1 0 0 / 4%)",
-                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.65 0 0)",
-                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 8%)"}`,
+                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.75 0 0)",
+                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 10%)"}`,
                           boxShadow: selected ? `0 0 10px -2px ${ACCENT_GLOW}` : "none",
                         }}
                       >
@@ -160,7 +160,7 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                   onChange={(e) => setNote(q.id, e.target.value)}
                   placeholder="補足があれば..."
                   aria-label={`${q.text} — additional notes`}
-                  className="w-full px-3 py-1.5 rounded-lg text-[12px] text-foreground/60 placeholder:text-foreground/20 focus:outline-none transition-colors duration-150"
+                  className="w-full px-3 py-1.5 rounded-lg text-[12px] text-foreground/70 placeholder:text-foreground/30 focus:outline-none transition-colors duration-150"
                   style={{
                     background: "oklch(1 0 0 / 2%)",
                     border: "1px solid oklch(1 0 0 / 4%)",

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -135,9 +135,9 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                         onClick={() => q.type === "single_select" ? toggleSingle(q.id, opt) : toggleMulti(q.id, opt)}
                         className="relative px-3 py-1.5 rounded-full text-[12px] transition-all duration-150 active:scale-[0.96] focus:outline-none"
                         style={{
-                          background: selected ? ACCENT : "oklch(1 0 0 / 6%)",
-                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.80 0 0)",
-                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 12%)"}`,
+                          background: selected ? "oklch(0.40 0.17 305)" : "oklch(1 0 0 / 6%)",
+                          color: selected ? "oklch(0.92 0.05 305)" : "oklch(0.80 0 0)",
+                          border: `1px solid ${selected ? "oklch(0.55 0.17 305)" : "oklch(1 0 0 / 12%)"}`,
                           boxShadow: selected ? `0 0 10px -2px ${ACCENT_GLOW}` : "none",
                         }}
                       >

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -4,11 +4,9 @@
 
 import { useState } from "react"
 import { Lightbulb, Send } from "lucide-react"
+import { CAT } from "./ToolCard"
 
-const ACCENT = "oklch(0.76 0.17 305)"
-const ACCENT_DIM = "oklch(0.76 0.17 305 / 15%)"
-const ACCENT_BORDER = "oklch(0.76 0.17 305 / 25%)"
-const ACCENT_GLOW = "oklch(0.76 0.17 305 / 10%)"
+const P = CAT.hearing
 
 interface Question {
   id: string
@@ -24,7 +22,6 @@ interface HearingCardProps {
   questions: Question[]
   disabled?: boolean
   onSubmit: (text: string) => void
-  onCancel: () => void
 }
 
 function isRecommended(option: string, rec?: string | string[]): boolean {
@@ -52,7 +49,7 @@ function formatAnswers(questions: Question[], answers: Answers): string {
     .join("\n")
 }
 
-export function HearingCard({ inference, questions, disabled = false, onSubmit, onCancel }: HearingCardProps) {
+export function HearingCard({ inference, questions, disabled = false, onSubmit }: HearingCardProps) {
   const [answers, setAnswers] = useState<Answers>({ selections: {}, notes: {} })
   const [submitted, setSubmitted] = useState(false)
 
@@ -100,15 +97,15 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
       aria-disabled={isDisabled}
       className={`rounded-xl transition-all duration-300 ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
       style={{
-        border: `1px solid ${isDisabled ? "oklch(1 0 0 / 5%)" : ACCENT_BORDER}`,
-        background: isDisabled ? "oklch(1 0 0 / 2%)" : "oklch(0.76 0.17 305 / 6%)",
-        boxShadow: isDisabled ? "none" : `0 0 30px -4px oklch(0.76 0.17 305 / 12%)`,
+        border: `1px solid ${isDisabled ? "oklch(1 0 0 / 5%)" : P.border}`,
+        background: isDisabled ? "oklch(1 0 0 / 2%)" : P.bg,
+        boxShadow: isDisabled ? "none" : `0 0 30px -4px ${P.glow}`,
       }}
     >
       {/* Inference */}
       <div className="flex items-start gap-2.5 px-4 pt-3.5 pb-2">
-        <Lightbulb className="h-4 w-4 mt-0.5 flex-none" style={{ color: ACCENT }} />
-        <p className="text-[13px] leading-relaxed" style={{ color: "oklch(0.82 0.12 305)" }}>{inference}</p>
+        <Lightbulb className="h-4 w-4 mt-0.5 flex-none" style={{ color: P.accent }} />
+        <p className="text-[13px] leading-relaxed" style={{ color: P.accent }}>{inference}</p>
       </div>
 
       {/* Questions */}
@@ -116,7 +113,6 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
         {questions.map((q) => (
           <fieldset key={q.id} className="space-y-2.5 animate-in fade-in-0 duration-300">
             {!q.text ? (
-              /* Skeleton for question still streaming */
               <div className="space-y-2">
                 <div className="h-4 w-2/3 rounded bg-white/[4%] animate-pulse" />
                 <div className="flex gap-1.5">
@@ -129,7 +125,6 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
             <>
             <legend className="text-[13px] font-medium text-foreground">{q.text}</legend>
 
-            {/* Chip-based select */}
             {(q.type === "single_select" || q.type === "multi_select") && q.options && (
               <>
                 <div className="flex flex-wrap gap-1.5" role={q.type === "single_select" ? "radiogroup" : "group"} aria-label={q.text}>
@@ -147,17 +142,17 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                         onClick={() => q.type === "single_select" ? toggleSingle(q.id, opt) : toggleMulti(q.id, opt)}
                         className="relative px-3 py-1.5 rounded-full text-[12px] transition-all duration-150 active:scale-[0.96] focus:outline-none"
                         style={{
-                          background: selected ? "oklch(0.40 0.17 305)" : "oklch(1 0 0 / 6%)",
-                          color: selected ? "oklch(0.92 0.05 305)" : "oklch(0.80 0 0)",
-                          border: `1px solid ${selected ? "oklch(0.55 0.17 305)" : "oklch(1 0 0 / 12%)"}`,
-                          boxShadow: selected ? `0 0 10px -2px ${ACCENT_GLOW}` : "none",
+                          background: selected ? P.border : "oklch(1 0 0 / 6%)",
+                          color: selected ? "oklch(0.95 0 0)" : "oklch(0.80 0 0)",
+                          border: `1px solid ${selected ? P.accent : "oklch(1 0 0 / 12%)"}`,
+                          boxShadow: selected ? `0 0 10px -2px ${P.glow}` : "none",
                         }}
                       >
                         {opt}
                         {rec && !selected && (
                           <span
                             className="absolute -top-1 -right-1 w-2 h-2 rounded-full"
-                            style={{ background: ACCENT }}
+                            style={{ background: P.accent }}
                             title="Recommended"
                           />
                         )}
@@ -165,7 +160,6 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                     )
                   })}
                 </div>
-                {/* Note field for select questions */}
                 <input
                   type="text"
                   value={answers.notes[q.id] || ""}
@@ -177,13 +171,12 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                     background: "oklch(1 0 0 / 2%)",
                     border: "1px solid oklch(1 0 0 / 4%)",
                   }}
-                  onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
+                  onFocus={(e) => { e.currentTarget.style.borderColor = P.border }}
                   onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 4%)" }}
                 />
               </>
             )}
 
-            {/* Free text */}
             {q.type === "free_text" && (
               <textarea
                 value={(answers.selections[q.id] as string) || ""}
@@ -196,7 +189,7 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                   background: "oklch(1 0 0 / 3%)",
                   border: "1px solid oklch(1 0 0 / 5%)",
                 }}
-                onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
+                onFocus={(e) => { e.currentTarget.style.borderColor = P.border }}
                 onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 5%)" }}
               />
             )}
@@ -206,28 +199,20 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
         ))}
       </div>
 
-      {/* Actions */}
       {!isDisabled && (
         <div className="flex justify-end gap-2 px-4 pb-3.5">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="px-3 py-1.5 text-[12px] text-foreground/40 hover:text-foreground/60 transition-colors rounded-lg focus:outline-none"
-          >
-            Skip
-          </button>
           <button
             type="button"
             onClick={handleSubmit}
             disabled={!hasAnswer}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium active:scale-[0.97] disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-150 focus:outline-none"
             style={{
-              background: ACCENT_DIM,
-              color: ACCENT,
-              boxShadow: hasAnswer ? `0 0 12px -3px ${ACCENT_GLOW}` : "none",
+              background: P.bg,
+              color: P.accent,
+              boxShadow: hasAnswer ? `0 0 12px -3px ${P.glow}` : "none",
             }}
-            onMouseEnter={(e) => { if (hasAnswer) e.currentTarget.style.background = "oklch(0.74 0.16 305 / 20%)" }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = ACCENT_DIM }}
+            onMouseEnter={(e) => { if (hasAnswer) e.currentTarget.style.background = P.border }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = P.bg }}
           >
             <Send className="h-3 w-3" />
             Submit

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -114,7 +114,19 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
       {/* Questions */}
       <div className="px-4 pb-3 space-y-4" role="group">
         {questions.map((q) => (
-          <fieldset key={q.id} className="space-y-2.5">
+          <fieldset key={q.id} className="space-y-2.5 animate-in fade-in-0 duration-300">
+            {!q.text ? (
+              /* Skeleton for question still streaming */
+              <div className="space-y-2">
+                <div className="h-4 w-2/3 rounded bg-white/[4%] animate-pulse" />
+                <div className="flex gap-1.5">
+                  <div className="h-7 w-20 rounded-full bg-white/[3%] animate-pulse" />
+                  <div className="h-7 w-24 rounded-full bg-white/[3%] animate-pulse" />
+                  <div className="h-7 w-16 rounded-full bg-white/[3%] animate-pulse" />
+                </div>
+              </div>
+            ) : (
+            <>
             <legend className="text-[13px] font-medium text-foreground">{q.text}</legend>
 
             {/* Chip-based select */}
@@ -187,6 +199,8 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                 onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
                 onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 5%)" }}
               />
+            )}
+          </>
             )}
           </fieldset>
         ))}

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -41,7 +41,7 @@ function formatAnswers(questions: Question[], answers: Answers): string {
       const note = answers.notes[q.id]?.trim()
       const selText = sel ? (Array.isArray(sel) ? sel.join(", ") : sel) : ""
       if (!selText && !note) return null
-      if (selText && note) return `${q.text}: ${selText}（${note}）`
+      if (selText && note) return `${q.text}: ${selText} (${note})`
       if (selText) return `${q.text}: ${selText}`
       return `${q.text}: ${note}`
     })
@@ -164,7 +164,7 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit }
                   type="text"
                   value={answers.notes[q.id] || ""}
                   onChange={(e) => setNote(q.id, e.target.value)}
-                  placeholder="補足があれば..."
+                  placeholder="Additional notes..."
                   aria-label={`${q.text} — additional notes`}
                   className="w-full px-3 py-1.5 rounded-lg text-[12px] text-foreground/70 placeholder:text-foreground/30 focus:outline-none transition-colors duration-150"
                   style={{

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -5,10 +5,10 @@
 import { useState } from "react"
 import { Lightbulb, Send } from "lucide-react"
 
-const ACCENT = "oklch(0.74 0.16 305)"
-const ACCENT_DIM = "oklch(0.74 0.16 305 / 12%)"
-const ACCENT_BORDER = "oklch(0.74 0.16 305 / 20%)"
-const ACCENT_GLOW = "oklch(0.74 0.16 305 / 8%)"
+const ACCENT = "oklch(0.76 0.17 305)"
+const ACCENT_DIM = "oklch(0.76 0.17 305 / 15%)"
+const ACCENT_BORDER = "oklch(0.76 0.17 305 / 25%)"
+const ACCENT_GLOW = "oklch(0.76 0.17 305 / 10%)"
 
 interface Question {
   id: string
@@ -101,21 +101,21 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
       className={`rounded-xl transition-all duration-300 ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
       style={{
         border: `1px solid ${isDisabled ? "oklch(1 0 0 / 5%)" : ACCENT_BORDER}`,
-        background: isDisabled ? "oklch(1 0 0 / 2%)" : "oklch(0.74 0.16 305 / 5%)",
-        boxShadow: isDisabled ? "none" : `0 0 30px -4px oklch(0.74 0.16 305 / 10%)`,
+        background: isDisabled ? "oklch(1 0 0 / 2%)" : "oklch(0.76 0.17 305 / 6%)",
+        boxShadow: isDisabled ? "none" : `0 0 30px -4px oklch(0.76 0.17 305 / 12%)`,
       }}
     >
       {/* Inference */}
       <div className="flex items-start gap-2.5 px-4 pt-3.5 pb-2">
         <Lightbulb className="h-4 w-4 mt-0.5 flex-none" style={{ color: ACCENT }} />
-        <p className="text-[13px] leading-relaxed" style={{ color: "oklch(0.78 0.12 305)" }}>{inference}</p>
+        <p className="text-[13px] leading-relaxed" style={{ color: "oklch(0.82 0.12 305)" }}>{inference}</p>
       </div>
 
       {/* Questions */}
       <div className="px-4 pb-3 space-y-4" role="group">
         {questions.map((q) => (
           <fieldset key={q.id} className="space-y-2.5">
-            <legend className="text-[13px] font-medium text-foreground/90">{q.text}</legend>
+            <legend className="text-[13px] font-medium text-foreground">{q.text}</legend>
 
             {/* Chip-based select */}
             {(q.type === "single_select" || q.type === "multi_select") && q.options && (
@@ -135,9 +135,9 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                         onClick={() => q.type === "single_select" ? toggleSingle(q.id, opt) : toggleMulti(q.id, opt)}
                         className="relative px-3 py-1.5 rounded-full text-[12px] transition-all duration-150 active:scale-[0.96] focus:outline-none"
                         style={{
-                          background: selected ? ACCENT : "oklch(1 0 0 / 4%)",
-                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.75 0 0)",
-                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 10%)"}`,
+                          background: selected ? ACCENT : "oklch(1 0 0 / 6%)",
+                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.80 0 0)",
+                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 12%)"}`,
                           boxShadow: selected ? `0 0 10px -2px ${ACCENT_GLOW}` : "none",
                         }}
                       >

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -5,10 +5,6 @@
 import { useState } from "react"
 import { Lightbulb, Send } from "lucide-react"
 
-/**
- * Hearing accent — oklch violet matching ToolCard "produce" category
- * but slightly warmer to distinguish interactive cards from output tools.
- */
 const ACCENT = "oklch(0.74 0.16 305)"
 const ACCENT_DIM = "oklch(0.74 0.16 305 / 12%)"
 const ACCENT_BORDER = "oklch(0.74 0.16 305 / 20%)"
@@ -36,29 +32,50 @@ function isRecommended(option: string, rec?: string | string[]): boolean {
   return Array.isArray(rec) ? rec.includes(option) : rec === option
 }
 
-function formatAnswers(questions: Question[], answers: Record<string, string | string[]>): string {
+interface Answers {
+  selections: Record<string, string | string[]>
+  notes: Record<string, string>
+}
+
+function formatAnswers(questions: Question[], answers: Answers): string {
   return questions
     .map((q) => {
-      const a = answers[q.id]
-      if (!a || (Array.isArray(a) && a.length === 0)) return null
-      const val = Array.isArray(a) ? a.join(", ") : a
-      return val ? `${q.text}: ${val}` : null
+      const sel = answers.selections[q.id]
+      const note = answers.notes[q.id]?.trim()
+      const selText = sel ? (Array.isArray(sel) ? sel.join(", ") : sel) : ""
+      if (!selText && !note) return null
+      if (selText && note) return `${q.text}: ${selText}（${note}）`
+      if (selText) return `${q.text}: ${selText}`
+      return `${q.text}: ${note}`
     })
     .filter(Boolean)
     .join("\n")
 }
 
 export function HearingCard({ inference, questions, disabled = false, onSubmit, onCancel }: HearingCardProps) {
-  const [answers, setAnswers] = useState<Record<string, string | string[]>>({})
+  const [answers, setAnswers] = useState<Answers>({ selections: {}, notes: {} })
   const [submitted, setSubmitted] = useState(false)
 
-  const setSingle = (id: string, value: string) => setAnswers((p) => ({ ...p, [id]: value }))
+  const toggleSingle = (id: string, value: string) =>
+    setAnswers((p) => ({
+      ...p,
+      selections: { ...p.selections, [id]: p.selections[id] === value ? "" : value },
+    }))
+
   const toggleMulti = (id: string, value: string) =>
     setAnswers((p) => {
-      const cur = (p[id] as string[]) || []
-      return { ...p, [id]: cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value] }
+      const cur = (p.selections[id] as string[]) || []
+      return {
+        ...p,
+        selections: { ...p.selections, [id]: cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value] },
+      }
     })
-  const setText = (id: string, value: string) => setAnswers((p) => ({ ...p, [id]: value }))
+
+  const setNote = (id: string, value: string) =>
+    setAnswers((p) => ({ ...p, notes: { ...p.notes, [id]: value } }))
+
+  const setText = (id: string, value: string) =>
+    setAnswers((p) => ({ ...p, selections: { ...p.selections, [id]: value } }))
 
   const handleSubmit = () => {
     const text = formatAnswers(questions, answers)
@@ -69,16 +86,12 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
   }
 
   const hasAnswer = questions.some((q) => {
-    const a = answers[q.id]
-    return a && (typeof a === "string" ? a.trim() : a.length > 0)
+    const sel = answers.selections[q.id]
+    const note = answers.notes[q.id]?.trim()
+    return note || (sel && (typeof sel === "string" ? sel.trim() : sel.length > 0))
   })
 
   const isDisabled = disabled || submitted
-
-  /* Style objects using oklch accent — avoids Tailwind purple mismatch with project palette */
-  const optionBase = { border: `1px solid oklch(1 0 0 / 5%)`, background: "oklch(1 0 0 / 3%)" }
-  const optionHover = { border: `1px solid oklch(1 0 0 / 8%)`, background: "oklch(1 0 0 / 5%)" }
-  const optionSelected = { border: `1px solid ${ACCENT_BORDER}`, background: ACCENT_DIM }
 
   return (
     <div
@@ -101,88 +114,67 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
       {/* Questions */}
       <div className="px-4 pb-3 space-y-4" role="group">
         {questions.map((q) => (
-          <fieldset key={q.id} className="space-y-2">
+          <fieldset key={q.id} className="space-y-2.5">
             <legend className="text-[13px] font-medium text-foreground/80">{q.text}</legend>
 
-            {q.type === "single_select" && q.options && (
-              <div className="space-y-1.5" role="radiogroup" aria-label={q.text}>
-                {q.options.map((opt) => {
-                  const selected = answers[q.id] === opt
-                  return (
-                    <label
-                      key={opt}
-                      className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-150"
-                      style={{
-                        ...(selected ? optionSelected : optionBase),
-                        transform: selected ? "scale(1.01)" : "scale(1)",
-                      }}
-                      onMouseEnter={(e) => { if (!selected) Object.assign(e.currentTarget.style, optionHover) }}
-                      onMouseLeave={(e) => { if (!selected) Object.assign(e.currentTarget.style, optionBase) }}
-                    >
-                      <input type="radio" name={q.id} value={opt} checked={selected} onChange={() => setSingle(q.id, opt)} className="sr-only" />
-                      <div
-                        className="w-3.5 h-3.5 rounded-full border-2 flex items-center justify-center transition-colors duration-150"
-                        style={{ borderColor: selected ? ACCENT : "oklch(1 0 0 / 12%)" }}
-                      >
-                        {selected && <div className="w-1.5 h-1.5 rounded-full animate-in zoom-in-50 duration-150" style={{ background: ACCENT }} />}
-                      </div>
-                      <span className="text-[12px] text-foreground/70 flex-1">{opt}</span>
-                      {isRecommended(opt, q.recommended) && (
-                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded" style={{ background: ACCENT_DIM, color: ACCENT }}>
-                          Recommended
-                        </span>
-                      )}
-                    </label>
-                  )
-                })}
-              </div>
-            )}
-
-            {q.type === "multi_select" && q.options && (
-              <div className="space-y-1.5" role="group" aria-label={q.text}>
-                {q.options.map((opt) => {
-                  const checked = ((answers[q.id] as string[]) || []).includes(opt)
-                  return (
-                    <label
-                      key={opt}
-                      className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-150"
-                      style={{
-                        ...(checked ? optionSelected : optionBase),
-                        transform: checked ? "scale(1.01)" : "scale(1)",
-                      }}
-                      onMouseEnter={(e) => { if (!checked) Object.assign(e.currentTarget.style, optionHover) }}
-                      onMouseLeave={(e) => { if (!checked) Object.assign(e.currentTarget.style, optionBase) }}
-                    >
-                      <input type="checkbox" checked={checked} onChange={() => toggleMulti(q.id, opt)} className="sr-only" aria-label={opt} />
-                      <div
-                        className="w-3.5 h-3.5 rounded border-2 flex items-center justify-center transition-all duration-150"
+            {/* Chip-based select */}
+            {(q.type === "single_select" || q.type === "multi_select") && q.options && (
+              <>
+                <div className="flex flex-wrap gap-1.5" role={q.type === "single_select" ? "radiogroup" : "group"} aria-label={q.text}>
+                  {q.options.map((opt) => {
+                    const selected = q.type === "single_select"
+                      ? answers.selections[q.id] === opt
+                      : ((answers.selections[q.id] as string[]) || []).includes(opt)
+                    const rec = isRecommended(opt, q.recommended)
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        role={q.type === "single_select" ? "radio" : "checkbox"}
+                        aria-checked={selected}
+                        onClick={() => q.type === "single_select" ? toggleSingle(q.id, opt) : toggleMulti(q.id, opt)}
+                        className="relative px-3 py-1.5 rounded-full text-[12px] transition-all duration-150 active:scale-[0.96] focus:outline-none"
                         style={{
-                          borderColor: checked ? ACCENT : "oklch(1 0 0 / 12%)",
-                          background: checked ? ACCENT : "transparent",
-                          transform: checked ? "scale(1.05)" : "scale(1)",
+                          background: selected ? ACCENT : "oklch(1 0 0 / 4%)",
+                          color: selected ? "oklch(0.98 0 0)" : "oklch(0.65 0 0)",
+                          border: `1px solid ${selected ? ACCENT : "oklch(1 0 0 / 8%)"}`,
+                          boxShadow: selected ? `0 0 10px -2px ${ACCENT_GLOW}` : "none",
                         }}
                       >
-                        {checked && (
-                          <svg className="w-2.5 h-2.5 text-white animate-in zoom-in-50 duration-150" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
-                            <path d="M2 6l3 3 5-5" />
-                          </svg>
+                        {opt}
+                        {rec && !selected && (
+                          <span
+                            className="absolute -top-1 -right-1 w-2 h-2 rounded-full"
+                            style={{ background: ACCENT }}
+                            title="Recommended"
+                          />
                         )}
-                      </div>
-                      <span className="text-[12px] text-foreground/70 flex-1">{opt}</span>
-                      {isRecommended(opt, q.recommended) && (
-                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded" style={{ background: ACCENT_DIM, color: ACCENT }}>
-                          Recommended
-                        </span>
-                      )}
-                    </label>
-                  )
-                })}
-              </div>
+                      </button>
+                    )
+                  })}
+                </div>
+                {/* Note field for select questions */}
+                <input
+                  type="text"
+                  value={answers.notes[q.id] || ""}
+                  onChange={(e) => setNote(q.id, e.target.value)}
+                  placeholder="補足があれば..."
+                  aria-label={`${q.text} — additional notes`}
+                  className="w-full px-3 py-1.5 rounded-lg text-[12px] text-foreground/60 placeholder:text-foreground/20 focus:outline-none transition-colors duration-150"
+                  style={{
+                    background: "oklch(1 0 0 / 2%)",
+                    border: "1px solid oklch(1 0 0 / 4%)",
+                  }}
+                  onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
+                  onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 4%)" }}
+                />
+              </>
             )}
 
+            {/* Free text */}
             {q.type === "free_text" && (
               <textarea
-                value={(answers[q.id] as string) || ""}
+                value={(answers.selections[q.id] as string) || ""}
                 onChange={(e) => setText(q.id, e.target.value)}
                 placeholder={q.placeholder}
                 rows={2}
@@ -190,7 +182,7 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
                 className="w-full px-3 py-2 rounded-lg text-[12px] text-foreground/70 placeholder:text-foreground/25 focus:outline-none resize-y min-h-[2.5rem] transition-colors duration-150"
                 style={{
                   background: "oklch(1 0 0 / 3%)",
-                  border: `1px solid oklch(1 0 0 / 5%)`,
+                  border: "1px solid oklch(1 0 0 / 5%)",
                 }}
                 onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
                 onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 5%)" }}
@@ -207,7 +199,6 @@ export function HearingCard({ inference, questions, disabled = false, onSubmit, 
             type="button"
             onClick={onCancel}
             className="px-3 py-1.5 text-[12px] text-foreground/40 hover:text-foreground/60 transition-colors rounded-lg focus:outline-none"
-            style={{ boxShadow: "none" }}
           >
             Skip
           </button>

--- a/web-ui/src/components/chat/HearingCard.tsx
+++ b/web-ui/src/components/chat/HearingCard.tsx
@@ -1,0 +1,234 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+"use client"
+
+import { useState } from "react"
+import { Lightbulb, Send } from "lucide-react"
+
+/**
+ * Hearing accent — oklch violet matching ToolCard "produce" category
+ * but slightly warmer to distinguish interactive cards from output tools.
+ */
+const ACCENT = "oklch(0.74 0.16 305)"
+const ACCENT_DIM = "oklch(0.74 0.16 305 / 12%)"
+const ACCENT_BORDER = "oklch(0.74 0.16 305 / 20%)"
+const ACCENT_GLOW = "oklch(0.74 0.16 305 / 8%)"
+
+interface Question {
+  id: string
+  type: "single_select" | "multi_select" | "free_text"
+  text: string
+  options?: string[]
+  recommended?: string | string[]
+  placeholder?: string
+}
+
+interface HearingCardProps {
+  inference: string
+  questions: Question[]
+  disabled?: boolean
+  onSubmit: (text: string) => void
+  onCancel: () => void
+}
+
+function isRecommended(option: string, rec?: string | string[]): boolean {
+  if (!rec) return false
+  return Array.isArray(rec) ? rec.includes(option) : rec === option
+}
+
+function formatAnswers(questions: Question[], answers: Record<string, string | string[]>): string {
+  return questions
+    .map((q) => {
+      const a = answers[q.id]
+      if (!a || (Array.isArray(a) && a.length === 0)) return null
+      const val = Array.isArray(a) ? a.join(", ") : a
+      return val ? `${q.text}: ${val}` : null
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
+export function HearingCard({ inference, questions, disabled = false, onSubmit, onCancel }: HearingCardProps) {
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({})
+  const [submitted, setSubmitted] = useState(false)
+
+  const setSingle = (id: string, value: string) => setAnswers((p) => ({ ...p, [id]: value }))
+  const toggleMulti = (id: string, value: string) =>
+    setAnswers((p) => {
+      const cur = (p[id] as string[]) || []
+      return { ...p, [id]: cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value] }
+    })
+  const setText = (id: string, value: string) => setAnswers((p) => ({ ...p, [id]: value }))
+
+  const handleSubmit = () => {
+    const text = formatAnswers(questions, answers)
+    if (text) {
+      setSubmitted(true)
+      onSubmit(text)
+    }
+  }
+
+  const hasAnswer = questions.some((q) => {
+    const a = answers[q.id]
+    return a && (typeof a === "string" ? a.trim() : a.length > 0)
+  })
+
+  const isDisabled = disabled || submitted
+
+  /* Style objects using oklch accent — avoids Tailwind purple mismatch with project palette */
+  const optionBase = { border: `1px solid oklch(1 0 0 / 5%)`, background: "oklch(1 0 0 / 3%)" }
+  const optionHover = { border: `1px solid oklch(1 0 0 / 8%)`, background: "oklch(1 0 0 / 5%)" }
+  const optionSelected = { border: `1px solid ${ACCENT_BORDER}`, background: ACCENT_DIM }
+
+  return (
+    <div
+      role="form"
+      aria-label="Agent questions"
+      aria-disabled={isDisabled}
+      className={`rounded-xl transition-all duration-300 ${isDisabled ? "opacity-50 pointer-events-none" : ""}`}
+      style={{
+        border: `1px solid ${isDisabled ? "oklch(1 0 0 / 5%)" : ACCENT_BORDER}`,
+        background: isDisabled ? "oklch(1 0 0 / 2%)" : ACCENT_GLOW,
+        boxShadow: isDisabled ? "none" : `0 0 24px -6px ${ACCENT_GLOW}`,
+      }}
+    >
+      {/* Inference */}
+      <div className="flex items-start gap-2.5 px-4 pt-3.5 pb-2">
+        <Lightbulb className="h-4 w-4 mt-0.5 flex-none" style={{ color: ACCENT }} />
+        <p className="text-[13px] leading-relaxed" style={{ color: `${ACCENT}dd` }}>{inference}</p>
+      </div>
+
+      {/* Questions */}
+      <div className="px-4 pb-3 space-y-4" role="group">
+        {questions.map((q) => (
+          <fieldset key={q.id} className="space-y-2">
+            <legend className="text-[13px] font-medium text-foreground/80">{q.text}</legend>
+
+            {q.type === "single_select" && q.options && (
+              <div className="space-y-1.5" role="radiogroup" aria-label={q.text}>
+                {q.options.map((opt) => {
+                  const selected = answers[q.id] === opt
+                  return (
+                    <label
+                      key={opt}
+                      className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-150"
+                      style={{
+                        ...(selected ? optionSelected : optionBase),
+                        transform: selected ? "scale(1.01)" : "scale(1)",
+                      }}
+                      onMouseEnter={(e) => { if (!selected) Object.assign(e.currentTarget.style, optionHover) }}
+                      onMouseLeave={(e) => { if (!selected) Object.assign(e.currentTarget.style, optionBase) }}
+                    >
+                      <input type="radio" name={q.id} value={opt} checked={selected} onChange={() => setSingle(q.id, opt)} className="sr-only" />
+                      <div
+                        className="w-3.5 h-3.5 rounded-full border-2 flex items-center justify-center transition-colors duration-150"
+                        style={{ borderColor: selected ? ACCENT : "oklch(1 0 0 / 12%)" }}
+                      >
+                        {selected && <div className="w-1.5 h-1.5 rounded-full animate-in zoom-in-50 duration-150" style={{ background: ACCENT }} />}
+                      </div>
+                      <span className="text-[12px] text-foreground/70 flex-1">{opt}</span>
+                      {isRecommended(opt, q.recommended) && (
+                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded" style={{ background: ACCENT_DIM, color: ACCENT }}>
+                          Recommended
+                        </span>
+                      )}
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+
+            {q.type === "multi_select" && q.options && (
+              <div className="space-y-1.5" role="group" aria-label={q.text}>
+                {q.options.map((opt) => {
+                  const checked = ((answers[q.id] as string[]) || []).includes(opt)
+                  return (
+                    <label
+                      key={opt}
+                      className="flex items-center gap-2.5 px-3 py-2 rounded-lg cursor-pointer transition-all duration-150"
+                      style={{
+                        ...(checked ? optionSelected : optionBase),
+                        transform: checked ? "scale(1.01)" : "scale(1)",
+                      }}
+                      onMouseEnter={(e) => { if (!checked) Object.assign(e.currentTarget.style, optionHover) }}
+                      onMouseLeave={(e) => { if (!checked) Object.assign(e.currentTarget.style, optionBase) }}
+                    >
+                      <input type="checkbox" checked={checked} onChange={() => toggleMulti(q.id, opt)} className="sr-only" aria-label={opt} />
+                      <div
+                        className="w-3.5 h-3.5 rounded border-2 flex items-center justify-center transition-all duration-150"
+                        style={{
+                          borderColor: checked ? ACCENT : "oklch(1 0 0 / 12%)",
+                          background: checked ? ACCENT : "transparent",
+                          transform: checked ? "scale(1.05)" : "scale(1)",
+                        }}
+                      >
+                        {checked && (
+                          <svg className="w-2.5 h-2.5 text-white animate-in zoom-in-50 duration-150" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path d="M2 6l3 3 5-5" />
+                          </svg>
+                        )}
+                      </div>
+                      <span className="text-[12px] text-foreground/70 flex-1">{opt}</span>
+                      {isRecommended(opt, q.recommended) && (
+                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded" style={{ background: ACCENT_DIM, color: ACCENT }}>
+                          Recommended
+                        </span>
+                      )}
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+
+            {q.type === "free_text" && (
+              <textarea
+                value={(answers[q.id] as string) || ""}
+                onChange={(e) => setText(q.id, e.target.value)}
+                placeholder={q.placeholder}
+                rows={2}
+                aria-label={q.text}
+                className="w-full px-3 py-2 rounded-lg text-[12px] text-foreground/70 placeholder:text-foreground/25 focus:outline-none resize-y min-h-[2.5rem] transition-colors duration-150"
+                style={{
+                  background: "oklch(1 0 0 / 3%)",
+                  border: `1px solid oklch(1 0 0 / 5%)`,
+                }}
+                onFocus={(e) => { e.currentTarget.style.borderColor = ACCENT_BORDER }}
+                onBlur={(e) => { e.currentTarget.style.borderColor = "oklch(1 0 0 / 5%)" }}
+              />
+            )}
+          </fieldset>
+        ))}
+      </div>
+
+      {/* Actions */}
+      {!isDisabled && (
+        <div className="flex justify-end gap-2 px-4 pb-3.5">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-[12px] text-foreground/40 hover:text-foreground/60 transition-colors rounded-lg focus:outline-none"
+            style={{ boxShadow: "none" }}
+          >
+            Skip
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!hasAnswer}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[12px] font-medium active:scale-[0.97] disabled:opacity-30 disabled:cursor-not-allowed transition-all duration-150 focus:outline-none"
+            style={{
+              background: ACCENT_DIM,
+              color: ACCENT,
+              boxShadow: hasAnswer ? `0 0 12px -3px ${ACCENT_GLOW}` : "none",
+            }}
+            onMouseEnter={(e) => { if (hasAnswer) e.currentTarget.style.background = "oklch(0.74 0.16 305 / 20%)" }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = ACCENT_DIM }}
+          >
+            <Send className="h-3 w-3" />
+            Submit
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web-ui/src/components/chat/ToolCard.tsx
+++ b/web-ui/src/components/chat/ToolCard.tsx
@@ -32,7 +32,7 @@ import {
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 
-type ToolCategory = "build" | "explore" | "produce" | "compute" | "other"
+type ToolCategory = "build" | "explore" | "produce" | "compute" | "hearing" | "other"
 
 interface ToolMeta {
   Icon: LucideIcon
@@ -41,11 +41,12 @@ interface ToolMeta {
 }
 
 /** Accent palette per category — oklch for perceptual uniformity. */
-const CAT: Record<ToolCategory, { accent: string; bg: string; glow: string; border: string }> = {
+export const CAT: Record<ToolCategory, { accent: string; bg: string; glow: string; border: string }> = {
   build:   { accent: "oklch(0.75 0.14 185)", bg: "oklch(0.75 0.14 185 / 6%)",  glow: "oklch(0.75 0.14 185 / 12%)", border: "oklch(0.75 0.14 185 / 18%)" },
   explore: { accent: "oklch(0.80 0.14 80)",  bg: "oklch(0.80 0.14 80 / 6%)",   glow: "oklch(0.80 0.14 80 / 12%)",  border: "oklch(0.80 0.14 80 / 18%)" },
   produce: { accent: "oklch(0.72 0.16 300)", bg: "oklch(0.72 0.16 300 / 6%)",  glow: "oklch(0.72 0.16 300 / 12%)", border: "oklch(0.72 0.16 300 / 18%)" },
   compute: { accent: "oklch(0.78 0.12 220)", bg: "oklch(0.78 0.12 220 / 6%)",  glow: "oklch(0.78 0.12 220 / 12%)", border: "oklch(0.78 0.12 220 / 18%)" },
+  hearing: { accent: "oklch(0.74 0.16 330)", bg: "oklch(0.74 0.16 330 / 6%)",  glow: "oklch(0.74 0.16 330 / 12%)", border: "oklch(0.74 0.16 330 / 18%)" },
   other:   { accent: "oklch(0.55 0 0)",      bg: "oklch(0.55 0 0 / 4%)",       glow: "oklch(0.55 0 0 / 8%)",       border: "oklch(0.55 0 0 / 12%)" },
 }
 
@@ -91,7 +92,7 @@ const TOOL_META: Record<string, ToolMeta> = {
   pptx_to_json:       { Icon: FileText,        label: "Converting PPTX",        category: "explore" },
   grid:               { Icon: LayoutTemplate,  label: "Computing layout",       category: "compute" },
   // MCP prefixed tools (Strands adds prefix from MCPClient)
-  hearing:            { Icon: BookOpen,        label: "Asking questions",       category: "explore" },
+  hearing:            { Icon: BookOpen,        label: "Asking questions",       category: "hearing" },
   spec_driven_presentation_maker_init_presentation:  { Icon: FolderPlus,     label: "Initializing deck",     category: "build" },
   spec_driven_presentation_maker_analyze_template:   { Icon: LayoutTemplate, label: "Analyzing template",    category: "explore" },
   spec_driven_presentation_maker_start_presentation: { Icon: Play,           label: "Starting workflow",      category: "explore" },

--- a/web-ui/src/components/chat/ToolCard.tsx
+++ b/web-ui/src/components/chat/ToolCard.tsx
@@ -91,6 +91,7 @@ const TOOL_META: Record<string, ToolMeta> = {
   pptx_to_json:       { Icon: FileText,        label: "Converting PPTX",        category: "explore" },
   grid:               { Icon: LayoutTemplate,  label: "Computing layout",       category: "compute" },
   // MCP prefixed tools (Strands adds prefix from MCPClient)
+  hearing:            { Icon: BookOpen,        label: "Asking questions",       category: "explore" },
   spec_driven_presentation_maker_init_presentation:  { Icon: FolderPlus,     label: "Initializing deck",     category: "build" },
   spec_driven_presentation_maker_analyze_template:   { Icon: LayoutTemplate, label: "Analyzing template",    category: "explore" },
   spec_driven_presentation_maker_start_presentation: { Icon: Play,           label: "Starting workflow",      category: "explore" },


### PR DESCRIPTION
## ✨ Add structured interview (hearing) tool

Adds a hearing tool that presents structured questions via a rich UI card in the
chat. Layer 4 only — no impact on Layer 3 or below.

### What's included

- **Agent tool** (agent/tools/hearing_tool.py): hearing(inference, q0, q1, q2) —
questions as separate args for incremental streaming
- **Incremental streaming** (agent/basic_agent.py): Partial JSON parsing for
early toolUse SSE emission. Each question appears as it's generated
- **HearingCard UI** (web-ui/src/components/chat/HearingCard.tsx): Chip/pill
selects, free-text, per-question notes, skeleton loading, oklch palette
- **Integration** (ChatMessage.tsx, ChatPanel.tsx, ToolCard.tsx): Non-blocking
card that disables when user sends a message