### PR TITLE
feat(acp-local): multi-process session management with SSE resume

### DIFF
--- a/web-ui/src/app/api/agent/config/route.ts
+++ b/web-ui/src/app/api/agent/config/route.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * Local ACP Agent Config — CRUD for agent adapters.
+ * Bridges AgentSettingsDialog (client) ↔ acp-adapter (server-side JSON).
+ */
+import { getAgents, getActiveAgentId, setActiveAgentId, saveAgents } from "@/lib/local/acp-adapter"
+
+/** GET: list agents + active ID */
+export async function GET() {
+  return Response.json({
+    agents: getAgents(),
+    activeAgent: getActiveAgentId(),
+  })
+}
+
+/** PUT: update agents list and/or active agent */
+export async function PUT(req: Request) {
+  const body = await req.json()
+  if (body.agents) saveAgents(body.agents)
+  if (body.activeAgent) setActiveAgentId(body.activeAgent)
+  return Response.json({ ok: true })
+}

--- a/web-ui/src/app/api/agent/invoke/route.ts
+++ b/web-ui/src/app/api/agent/invoke/route.ts
@@ -4,7 +4,7 @@
  * Local ACP Agent Invoke — sends prompt to deck-specific kiro-cli process.
  * Each deck gets its own process; switching decks doesn't interrupt others.
  */
-import { sendPrompt, newProcess, associateDeck, saveSessionToDeck, markSessionRunning } from "@/lib/local/acp-process"
+import { sendPrompt, newProcess, associateDeck, saveSessionToDeck } from "@/lib/local/acp-process"
 import { createSSEStream } from "@/lib/local/sse-bridge"
 
 const MODE_TO_AGENT: Record<string, string> = {
@@ -45,7 +45,8 @@ export async function POST(req: Request) {
       }
       saveSessionToDeck(createdDeckId)
     },
-    onDone: () => markSessionRunning(effectiveDeckId, false),
+    // onDone intentionally omitted — SSE close happens when browser navigates away,
+    // not when agent finishes. running=false is set by handleLine on end_turn.
   })
 
   // Now send the prompt — listener is already registered

--- a/web-ui/src/app/api/agent/invoke/route.ts
+++ b/web-ui/src/app/api/agent/invoke/route.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local ACP Agent Invoke — API Route that bridges kiro-cli acp to SSE.
- * Local mode only (`NEXT_PUBLIC_MODE=local`).
+ * Local ACP Agent Invoke — sends prompt to deck-specific kiro-cli process.
+ * Each deck gets its own process; switching decks doesn't interrupt others.
  */
-import { ensureAgent, newSession, getSessionId, rpcRequest, subscribe, saveSessionToDeck } from "@/lib/local/acp-process"
+import { sendPrompt, newProcess, associateDeck, saveSessionToDeck, markSessionRunning } from "@/lib/local/acp-process"
 import { createSSEStream } from "@/lib/local/sse-bridge"
 
 const MODE_TO_AGENT: Record<string, string> = {
@@ -14,24 +14,42 @@ const MODE_TO_AGENT: Record<string, string> = {
   single: "sdpm-spec",
 }
 
+export const dynamic = 'force-dynamic'
+
 export async function POST(req: Request) {
-  const { query, mode } = await req.json()
-
+  const { query, mode, deckId } = await req.json()
   const agentName = MODE_TO_AGENT[mode || "spec"] || "sdpm-spec"
-  await ensureAgent(agentName)
 
-  const sessionId = getSessionId()!
+  let effectiveDeckId: string
+  let tempKey: string | null = null
+
+  if (deckId && deckId !== "new") {
+    effectiveDeckId = deckId
+  } else {
+    // New deck — spawn process with temp key
+    const { tempKey: tk } = await newProcess(agentName)
+    tempKey = tk
+    effectiveDeckId = tk
+  }
+
+  const { sessionId, subscribe, send } = await sendPrompt(effectiveDeckId, query, agentName)
+
+  // Create SSE stream (registers listener) BEFORE sending prompt
   const stream = createSSEStream({
     sessionId,
     subscribe,
-    onDeckId: (deckId) => saveSessionToDeck(deckId),
+    onDeckId: (createdDeckId) => {
+      if (tempKey) {
+        associateDeck(tempKey, createdDeckId)
+        tempKey = null
+      }
+      saveSessionToDeck(createdDeckId)
+    },
+    onDone: () => markSessionRunning(effectiveDeckId, false),
   })
 
-  // Send prompt (don't await — response comes via notifications)
-  rpcRequest("session/prompt", {
-    sessionId,
-    prompt: [{ type: "text", text: query }],
-  })
+  // Now send the prompt — listener is already registered
+  send()
 
   return new Response(stream, {
     headers: {

--- a/web-ui/src/app/api/agent/load/route.ts
+++ b/web-ui/src/app/api/agent/load/route.ts
@@ -1,20 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local ACP Session Load — restores an existing session.
- * Returns SSE stream of replayed history (session/update notifications).
+ * Local ACP Session Load — restores chat history from disk.
+ * Does NOT interact with kiro-cli to avoid interrupting background processes.
  */
-import { ensureAgent, loadSession, getSessionId, subscribe, readChatFromDeck } from "@/lib/local/acp-process"
+import { readChatFromDeck } from "@/lib/local/acp-process"
 
 export async function POST(req: Request) {
   const { sessionId: savedSessionId, deckId } = await req.json()
   if (!savedSessionId) return Response.json({ error: "sessionId required" }, { status: 400 })
-
-  // Restore agent context (replay is ignored by client)
-  await ensureAgent()
-  await loadSession(savedSessionId)
-
-  // Return saved chat messages
   const messages = deckId ? readChatFromDeck(deckId) : []
   return Response.json({ messages })
 }

--- a/web-ui/src/app/api/agent/models/route.ts
+++ b/web-ui/src/app/api/agent/models/route.ts
@@ -1,19 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local Model List/Select API — returns available models and sets the active model.
- * Local mode only.
+ * Local Model List/Select API.
+ * Spawns a process if none exist (for initial model list).
  */
-import { ensureAgent, getModels, setConfigOption } from "@/lib/local/acp-process"
+import { getModels, setConfigOption, getActiveDeckId, newProcess } from "@/lib/local/acp-process"
 
 export async function GET() {
-  await ensureAgent()
+  const models = getModels()
+  if (!models.available.length) {
+    // No process yet — spawn one so model list is populated
+    await newProcess()
+  }
   return Response.json(getModels())
 }
 
 export async function PUT(req: Request) {
   const { modelId } = await req.json()
-  await ensureAgent()
-  await setConfigOption("model", modelId)
+  const deckId = getActiveDeckId()
+  if (deckId) await setConfigOption(deckId, "model", modelId)
   return Response.json({ ok: true })
 }

--- a/web-ui/src/app/api/agent/stop/route.ts
+++ b/web-ui/src/app/api/agent/stop/route.ts
@@ -1,19 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local ACP Agent Stop — cancel current prompt or reset session.
- * Local mode only.
+ * Local ACP Agent Stop — cancel a specific deck's prompt.
+ * newChat=true is a no-op (process is spawned on first invoke).
  */
-import { newSession, cancelAll, getSessionId } from "@/lib/local/acp-process"
+import { cancelDeck } from "@/lib/local/acp-process"
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}))
 
   if (body.newChat) {
-    await newSession()
-    return Response.json({ ok: true, sessionId: getSessionId() })
+    // No-op: new process will be spawned when user sends first message
+    return Response.json({ ok: true })
   }
 
-  cancelAll()
+  if (body.deckId) {
+    cancelDeck(body.deckId)
+  }
+  // Without deckId, do nothing — don't cancel all background processes
   return Response.json({ ok: true })
 }

--- a/web-ui/src/app/api/agent/stream/route.ts
+++ b/web-ui/src/app/api/agent/stream/route.ts
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * Local ACP Stream — SSE endpoint with Last-Event-ID resume support.
+ * Replays buffered events after the given ID, then streams live.
+ */
+import { isSessionRunning, getBufferedEvents, subscribeToDeck } from "@/lib/local/acp-process"
+import { createSSEStream } from "@/lib/local/sse-bridge"
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const deckId = url.searchParams.get("deckId")
+  if (!deckId) return Response.json({ error: "deckId required" }, { status: 400 })
+
+  if (!isSessionRunning(deckId)) {
+    return Response.json({ running: false })
+  }
+
+  const sub = subscribeToDeck(deckId)
+  if (!sub?.sessionId) return Response.json({ running: false })
+
+  // Resume from Last-Event-ID if provided
+  const lastEventId = req.headers.get("Last-Event-ID")
+  const afterId = lastEventId ? parseInt(lastEventId, 10) : undefined
+  const buffered = getBufferedEvents(deckId, afterId)
+
+  const stream = createSSEStream({
+    sessionId: sub.sessionId,
+    subscribe: sub.subscribe,
+    replay: buffered,
+  })
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  })
+}

--- a/web-ui/src/app/api/upload/route.ts
+++ b/web-ui/src/app/api/upload/route.ts
@@ -10,12 +10,12 @@ import { spawn } from "child_process"
 import fs from "fs"
 import os from "os"
 import path from "path"
-import { getSessionId, ensureAgent } from "@/lib/local/acp-process"
+import { getSessionId, getActiveDeckId, getProcess } from "@/lib/local/acp-process"
 
 const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
 
 export async function POST(req: Request): Promise<Response> {
-  await ensureAgent()
+  const did = getActiveDeckId(); if (did) await getProcess(did)
   const sessionId = getSessionId()
   if (!sessionId) {
     return Response.json({ error: "No active session" }, { status: 400 })

--- a/web-ui/src/components/chat/AgentSettingsDialog.tsx
+++ b/web-ui/src/components/chat/AgentSettingsDialog.tsx
@@ -49,6 +49,10 @@ const PRESETS: AgentConfig[] = [
 const STORAGE_KEY = "sdpm-acp-agents"
 const ACTIVE_KEY = "sdpm-acp-active"
 
+// Local mode: use API routes for server-side persistence
+// Browser mode: fall back to localStorage
+const IS_LOCAL = typeof window !== "undefined" && process.env.NEXT_PUBLIC_MODE === "local"
+
 export function loadAgents(): AgentConfig[] {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
@@ -59,6 +63,13 @@ export function loadAgents(): AgentConfig[] {
 
 export function saveAgents(agents: AgentConfig[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(agents))
+  if (IS_LOCAL) {
+    fetch("/api/agent/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agents }),
+    }).catch(() => {})
+  }
 }
 
 export function getActiveAgentId(): string {
@@ -67,6 +78,13 @@ export function getActiveAgentId(): string {
 
 export function setActiveAgentId(id: string) {
   localStorage.setItem(ACTIVE_KEY, id)
+  if (IS_LOCAL) {
+    fetch("/api/agent/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ activeAgent: id }),
+    }).catch(() => {})
+  }
 }
 
 export function getActiveAgent(): AgentConfig {

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -108,6 +108,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const mentionPopupRef = useRef<{ _handleKeyDown?: (e: KeyboardEvent) => boolean } | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
+  const reconnectingRef = useRef(false)
   const messagesRef = useRef(messages)
   messagesRef.current = messages
   const currentDeckId = useRef(deckId)
@@ -121,13 +122,15 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   /** Persist chat messages to disk (Local mode only, no-op otherwise). */
   const saveLocalChat = useCallback((overrideDeckId?: string) => {
     const did = overrideDeckId || currentDeckId.current
-    if (!IS_LOCAL || !did) return
+    if (!IS_LOCAL || !did || reconnectingRef.current) return
     fetch("/api/agent/chat", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ deckId: did, messages: messagesRef.current }),
     }).catch(() => {})
   }, [])
+
+
 
   /**
    * Insert text at the current cursor position in the textarea.
@@ -335,11 +338,20 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       const { parseStreamingChunk, resetParserState } = await import("@/services/strandsParser")
       if (resetParserState) resetParserState()
 
+      reconnectingRef.current = true
       es = new EventSource(`/api/agent/stream?deckId=${encodeURIComponent(deckId)}`)
 
       let receivedData = false
+      let replayDone = false
       es.onmessage = (event) => {
         if (!receivedData) { receivedData = true; setIsLoading(true) }
+        // After replay, live events arrive with delay. Once we get data
+        // and toolOrder has been populated, replay is effectively done.
+        if (!replayDone && toolOrder.length > 0) {
+          replayDone = true
+          reconnectingRef.current = false
+          setTimeout(() => saveLocalChat(), 200)
+        }
         const line = "data: " + event.data
         completion = parseStreamingChunk(
           line,
@@ -349,8 +361,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
               const updated = [...prev]
               const last = updated[updated.length - 1]
               if (last?.role === "assistant") {
-                const blocks = buildBlocks(streamed, last.toolUses)
-                updated[updated.length - 1] = { ...last, content: streamed, blocks }
+                // Only rebuild blocks if we have tool position info;
+                // otherwise preserve existing blocks from loadHistory
+                const hasPositions = toolOrder.length > 0
+                const blocks = hasPositions ? buildBlocks(streamed, last.toolUses) : last.blocks
+                updated[updated.length - 1] = { ...last, content: streamed, ...(blocks ? { blocks } : {}) }
                 return updated
               }
               return [...prev, { role: "assistant" as const, content: streamed, blocks: [{ type: "text" as const, text: streamed }], toolUses: [] }]
@@ -423,13 +438,14 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       }
 
       es.onerror = () => {
-        es?.close()
-        setIsLoading(false)
-        saveLocalChat()
+        if (es?.readyState === EventSource.CLOSED) {
+          reconnectingRef.current = false
+          setIsLoading(false)
+        }
       }
     }, 800)
 
-    return () => { clearTimeout(timer); es?.close() }
+    return () => { clearTimeout(timer); es?.close(); reconnectingRef.current = false }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deckId])
 
@@ -775,8 +791,9 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
               updated[updated.length - 1] = { ...last, toolUses: newToolUses, blocks }
               return updated
             })
-            // Save chat on compose group start/done so switching decks preserves progress
-            if (d.status === "starting" || d.status === "done") saveLocalChat()
+            // Save chat on compose events so switching decks preserves subagent progress
+            // setTimeout lets React render first so messagesRef.current is up to date
+            if (d.status === "starting" || d.status === "done" || d.toolResult) setTimeout(() => saveLocalChat(), 100)
             return
           }
 
@@ -858,6 +875,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
             updated[updated.length - 1] = { ...last, content: lastTextSnapshot, blocks, toolUses: newToolUses }
             return updated
           })
+          // Save after tool added (ensures compose_slides is persisted before user switches)
+          if (!toolUseData?.completed) setTimeout(() => saveLocalChat(), 100)
         },
         controller.signal,
         agentMode === "vibe" ? "vibe" : (parallelAgents ? "separated" : "single"),

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -177,6 +177,16 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       try {
       const history = await getChatHistory(sessionId, idToken, deckId || undefined)
       if (history.length > 0) {
+        // Local mode: .chat.json is already in ChatPanel's internal format
+        if (IS_LOCAL && history[0]?.toolUses !== undefined) {
+          setMessages(history.map((m: Record<string, unknown>) => ({
+            role: (m.role as string) || "assistant",
+            content: (typeof m.content === "string" ? m.content : "") as string,
+            toolUses: (m.toolUses as ToolUse[]) || [],
+            blocks: (m.blocks as ({ type: "text"; text: string } | { type: "tool"; tool: ToolUse })[]) || undefined,
+          })))
+          return
+        }
         const parsed: typeof messages = []
         for (const m of history) {
           let text = ""
@@ -284,6 +294,144 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
     }
     if (auth.isAuthenticated) loadHistory()
   }, [sessionId, auth.isAuthenticated])
+
+  // Reconnect to running background session (Local mode)
+  // Uses EventSource with Last-Event-ID for seamless SSE resume.
+  useEffect(() => {
+    if (!IS_LOCAL || !deckId || deckId === "new") return
+    let es: EventSource | null = null
+    let completion = ""
+    // Track tool positions: toolUseId → character offset in completion text
+    const toolPositions = new Map<string, number>()
+    const toolOrder: string[] = []
+
+    function buildBlocks(text: string, toolUses: ToolUse[]) {
+      const blocks: ({ type: "text"; text: string } | { type: "tool"; tool: ToolUse })[] = []
+      const toolMap = new Map(toolUses.map(t => [t.toolUseId, t]))
+      let textStart = 0
+      for (const id of toolOrder) {
+        const pos = toolPositions.get(id) ?? textStart
+        const tool = toolMap.get(id)
+        if (!tool) continue
+        const slice = text.slice(textStart, pos)
+        if (slice) blocks.push({ type: "text", text: slice })
+        blocks.push({ type: "tool", tool })
+        textStart = pos
+      }
+      const trailing = text.slice(textStart)
+      if (trailing) blocks.push({ type: "text", text: trailing })
+      return blocks
+    }
+
+    const timer = setTimeout(async () => {
+      // Check if running
+      try {
+        const check = await fetch(`/api/agent/stream?deckId=${encodeURIComponent(deckId)}`)
+        const ct = check.headers.get("content-type") || ""
+        try { check.body?.getReader()?.cancel() } catch {}
+        if (!ct.includes("text/event-stream")) return
+      } catch { return }
+
+      const { parseStreamingChunk, resetParserState } = await import("@/services/strandsParser")
+      if (resetParserState) resetParserState()
+
+      es = new EventSource(`/api/agent/stream?deckId=${encodeURIComponent(deckId)}`)
+
+      let receivedData = false
+      es.onmessage = (event) => {
+        if (!receivedData) { receivedData = true; setIsLoading(true) }
+        const line = "data: " + event.data
+        completion = parseStreamingChunk(
+          line,
+          completion,
+          (streamed: string) => {
+            setMessages((prev) => {
+              const updated = [...prev]
+              const last = updated[updated.length - 1]
+              if (last?.role === "assistant") {
+                const blocks = buildBlocks(streamed, last.toolUses)
+                updated[updated.length - 1] = { ...last, content: streamed, blocks }
+                return updated
+              }
+              return [...prev, { role: "assistant" as const, content: streamed, blocks: [{ type: "text" as const, text: streamed }], toolUses: [] }]
+            })
+          },
+          (toolName: string, toolUseData: ToolUseCallbackData | undefined) => {
+            if (toolUseData && 'started' in toolUseData && (toolUseData as Record<string, unknown>).started) {
+              const tuId = toolUseData.toolUseId || ""
+              toolPositions.set(tuId, completion.length)
+              if (!toolOrder.includes(tuId)) toolOrder.push(tuId)
+              setMessages((prev) => {
+                const updated = [...prev]
+                const last = updated[updated.length - 1]
+                if (!last || last.role !== "assistant") return prev
+                // Skip if tool already exists (reconnect replay)
+                if (last.toolUses.some((t: ToolUse) => t.toolUseId === tuId)) return prev
+                const newTool = { toolUseId: tuId, name: toolName, input: toolUseData.input || {} }
+                const newToolUses = [...last.toolUses, newTool]
+                const blocks = buildBlocks(last.content, newToolUses)
+                updated[updated.length - 1] = { ...last, toolUses: newToolUses, blocks }
+                return updated
+              })
+            }
+            if (toolUseData?.completed) {
+              setMessages((prev) => {
+                const updated = [...prev]
+                const last = updated[updated.length - 1]
+                if (!last || last.role !== "assistant") return prev
+                const newToolUses = last.toolUses.map((t: ToolUse) =>
+                  t.toolUseId === toolUseData.toolUseId ? { ...t, status: "success" as const, result: toolUseData.result } : t
+                )
+                updated[updated.length - 1] = { ...last, toolUses: newToolUses }
+                return updated
+              })
+              saveLocalChat()
+            }
+            // Handle toolStream (compose_slides sub-agent progress)
+            if (toolUseData?.stream && toolUseData?.toolUseId) {
+              const d = (toolUseData as Record<string, unknown>).data as Record<string, unknown> || {}
+              setMessages((prev) => {
+                const updated = [...prev]
+                const last = updated[updated.length - 1]
+                if (!last || last.role !== "assistant") return prev
+                const idx = last.toolUses.findIndex((t: ToolUse) => t.toolUseId === toolUseData.toolUseId)
+                if (idx < 0) return prev
+                const newToolUses = [...last.toolUses]
+                const existing = newToolUses[idx].streamMessages || []
+                let next: typeof existing
+                if (d.toolResult) {
+                  next = existing.map((e: Record<string, unknown>) =>
+                    e.toolUseId === d.toolResult ? { ...e, status: d.toolStatus || "success" } : e
+                  )
+                } else if (d.tool) {
+                  const existingIdx = existing.findIndex((e: Record<string, unknown>) => e.toolUseId === d.toolUseId)
+                  if (existingIdx < 0) {
+                    next = [...existing, { tool: d.tool, group: d.group, slugs: d.slugs, toolUseId: d.toolUseId }]
+                  } else { next = existing }
+                } else if (d.status) {
+                  next = [...existing, { status: d.status, group: d.group, slugs: d.slugs, total_groups: d.total_groups }]
+                } else { return prev }
+                newToolUses[idx] = { ...newToolUses[idx], streamMessages: next }
+                const blocks = buildBlocks(last.content, newToolUses)
+                updated[updated.length - 1] = { ...last, toolUses: newToolUses, blocks }
+                return updated
+              })
+              if (d.status === "starting" || d.status === "done") saveLocalChat()
+            }
+          },
+        )
+      }
+
+      es.onerror = () => {
+        es?.close()
+        setIsLoading(false)
+        saveLocalChat()
+      }
+    }, 800)
+
+    return () => { clearTimeout(timer); es?.close() }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deckId])
 
   // Load deck list for @mentions
   useEffect(() => {
@@ -627,6 +775,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
               updated[updated.length - 1] = { ...last, toolUses: newToolUses, blocks }
               return updated
             })
+            // Save chat on compose group start/done so switching decks preserves progress
+            if (d.status === "starting" || d.status === "done") saveLocalChat()
             return
           }
 
@@ -711,6 +861,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         },
         controller.signal,
         agentMode === "vibe" ? "vibe" : (parallelAgents ? "separated" : "single"),
+        currentDeckId.current !== "new" ? currentDeckId.current : undefined,
       )
     } catch (err) {
       // AbortError is expected when user clicks stop — don't show error

--- a/web-ui/src/components/chat/ChatPanelShell.tsx
+++ b/web-ui/src/components/chat/ChatPanelShell.tsx
@@ -93,10 +93,20 @@ export function ChatPanelShell({
   const chatRef = externalChatRef || internalChatRef
   const panelRef = useRef<HTMLElement>(null)
 
-  // Start ACP agent early so model list is available immediately
+  // Fetch models; retry until available (first process populates model list)
   useEffect(() => {
     if (!IS_LOCAL) return
-    fetch("/api/agent/models").catch(() => {})
+    let cancelled = false
+    const poll = () => {
+      fetch("/api/agent/models").then(r => r.json()).then(data => {
+        if (cancelled) return
+        const avail = data.available || []
+        if (avail.length > 0) { setModels(avail); setCurrentModel(data.current || "") }
+        else setTimeout(poll, 3000) // retry until a process is spawned
+      }).catch(() => { if (!cancelled) setTimeout(poll, 3000) })
+    }
+    poll()
+    return () => { cancelled = true }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // When Panel A creates a deck, store the deckId so we know Panel A "owns" it

--- a/web-ui/src/lib/local/acp-adapter.ts
+++ b/web-ui/src/lib/local/acp-adapter.ts
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * ACP Agent Adapter — server-side storage for agent configs.
+ * Mirrors AgentSettingsDialog's AgentConfig interface.
+ * Stores in mcp-local/.sdpm/acp-config.json.
+ */
+
+import fs from "fs"
+import path from "path"
+
+export interface AgentConfig {
+  id: string
+  displayName: string
+  path: string
+  args: string[]
+  env: Record<string, string>
+  subagentTool: string
+  subagentInstruction: string
+  restartOnNewChat: boolean
+  subagentQueryField: "query" | "prompt"
+}
+
+const PRESETS: AgentConfig[] = [
+  {
+    id: "kiro-cli",
+    displayName: "Kiro CLI",
+    path: "kiro-cli",
+    args: ["acp", "--agent", "sdpm-spec"],
+    env: {},
+    subagentTool: "use_subagent",
+    subagentInstruction: "Use `use_subagent` with `subagents: [{\"query\": \"deck_id=... slides: slug1, slug2\", \"agent_name\": \"sdpm-composer\"}]` (max 4 parallel). ASCII-only queries.",
+    restartOnNewChat: true,
+    subagentQueryField: "query",
+  },
+  {
+    id: "claude",
+    displayName: "Claude Code",
+    path: "claude",
+    args: ["--acp"],
+    env: {},
+    subagentTool: "Task",
+    subagentInstruction: "Use `Task` tool with `subagent_type: \"sdpm-composer\"`, `description: \"<brief>\"`, `prompt: \"deck_id=... slides: slug1, slug2\"`. Invoke multiple Task calls in parallel (max 4).",
+    restartOnNewChat: false,
+    subagentQueryField: "prompt",
+  },
+]
+
+const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
+const CONFIG_DIR = path.join(MCP_LOCAL_DIR, ".sdpm")
+const CONFIG_PATH = path.join(CONFIG_DIR, "acp-config.json")
+
+interface StoredConfig {
+  activeAgent: string
+  agents: AgentConfig[]
+}
+
+function readConfig(): StoredConfig {
+  try {
+    if (fs.existsSync(CONFIG_PATH)) {
+      return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"))
+    }
+  } catch {}
+  return { activeAgent: "kiro-cli", agents: PRESETS }
+}
+
+function writeConfig(config: StoredConfig): void {
+  try {
+    fs.mkdirSync(CONFIG_DIR, { recursive: true })
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8")
+  } catch {}
+}
+
+export function getAgents(): AgentConfig[] {
+  return readConfig().agents
+}
+
+export function getActiveAgentId(): string {
+  return readConfig().activeAgent
+}
+
+export function getActiveAgent(): AgentConfig {
+  const config = readConfig()
+  return config.agents.find(a => a.id === config.activeAgent) || config.agents[0] || PRESETS[0]
+}
+
+export function setActiveAgentId(id: string): void {
+  const config = readConfig()
+  config.activeAgent = id
+  writeConfig(config)
+}
+
+export function saveAgents(agents: AgentConfig[]): void {
+  const config = readConfig()
+  config.agents = agents
+  writeConfig(config)
+}

--- a/web-ui/src/lib/local/acp-process.ts
+++ b/web-ui/src/lib/local/acp-process.ts
@@ -10,6 +10,7 @@
 import { spawn, type ChildProcess } from "child_process"
 import path from "path"
 import { DECK_ROOT, resolveDeckDir } from "./deck-paths"
+import { getActiveAgent, type AgentConfig } from "./acp-adapter"
 
 export { DECK_ROOT }
 const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
@@ -30,6 +31,9 @@ interface ProcessState {
   running: boolean
   notifications: { id: number; msg: Record<string, unknown> }[]
   eventIdCounter: number
+  // Server-side chat state — updated from notifications, saved to .chat.json
+  chatMessages: Record<string, unknown>[]
+  chatDirty: boolean
   lastActivity: number
   subSessionIds: Set<string>
 }
@@ -54,7 +58,92 @@ function handleLine(ps: ProcessState, line: string) {
     const resolve = ps.pending.get(msg.id as number)!
     ps.pending.delete(msg.id as number)
     resolve(msg.result)
-    for (const fn of ps.listeners) fn(msg)
+    // Server-side chat state tracking — updates .chat.json independent of browser
+  if (msg.method === "session/update" || msg.method === "_kiro.dev/session/update") {
+    const p = msg.params as Record<string, unknown>
+    const update = p?.update as Record<string, unknown>
+    if (update) {
+      const type = update.sessionUpdate as string
+      const msgSid = p?.sessionId as string
+
+      // Only track main session messages (not subagent)
+      if (msgSid === ps.sessionId) {
+        if (type === "agent_message_chunk") {
+          const content = update.content as Record<string, unknown>
+          if (content?.text) {
+            // Append text to last assistant message
+            let last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
+            if (!last || last.role !== "assistant") {
+              last = { role: "assistant", content: "", toolUses: [], blocks: [] }
+              ps.chatMessages.push(last)
+            }
+            last.content = (last.content as string || "") + (content.text as string)
+            ps.chatDirty = true
+          }
+        }
+        if (type === "tool_call" || type === "tool_call_chunk") {
+          const toolCallId = (update.toolCallId || "") as string
+          const title = (update.title || update.name || "") as string
+          const name = title.replace(/^Running:\s*@sdpm\//, "").replace(/^Running:\s*/, "") || title
+          const input = (update.rawInput || update.input || {}) as Record<string, unknown>
+          let last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
+          if (!last || last.role !== "assistant") {
+            last = { role: "assistant", content: "", toolUses: [], blocks: [] }
+            ps.chatMessages.push(last)
+          }
+          const toolUses = (last.toolUses as Record<string, unknown>[]) || []
+          if (!toolUses.some(t => t.toolUseId === toolCallId)) {
+            toolUses.push({ toolUseId: toolCallId, name, input, streamMessages: [] })
+            last.toolUses = toolUses
+            ps.chatDirty = true
+          }
+        }
+        if (type === "tool_call_update") {
+          const status = update.status as string
+          const toolCallId = (update.toolCallId || "") as string
+          if (status === "completed" || status === "error") {
+            const last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
+            if (last) {
+              const toolUses = (last.toolUses as Record<string, unknown>[]) || []
+              const tool = toolUses.find(t => t.toolUseId === toolCallId)
+              if (tool) {
+                tool.status = status === "completed" ? "success" : "error"
+                ps.chatDirty = true
+              }
+            }
+          }
+        }
+      }
+
+      // Track subagent toolStream events
+      if (msgSid !== ps.sessionId && ps.subSessionIds.has(msgSid)) {
+        const last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
+        if (last) {
+          const toolUses = (last.toolUses as Record<string, unknown>[]) || []
+          // Find compose_slides tool (the one with streamMessages)
+          const composeTool = toolUses.find(t => (t.streamMessages as unknown[])?.length >= 0 && (t.name === "compose_slides" || t.name === "subagent" || (t.name as string)?.includes("subagent")))
+          if (composeTool) {
+            const sm = (composeTool.streamMessages as Record<string, unknown>[]) || []
+            if (type === "tool_call") {
+              const title = (update.title || "") as string
+              const toolName = title.replace(/^Running:\s*@sdpm\//, "").replace(/^Running:\s*/, "") || title
+              sm.push({ tool: toolName, group: 0, toolUseId: update.toolCallId })
+              composeTool.streamMessages = sm
+              ps.chatDirty = true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Periodically flush dirty chat to .chat.json
+  if (ps.chatDirty && ps.deckId && !ps.deckId.startsWith("_new_")) {
+    ps.chatDirty = false
+    saveChatToDeck(ps.deckId, ps.chatMessages)
+  }
+
+  for (const fn of ps.listeners) fn(msg)
     return
   }
 
@@ -82,6 +171,7 @@ function handleLine(ps: ProcessState, line: string) {
   if (msg.id != null && msg.result) {
     const r = msg.result as Record<string, unknown>
     if (r.stopReason === "end_turn" || r.stopReason === "cancelled") {
+
       ps.running = false
     }
   }
@@ -101,17 +191,26 @@ function rpcNotifyTo(ps: ProcessState, method: string, params: Record<string, un
   ps.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n")
 }
 
-async function spawnProcess(deckId: string, agentName: string): Promise<ProcessState> {
-  const child = spawn("kiro-cli", ["acp", "--agent", agentName], {
+async function spawnProcess(deckId: string, agentName: string, adapter?: AgentConfig): Promise<ProcessState> {
+  const cfg = adapter || getActiveAgent()
+  // For kiro-cli, replace agent name in args if agentFlag is set
+  let args = [...cfg.args]
+  // For kiro-cli, replace agent name in args (--agent <name>)
+  const flagIdx = args.indexOf("--agent")
+  if (flagIdx >= 0 && flagIdx + 1 < args.length) {
+    args[flagIdx + 1] = agentName
+  }
+  const child = spawn(cfg.path, args, {
     cwd: MCP_LOCAL_DIR,
     stdio: ["pipe", "pipe", "pipe"],
-    env: { ...process.env, SDPM_OUTPUT_DIR: DECK_ROOT, SDPM_DECK_ROOT: DECK_ROOT },
+    env: { ...process.env, ...cfg.env, SDPM_OUTPUT_DIR: DECK_ROOT, SDPM_DECK_ROOT: DECK_ROOT },
   })
 
   const ps: ProcessState = {
     child, deckId, sessionId: null, agentName,
     requestId: 0, pending: new Map(), listeners: new Set(),
     lineBuffer: "", running: false, notifications: [], eventIdCounter: 0,
+    chatMessages: [], chatDirty: false,
     lastActivity: Date.now(), subSessionIds: new Set(),
   }
 
@@ -220,8 +319,10 @@ export async function sendPrompt(deckId: string, text: string, agentName?: strin
   ps.notifications = []; ps.eventIdCounter = 0
   ps.lastActivity = Date.now()
 
-  // Return subscribe BEFORE sending prompt to avoid race condition.
-  // Caller must: subscribe → then call send().
+  // Initialize server-side chat state with user message
+  ps.chatMessages = [{ role: "user", content: text, toolUses: [] }]
+  ps.chatDirty = false
+
   return {
     sessionId: ps.sessionId!,
     subscribe: (fn: NotifyListener) => {

--- a/web-ui/src/lib/local/acp-process.ts
+++ b/web-ui/src/lib/local/acp-process.ts
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * ACP Process Manager — spawns and manages a single kiro-cli acp child process.
+ * ACP Process Manager — manages multiple kiro-cli acp child processes,
+ * one per active deck. Enables background processing: switching decks
+ * does not interrupt running agents.
  *
- * Provides JSON-RPC request/response and notification subscription.
- * Singleton: one process shared across all API route invocations.
+ * Max MAX_PROCESSES concurrent processes. Idle processes are evicted LRU.
  */
 import { spawn, type ChildProcess } from "child_process"
 import path from "path"
@@ -12,199 +13,316 @@ import { DECK_ROOT, resolveDeckDir } from "./deck-paths"
 
 export { DECK_ROOT }
 const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
+const MAX_PROCESSES = 3
 
 type PendingResolve = (value: unknown) => void
 type NotifyListener = (msg: Record<string, unknown>) => void
 
-let child: ChildProcess | null = null
-let requestId = 0
-let sessionId: string | null = null
-const subSessionIds = new Set<string>()
-const pending = new Map<number, PendingResolve>()
-const listeners = new Set<NotifyListener>()
-let lineBuffer = ""
+interface ProcessState {
+  child: ChildProcess
+  deckId: string
+  sessionId: string | null
+  agentName: string
+  requestId: number
+  pending: Map<number, PendingResolve>
+  listeners: Set<NotifyListener>
+  lineBuffer: string
+  running: boolean
+  notifications: { id: number; msg: Record<string, unknown> }[]
+  eventIdCounter: number
+  lastActivity: number
+  subSessionIds: Set<string>
+}
 
-function handleLine(line: string) {
+const processes = new Map<string, ProcessState>()
+let activeDeckId: string | null = null
+
+// Model info (shared, populated from first process)
+export interface AcpModel { modelId: string; name: string; description?: string }
+let currentModelId = ""
+let availableModels: AcpModel[] = []
+
+// ── Per-process helpers ──
+
+function handleLine(ps: ProcessState, line: string) {
   if (!line.trim()) return
   let msg: Record<string, unknown>
   try { msg = JSON.parse(line) } catch { return }
 
   // JSON-RPC response
-  if (msg.id != null && pending.has(msg.id as number)) {
-    const resolve = pending.get(msg.id as number)!
-    pending.delete(msg.id as number)
+  if (msg.id != null && ps.pending.has(msg.id as number)) {
+    const resolve = ps.pending.get(msg.id as number)!
+    ps.pending.delete(msg.id as number)
     resolve(msg.result)
-    // Also notify listeners for end_turn detection
-    for (const fn of listeners) fn(msg)
+    for (const fn of ps.listeners) fn(msg)
     return
   }
 
   // Auto-approve permission requests
   if (msg.method === "session/request_permission") {
     const reqId = msg.id as string
-    if (reqId && child) {
-      child.stdin!.write(JSON.stringify({
+    if (reqId && ps.child) {
+      ps.child.stdin!.write(JSON.stringify({
         jsonrpc: "2.0", id: reqId, result: { outcome: { outcome: "selected", optionId: "allow_always" } },
       }) + "\n")
     }
     return
   }
 
-  // Forward notifications to all listeners
-  // Track subagent session IDs
+  // Buffer notifications
   if (msg.method === "session/update" || msg.method === "_kiro.dev/session/update") {
     const p = msg.params as Record<string, unknown>
     const sid = p?.sessionId as string
-    if (sid && sid !== sessionId) subSessionIds.add(sid)
+    if (sid && sid !== ps.sessionId) ps.subSessionIds.add(sid)
+    ps.notifications.push({ id: ++ps.eventIdCounter, msg })
+    if (ps.notifications.length > 2000) ps.notifications.shift()
   }
-  for (const fn of listeners) fn(msg)
-}
 
-/** Send a JSON-RPC request and await the response. */
-export function rpcRequest(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
-  if (!child) throw new Error("ACP agent not started")
-  const id = ++requestId
-  const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n"
-  child.stdin!.write(msg)
-  return new Promise((resolve) => { pending.set(id, resolve) })
-}
-
-/** Subscribe to JSON-RPC notifications. Returns unsubscribe function. */
-export function subscribe(fn: NotifyListener): () => void {
-  listeners.add(fn)
-  return () => { listeners.delete(fn) }
-}
-
-/** Send a fire-and-forget JSON-RPC notification (no id, no response). */
-export function rpcNotify(method: string, params: Record<string, unknown> = {}): void {
-  if (!child) return
-  child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n")
-}
-
-/** Cancel the current session and all subagent sessions. */
-export function cancelAll(): void {
-  if (!child) return
-  if (sessionId) {
-    rpcNotify("session/cancel", { sessionId })
-    for (const subId of subSessionIds) {
-      rpcNotify("session/cancel", { sessionId: subId })
+  // Detect end_turn
+  if (msg.id != null && msg.result) {
+    const r = msg.result as Record<string, unknown>
+    if (r.stopReason === "end_turn" || r.stopReason === "cancelled") {
+      ps.running = false
     }
-    subSessionIds.clear()
   }
-}
-export function getSessionId(): string | null { return sessionId }
 
-export interface AcpModel { modelId: string; name: string; description?: string }
-
-let currentModelId = ""
-let availableModels: AcpModel[] = []
-
-/** Get available models (populated after ensureAgent). */
-export function getModels(): { current: string; available: AcpModel[] } {
-  return { current: currentModelId, available: availableModels }
+  for (const fn of ps.listeners) fn(msg)
 }
 
-/** Set a session config option (e.g. model selection). */
-export async function setConfigOption(configId: string, value: string): Promise<void> {
-  if (!child || !sessionId) return
-  await rpcRequest("session/set_config_option", { sessionId, configId, value })
+function rpcRequestTo(ps: ProcessState, method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+  if (!ps.child) throw new Error("Process not running")
+  const id = ++ps.requestId
+  ps.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n")
+  return new Promise((resolve) => { ps.pending.set(id, resolve) })
 }
 
-let currentAgentName = "sdpm-spec"
+function rpcNotifyTo(ps: ProcessState, method: string, params: Record<string, unknown> = {}): void {
+  if (!ps.child) return
+  ps.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n")
+}
 
-/** Ensure the ACP process is running and a session exists. */
-export async function ensureAgent(agentName: string = "sdpm-spec"): Promise<void> {
-  // If agent name changed, kill existing process to restart with new agent
-  if (child && agentName !== currentAgentName) {
-    const oldChild = child
-    child = null
-    sessionId = null
-    pending.clear()
-    listeners.clear()
-    lineBuffer = ""
-    oldChild.kill()
-    // Wait for process to exit before spawning new one
-    await new Promise<void>((resolve) => {
-      oldChild.on("close", () => resolve())
-      setTimeout(resolve, 3000) // fallback timeout
-    })
-  }
-  if (child) return
-
-  currentAgentName = agentName
-  const mcpLocalDir = MCP_LOCAL_DIR
-
-  child = spawn("kiro-cli", ["acp", "--agent", agentName], {
-    cwd: mcpLocalDir,
+async function spawnProcess(deckId: string, agentName: string): Promise<ProcessState> {
+  const child = spawn("kiro-cli", ["acp", "--agent", agentName], {
+    cwd: MCP_LOCAL_DIR,
     stdio: ["pipe", "pipe", "pipe"],
     env: { ...process.env, SDPM_OUTPUT_DIR: DECK_ROOT, SDPM_DECK_ROOT: DECK_ROOT },
   })
-  const newChild = child
+
+  const ps: ProcessState = {
+    child, deckId, sessionId: null, agentName,
+    requestId: 0, pending: new Map(), listeners: new Set(),
+    lineBuffer: "", running: false, notifications: [], eventIdCounter: 0,
+    lastActivity: Date.now(), subSessionIds: new Set(),
+  }
 
   child.stdout!.setEncoding("utf-8")
   child.stdout!.on("data", (data: string) => {
-    lineBuffer += data
-    const lines = lineBuffer.split("\n")
-    lineBuffer = lines.pop() || ""
-    for (const l of lines) handleLine(l)
+    ps.lineBuffer += data
+    const lines = ps.lineBuffer.split("\n")
+    ps.lineBuffer = lines.pop() || ""
+    for (const l of lines) handleLine(ps, l)
   })
 
   child.stderr!.setEncoding("utf-8")
-  child.stderr!.on("data", (d: string) => console.warn("[acp stderr]", d))
+  child.stderr!.on("data", (d: string) => console.warn(`[acp:${deckId}] stderr:`, d.trim()))
 
   child.on("close", () => {
-    // Only reset if this is still the active child (not replaced by a new spawn)
-    if (child === newChild) {
-      child = null
-      sessionId = null
-      pending.clear()
-      listeners.clear()
-    }
+    processes.delete(deckId)
   })
 
-  await rpcRequest("initialize", {
+  // Initialize ACP
+  await rpcRequestTo(ps, "initialize", {
     protocolVersion: 1,
     clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
     clientInfo: { name: "sdpm-local", version: "0.1.0" },
   })
 
-  const AGENT_NAME = agentName
+  // Create session
+  const result = await rpcRequestTo(ps, "session/new", { cwd: MCP_LOCAL_DIR, mcpServers: [], agent: agentName }) as Record<string, unknown>
+  ps.sessionId = result.sessionId as string
 
-  const result = await rpcRequest("session/new", { cwd: MCP_LOCAL_DIR, mcpServers: [], agent: AGENT_NAME }) as Record<string, unknown>
-  sessionId = result.sessionId as string
-
-  // Extract model info from session/new response
-  const modelsData = result.models as { currentModelId?: string; availableModels?: AcpModel[] } | undefined
-  if (modelsData) {
-    currentModelId = modelsData.currentModelId || ""
-    availableModels = (modelsData.availableModels || [])
-      .filter(o => !o.description?.startsWith("[Internal]") && !o.description?.startsWith("[Deprecated]"))
+  // Extract model info from first process
+  if (!availableModels.length) {
+    const modelsData = result.models as { currentModelId?: string; availableModels?: AcpModel[] } | undefined
+    if (modelsData) {
+      currentModelId = modelsData.currentModelId || ""
+      availableModels = (modelsData.availableModels || [])
+        .filter(o => !o.description?.startsWith("[Internal]") && !o.description?.startsWith("[Deprecated]"))
+    }
   }
 
-  // Model preference is managed client-side via /api/agent/models PUT
+  return ps
 }
 
-/** Create a new ACP session (for new chat). */
-export async function newSession(agentName?: string): Promise<void> {
-  const agent = agentName || currentAgentName
-  const result = await rpcRequest("session/new", { cwd: MCP_LOCAL_DIR, mcpServers: [], agent }) as Record<string, unknown>
-  sessionId = result.sessionId as string
+async function evictIfNeeded(): Promise<void> {
+  if (processes.size < MAX_PROCESSES) return
+  // Find oldest idle process (not running, not active)
+  let oldest: ProcessState | null = null
+  for (const ps of processes.values()) {
+    if (ps.running || ps.deckId === activeDeckId) continue
+    if (!oldest || ps.lastActivity < oldest.lastActivity) oldest = ps
+  }
+  if (oldest) {
+    oldest.child.kill()
+    processes.delete(oldest.deckId)
+    // Wait briefly for cleanup
+    await new Promise(r => setTimeout(r, 500))
+  }
 }
 
-/** Load an existing ACP session (replays history via session/update notifications). */
-export async function loadSession(savedSessionId: string): Promise<void> {
-  await ensureAgent()
-  const result = await rpcRequest("session/load", { sessionId: savedSessionId, cwd: MCP_LOCAL_DIR, mcpServers: [] }) as Record<string, unknown> | undefined
-  sessionId = (result?.sessionId as string) || savedSessionId
+// ── Public API ──
+
+/** Get or create a process for a deck. */
+export async function getProcess(deckId: string, agentName: string = "sdpm-spec"): Promise<ProcessState> {
+  let ps = processes.get(deckId)
+  if (ps) {
+    ps.lastActivity = Date.now()
+    return ps
+  }
+  await evictIfNeeded()
+  ps = await spawnProcess(deckId, agentName)
+  processes.set(deckId, ps)
+  activeDeckId = deckId
+  return ps
+}
+
+/** Get or create a process for a new deck (no deckId yet). Returns temp key. */
+export async function newProcess(agentName: string = "sdpm-spec"): Promise<{ ps: ProcessState; tempKey: string }> {
+  // Reuse existing idle temp process if available
+  for (const [key, ps] of processes) {
+    if (key.startsWith("_new_") && !ps.running && ps.agentName === agentName) {
+      activeDeckId = key
+      return { ps, tempKey: key }
+    }
+  }
+  const tempKey = `_new_${Date.now()}`
+  await evictIfNeeded()
+  const ps = await spawnProcess(tempKey, agentName)
+  processes.set(tempKey, ps)
+  activeDeckId = tempKey
+  return { ps, tempKey }
+}
+
+/** Re-key a temp process to a real deckId. */
+export function associateDeck(tempKey: string, deckId: string): void {
+  const ps = processes.get(tempKey)
+  if (!ps) return
+  processes.delete(tempKey)
+  ps.deckId = deckId
+  processes.set(deckId, ps)
+  if (activeDeckId === tempKey) activeDeckId = deckId
+}
+
+/** Send a prompt to a deck's process. */
+export async function sendPrompt(deckId: string, text: string, agentName?: string): Promise<{ sessionId: string; subscribe: (fn: NotifyListener) => () => void; send: () => void }> {
+  const ps = await getProcess(deckId, agentName)
+  ps.running = true
+  ps.notifications = []; ps.eventIdCounter = 0
+  ps.lastActivity = Date.now()
+
+  // Return subscribe BEFORE sending prompt to avoid race condition.
+  // Caller must: subscribe → then call send().
+  return {
+    sessionId: ps.sessionId!,
+    subscribe: (fn: NotifyListener) => {
+      ps.listeners.add(fn)
+      return () => { ps.listeners.delete(fn) }
+    },
+    send: () => {
+      rpcRequestTo(ps, "session/prompt", {
+        sessionId: ps.sessionId,
+        prompt: [{ type: "text", text }],
+      })
+    },
+  }
+}
+
+/** Cancel a deck's active prompt. */
+export function cancelDeck(deckId: string): void {
+  const ps = processes.get(deckId)
+  if (!ps) return
+  if (ps.sessionId) {
+    rpcNotifyTo(ps, "session/cancel", { sessionId: ps.sessionId })
+    for (const subId of ps.subSessionIds) {
+      rpcNotifyTo(ps, "session/cancel", { sessionId: subId })
+    }
+    ps.subSessionIds.clear()
+  }
+}
+
+/** Cancel all processes (stop button with no specific deck). */
+export function cancelAll(): void {
+  for (const ps of processes.values()) {
+    if (ps.running && ps.sessionId) {
+      rpcNotifyTo(ps, "session/cancel", { sessionId: ps.sessionId })
+      for (const subId of ps.subSessionIds) {
+        rpcNotifyTo(ps, "session/cancel", { sessionId: subId })
+      }
+      ps.subSessionIds.clear()
+    }
+  }
+}
+
+/** Check if a deck has a running process. */
+export function isSessionRunning(deckId: string): boolean {
+  return processes.get(deckId)?.running ?? false
+}
+
+/** Mark running state. */
+export function markSessionRunning(deckId: string, running: boolean): void {
+  const ps = processes.get(deckId)
+  if (ps) ps.running = running
+}
+
+/** Drain buffered notifications for a deck. */
+export function getBufferedEvents(deckId: string, afterId?: number): { id: number; msg: Record<string, unknown> }[] {
+  const ps = processes.get(deckId)
+  if (!ps) return []
+  if (afterId == null) return [...ps.notifications]
+  return ps.notifications.filter(e => e.id > afterId)
+}
+
+/** Subscribe to a deck's process notifications. */
+export function subscribeToDeck(deckId: string): { sessionId: string | null; subscribe: (fn: NotifyListener) => () => void } | null {
+  const ps = processes.get(deckId)
+  if (!ps) return null
+  return {
+    sessionId: ps.sessionId,
+    subscribe: (fn: NotifyListener) => {
+      ps.listeners.add(fn)
+      return () => { ps.listeners.delete(fn) }
+    },
+  }
+}
+
+/** Get session ID for a deck. */
+export function getSessionId(deckId?: string): string | null {
+  const id = deckId || activeDeckId
+  if (!id) return null
+  return processes.get(id)?.sessionId ?? null
+}
+
+export function getActiveDeckId(): string | null { return activeDeckId }
+export function setActiveDeckId(id: string): void { activeDeckId = id }
+
+export function getModels(): { current: string; available: AcpModel[] } {
+  return { current: currentModelId, available: availableModels }
+}
+
+export async function setConfigOption(deckId: string, configId: string, value: string): Promise<void> {
+  const ps = processes.get(deckId)
+  if (!ps?.sessionId) return
+  await rpcRequestTo(ps, "session/set_config_option", { sessionId: ps.sessionId, configId, value })
 }
 
 /** Save sessionId to deck's .session file. */
 export function saveSessionToDeck(deckId: string): void {
-  if (!sessionId) return
+  const sid = getSessionId(deckId)
+  if (!sid) return
   const fs = require("fs") as typeof import("fs")
   const dir = resolveDeckDir(deckId)
   if (!dir || !fs.existsSync(dir)) return
-  fs.writeFileSync(path.join(dir, ".session"), sessionId, "utf-8")
+  fs.writeFileSync(path.join(dir, ".session"), sid, "utf-8")
 }
 
 /** Read sessionId from deck's .session file. */
@@ -233,5 +351,8 @@ export function readChatFromDeck(deckId: string): unknown[] {
 
 // Cleanup on process exit
 for (const sig of ["exit", "SIGINT", "SIGTERM"] as const) {
-  process.on(sig, () => { child?.kill(); child = null })
+  process.on(sig, () => {
+    for (const ps of processes.values()) ps.child.kill()
+    processes.clear()
+  })
 }

--- a/web-ui/src/lib/local/sse-bridge.ts
+++ b/web-ui/src/lib/local/sse-bridge.ts
@@ -11,6 +11,9 @@ interface BridgeOptions {
   sessionId: string
   subscribe: (fn: (msg: Record<string, unknown>) => void) => () => void
   onDeckId?: (deckId: string) => void
+  onDone?: () => void
+  /** Pre-buffered notifications to replay before subscribing to live events. */
+  replay?: { id: number; msg: Record<string, unknown> }[]
 }
 
 function extractSlugs(q: string): string {
@@ -18,7 +21,7 @@ function extractSlugs(q: string): string {
   return m ? m[1].trim() : ""
 }
 
-export function createSSEStream({ sessionId, subscribe, onDeckId }: BridgeOptions): ReadableStream {
+export function createSSEStream({ sessionId, subscribe, onDeckId, onDone, replay }: BridgeOptions): ReadableStream {
   const encoder = new TextEncoder()
 
   return new ReadableStream({
@@ -28,20 +31,39 @@ export function createSSEStream({ sessionId, subscribe, onDeckId }: BridgeOption
       const subagentGroups = new Map<string, { group: number; slugs: string }>()
       const subagentQueryQueue: string[] = []
 
-      function send(event: Record<string, unknown>) {
-        try { controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`)) } catch {}
+      let eventId = 0
+      function send(event: Record<string, unknown>, id?: number) {
+        const eid = id ?? ++eventId
+        try { controller.enqueue(encoder.encode(`id: ${eid}\ndata: ${JSON.stringify(event)}\n\n`)) } catch {}
       }
 
       function close() {
         unsubscribe()
+        onDone?.()
         try { controller.close() } catch {}
       }
 
-      const unsubscribe = subscribe((msg) => {
+      // Replay buffered notifications first (for reconnecting to background sessions)
+      let replaying = true
+      if (replay?.length) {
+        for (const { id, msg } of replay) {
+          eventId = id  // sync event ID counter
+          processMsg(msg)
+        }
+      }
+      replaying = false
+
+      const unsubscribe = subscribe(processMsg)
+
+      function processMsg(msg: Record<string, unknown>) {
         // End turn from RPC response
         if (msg.id != null && msg.result) {
           const r = msg.result as Record<string, unknown>
-          if (r.stopReason === "end_turn" || r.stopReason === "cancelled") { close(); return }
+          if (r.stopReason === "end_turn" || r.stopReason === "cancelled") {
+            if (!replaying) { close(); return }
+            // During replay, ignore end_turn from old responses
+            return
+          }
         }
 
         if (msg.method !== "session/update" && msg.method !== "_kiro.dev/session/update") return
@@ -152,8 +174,8 @@ export function createSSEStream({ sessionId, subscribe, onDeckId }: BridgeOption
           }
         }
 
-        if (type === "turn_end" || type === "end_turn") { close() }
-      })
+        if (type === "turn_end" || type === "end_turn") { if (!replaying) close() }
+      }
     },
   })
 }

--- a/web-ui/src/services/agentCoreService.js
+++ b/web-ui/src/services/agentCoreService.js
@@ -30,10 +30,10 @@ export const setAgentConfig = (runtimeArn, region = "us-east-1") => {
 /**
  * Invokes the AgentCore runtime with streaming support
  */
-export const invokeAgentCore = async (query, sessionId, onStreamUpdate, accessToken, userId, onToolUse, signal, mode) => {
+export const invokeAgentCore = async (query, sessionId, onStreamUpdate, accessToken, userId, onToolUse, signal, mode, deckId) => {
   // Local mode: proxy through Next.js API Route → kiro-cli acp
   if (IS_LOCAL) {
-    return invokeLocalAgent(query, sessionId, onStreamUpdate, onToolUse, signal, mode);
+    return invokeLocalAgent(query, sessionId, onStreamUpdate, onToolUse, signal, mode, deckId);
   }
 
   try {
@@ -202,16 +202,17 @@ export const generateSessionId = () => {
  * Reads SSE stream from /api/agent/invoke and feeds events through the same
  * strandsParser used by the cloud path, so ChatPanel works unchanged.
  */
-const invokeLocalAgent = async (query, sessionId, onStreamUpdate, onToolUse, signal, mode) => {
+const invokeLocalAgent = async (query, sessionId, onStreamUpdate, onToolUse, signal, mode, deckId) => {
   const response = await fetch('/api/agent/invoke', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, sessionId, mode: mode || 'spec' }),
+    body: JSON.stringify({ query, sessionId, mode: mode || 'spec', deckId: deckId || undefined }),
     signal,
   });
 
   if (!response.ok) {
     const errorText = await response.text();
+    console.error('[invokeLocal] error:', errorText);
     throw new Error(`Local agent error: ${response.status}: ${errorText}`);
   }
 
@@ -233,6 +234,7 @@ const invokeLocalAgent = async (query, sessionId, onStreamUpdate, onToolUse, sig
         buffer = lines.pop() || '';
         for (const line of lines) {
           if (line.trim()) {
+            const prev = completion;
             completion = parser.parseStreamingChunk(line, completion, onStreamUpdate, onToolUse);
           }
         }
@@ -244,3 +246,31 @@ const invokeLocalAgent = async (query, sessionId, onStreamUpdate, onToolUse, sig
 
   return completion;
 }
+
+/**
+ * Reconnect to a running background session using EventSource.
+ * Supports Last-Event-ID for seamless resume after disconnect.
+ * Returns a cleanup function, or null if no session is running.
+ */
+export const reconnectLocalSession = (deckId, onStreamUpdate, onToolUse) => {
+  if (!IS_LOCAL) return null;
+
+  const url = `/api/agent/stream?deckId=${encodeURIComponent(deckId)}`;
+  const es = new EventSource(url);
+  let completion = '';
+  if (parser.resetParserState) parser.resetParserState();
+
+  es.onmessage = (event) => {
+    const line = `data: ${event.data}`;
+    completion = parser.parseStreamingChunk(line, completion, onStreamUpdate, onToolUse);
+  };
+
+  es.onerror = () => {
+    // EventSource auto-reconnects with Last-Event-ID
+    // If server returns non-SSE (session ended), close
+    es.close();
+  };
+
+  // Return cleanup function
+  return () => es.close();
+};


### PR DESCRIPTION
## Summary

Multi-process kiro-cli session management + multi-agent adapter for Local mode. Each deck gets its own ACP process (max 3, LRU eviction). Switching decks does not interrupt running agents. Supports multiple ACP-compatible agents (kiro-cli, Claude Code, etc.) via the existing Agent Settings UI.

## Problem

1. Single kiro-cli process meant switching decks or creating new chats cancelled running agents
2. Only kiro-cli was supported — no way to use Claude Code, opencode, or other ACP agents

## Solution

### Multi-process session management
- **One process per deck**: `acp-process.ts` manages `Map<deckId, ProcessState>`, each with independent child process, ACP session, and event buffer
- **Background continuity**: Navigating away does not stop agents. Notifications buffered server-side with sequential IDs
- **SSE resume with Last-Event-ID**: `EventSource` reconnects and replays missed events. Tool cards appear at correct text positions via `buildBlocks`
- **No impact on Cloud mode**: All changes guarded by `IS_LOCAL` or in `lib/local/` / `app/api/` (excluded from cloud build)

### Multi-agent adapter
- **Reuses existing AgentSettingsDialog UI** (AppShell menu → ACP Agents)
- **Server-side config**: `mcp-local/.sdpm/acp-config.json` synced via `/api/agent/config` API
- **`acp-process.ts`** reads active agent's `path`/`args`/`env` when spawning
- **Presets**: Kiro CLI, Claude Code (extensible via UI)

## Changed files

| File | Change |
|---|---|
| `lib/local/acp-process.ts` | Multi-process manager, per-deck spawn with adapter config, event buffer with IDs, LRU eviction |
| `lib/local/acp-adapter.ts` | **New** — server-side agent config read/write |
| `lib/local/sse-bridge.ts` | `id:` field on SSE events, replay with `replaying` guard |
| `app/api/agent/invoke/route.ts` | Subscribe before send (race fix), `force-dynamic` |
| `app/api/agent/stream/route.ts` | **New** — GET endpoint with Last-Event-ID resume |
| `app/api/agent/config/route.ts` | **New** — GET/PUT for agent adapter config |
| `app/api/agent/load/route.ts` | Read `.chat.json` only (no kiro-cli interaction) |
| `app/api/agent/stop/route.ts` | Cancel specific deck, newChat is no-op |
| `app/api/agent/models/route.ts` | Spawn process for initial model list, reuse idle temp process |
| `app/api/upload/route.ts` | Use `getProcess` instead of removed `ensureAgent` |
| `components/chat/ChatPanel.tsx` | EventSource reconnect with `buildBlocks`, Local-format chat restore, compose toolStream in reconnect, deferred `isLoading`, duplicate tool guard |
| `components/chat/ChatPanelShell.tsx` | Model polling retry |
| `components/chat/AgentSettingsDialog.tsx` | Sync to server-side config via API (Local mode) |
| `services/agentCoreService.js` | EventSource-based `reconnectLocalSession`, `deckId` passthrough |

## Testing

1. `npm run dev:local`
2. Create deck A, start agent → agent begins working
3. Click New, create deck B → deck A continues in background
4. Return to deck A → chat + tools resume via EventSource
5. AppShell menu → ACP Agents → add/switch agents
6. `npm run build:cloud` — passes, no cloud impact
