### PR TITLE
🐛 fix(templates): use shared template dirs in MCP Local list_templates

### DIFF
--- a/docs/en/custom-template.md
+++ b/docs/en/custom-template.md
@@ -109,7 +109,7 @@ Custom templates can also be placed outside the package, so they survive a
 searches the following locations in order and merges the results in
 `list_templates`:
 
-1. Directories listed in `$SDPM_TEMPLATES_DIR` (colon-separated, same semantics as `PATH`)
+1. Directories listed in `$SDPM_TEMPLATES_DIR` (platform path separator: `:` on Unix, `;` on Windows — same semantics as `PATH`)
 2. `~/.config/sdpm/templates/`
 3. `skill/templates/` (package-bundled)
 

--- a/docs/ja/custom-template.md
+++ b/docs/ja/custom-template.md
@@ -108,7 +108,7 @@ skill/templates/
 `pip install --upgrade` やリポジトリの再 clone でも消えません。Kiro CLI /
 `pptx_builder.py` は以下の順で検索し、`list_templates` ではマージして表示します。
 
-1. `$SDPM_TEMPLATES_DIR` に列挙されたディレクトリ (コロン区切り、`PATH` と同じセマンティクス)
+1. `$SDPM_TEMPLATES_DIR` に列挙されたディレクトリ (プラットフォームのパス区切り文字: Unixは `:`、Windowsは `;` — `PATH` と同じセマンティクス)
 2. `~/.config/sdpm/templates/`
 3. `skill/templates/` (パッケージ同梱)
 

--- a/mcp-local/server.py
+++ b/mcp-local/server.py
@@ -213,14 +213,22 @@ def search_assets(
 def list_templates() -> str:
     """List all available PPTX templates with name.
 
+    Includes user-local templates (via $SDPM_TEMPLATES_DIR or ~/.config/sdpm/templates/)
+    in addition to the package-bundled ones. User-local templates shadow bundled
+    templates with the same stem.
+
     Returns:
         JSON with list of template names.
     """
-    templates_dir = _SKILL_DIR / "templates"
-    if not templates_dir.exists():
-        return json.dumps({"templates": []})
-    templates = sorted(t.stem for t in templates_dir.glob("*.pptx"))
-    return json.dumps({"templates": templates})
+    from sdpm.api import _get_templates_dirs
+
+    seen: dict[str, str] = {}
+    for d in _get_templates_dirs():
+        if not d.exists():
+            continue
+        for t in sorted(d.glob("*.pptx")):
+            seen.setdefault(t.stem, t.stem)
+    return json.dumps({"templates": sorted(seen)})
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

Follow-up to #96. The MCP Local list_templates tool was still hard-coded to only scan skill/templates/, so user-local
templates (via $SDPM_TEMPLATES_DIR or ~/.config/sdpm/templates/) did not appear when listing templates through MCP
clients.

## Changes

- **mcp-local/server.py**: list_templates now uses _get_templates_dirs() from sdpm.api, consistent with the CLI and
Engine layers
- **docs/{en,ja}/custom-template.md**: Fix env var separator description to note platform dependency (os.pathsep: : on
Unix, ; on Windows)

## Testing

All 94 existing tests pass.