### PR TITLE
feat: user-local styles, assets, and config with cross-platform paths

### DIFF
--- a/docs/en/custom-template.md
+++ b/docs/en/custom-template.md
@@ -1,9 +1,19 @@
 [EN](../en/custom-template.md) | [JA](../ja/custom-template.md)
 
-# Custom Templates and Assets
+# Custom Templates, Styles, and Assets
 
 spec-driven-presentation-maker works with any `.pptx` file as a template.
 It automatically analyzes the template's layouts, colors, fonts, and placeholders — no manual configuration needed.
+
+Beyond templates, three other resource types can be customized per-user:
+
+- **Templates** (`.pptx`) — slide masters
+- **Styles** (`.html`) — design guides used by the agent
+- **Assets** (images such as `.svg`, `.png`) — icons, logos, illustrations
+- **Config** (`config.json`) — output directory, extra asset sources, etc.
+
+All four support user-local placement so your customizations survive
+`pip install --upgrade` or a repository re-clone.
 
 ---
 
@@ -110,11 +120,36 @@ searches the following locations in order and merges the results in
 `list_templates`:
 
 1. Directories listed in `$SDPM_TEMPLATES_DIR` (platform path separator: `:` on Unix, `;` on Windows — same semantics as `PATH`)
-2. `~/.config/sdpm/templates/`
+2. `<user-config>/templates/` — see **User-local directory layout** below
 3. `skill/templates/` (package-bundled)
 
 A user-local template shadows a bundled one with the same file name, which
 makes it easy to override sample templates without editing the repository.
+
+#### User-local directory layout
+
+The user-local base directory is platform-aware:
+
+| Platform | Location |
+|----------|----------|
+| macOS / Linux | `$XDG_CONFIG_HOME/sdpm/` (default: `~/.config/sdpm/`) |
+| Windows | `%APPDATA%/sdpm/` (default: `C:\Users\<you>\AppData\Roaming\sdpm\`) |
+
+Layout:
+
+```
+<user-config>/sdpm/
+├── templates/          # User-local .pptx templates
+├── styles/             # User-local style HTMLs (see "Custom Styles" below)
+├── assets/             # User-local asset sources (see "Custom Assets" below)
+│   └── my-company/
+│       ├── manifest.json
+│       └── logo.svg
+└── config.json         # Per-user config overrides (output_dir, extra_sources, …)
+```
+
+None of these paths exist by default — create only what you need
+(`mkdir -p ~/.config/sdpm/styles` etc.).
 
 ### Layer 3 (Remote MCP)
 
@@ -141,7 +176,38 @@ The script handles S3 upload, template analysis, and Amazon DynamoDB metadata re
 
 ---
 
-## Asset Customization
+## Custom Styles
+
+Styles are HTML files that describe the visual direction (colors, typography,
+components, tone) for a deck. The agent reads `:root` CSS variables and style
+classes to mirror the design in `slides.json`.
+
+### User-local styles
+
+Use the `create-style` workflow (agent-driven) to generate a new style HTML.
+The workflow writes to `<user-config>/styles/{name}.html` — i.e.
+`~/.config/sdpm/styles/` on macOS/Linux or `%APPDATA%/sdpm/styles/` on Windows.
+
+You can also copy an existing style manually:
+
+```bash
+mkdir -p ~/.config/sdpm/styles
+cp skill/references/examples/styles/elegant-dark.html \
+   ~/.config/sdpm/styles/my-style.html
+```
+
+Search order (first match wins on same file name):
+
+1. Directories listed in `$SDPM_STYLES_DIR` (platform path separator, like `PATH`)
+2. `<user-config>/styles/`
+3. `skill/references/examples/styles/` (package-bundled samples)
+
+The styles gallery (opened by `list_styles` or the CLI `examples styles` command)
+scans all three locations and displays them in a single list. User-local styles
+shadow bundled ones of the same name so you can override samples without
+touching the repository.
+
+---
 
 ### Built-in Asset Sources
 
@@ -185,36 +251,95 @@ Reference formats:
 
 ### Adding Custom Asset Sources
 
-Create a directory with your icons and a `manifest.json`:
+There are two ways to add a custom asset source (e.g. your company logos):
+
+#### Option A — Drop-in under `<user-config>/assets/` (auto-discovered)
+
+Place the source directory under the user-local assets path. It is automatically
+scanned at runtime — no config changes required:
+
+```
+~/.config/sdpm/assets/my-company/     # (Windows: %APPDATA%/sdpm/assets/my-company/)
+├── manifest.json
+└── logo.svg
+```
+
+`manifest.json` follows the built-in format:
 
 ```json
 {
+  "source": "my-company",
   "icons": [
-    {"name": "my-logo", "file": "logo.svg", "tags": ["brand", "logo"]},
-    {"name": "product-icon", "file": "product.svg", "tags": ["product"]}
+    {"name": "my-logo", "file": "logo.svg", "tags": ["brand", "logo"], "type": "service"}
   ]
 }
 ```
 
-Register in `skill/assets/config.json` (copy from `config.example.json`):
+Reference in `slides.json`:
+
+```json
+{ "type": "image", "src": "assets:my-company/logo", "x": 100, "y": 200, "width": 64, "height": 64 }
+```
+
+#### Option B — Explicit registration via `config.json`
+
+Use this when the files live anywhere on disk (e.g. a shared network drive),
+or when you want to point at an existing directory without moving it:
+
+```json
+{
+  "extra_sources": [
+    {
+      "source": "mybrand",
+      "manifest": "/path/to/my-icons/manifest.json",
+      "files_dir": "/path/to/my-icons/"
+    }
+  ]
+}
+```
+
+Save as `<user-config>/config.json` (see **User config** below).
+
+### Priority order
+
+When an asset name appears in multiple sources, the earlier source wins:
+
+1. `extra_sources` from `config.json` — explicit override
+2. `<user-config>/assets/` — auto-discovered user-local sources
+3. `skill/assets/` — built-in sources (aws, material)
+4. Legacy `icons/` directory (only if present)
+
+This lets `extra_sources` override user-local sources, which in turn override
+bundled ones. Registering a built-in name in `extra_sources` is an intentional
+way to replace a bundled icon with your own.
+
+---
+
+## User config
+
+Per-user configuration lives in `<user-config>/config.json` (that is,
+`~/.config/sdpm/config.json` on macOS/Linux or `%APPDATA%/sdpm/config.json`
+on Windows). The file is optional; missing keys fall back to defaults.
+
+Full schema with defaults:
 
 ```json
 {
   "output_dir": "~/Documents/SDPM-Presentations",
-  "extra_sources": [
-    {
-      "name": "mybrand",
-      "manifest": "/path/to/my-icons/manifest.json",
-      "files_dir": "/path/to/my-icons/"
-    }
-  ],
-  "preview": {
-    "backend": ""
-  }
+  "extra_sources": []
 }
 ```
 
-Now reference as `assets:mybrand/my-logo`.
+- `output_dir` — Base directory where generated PPTX files are written.
+  Supports `~` expansion. Can also be overridden per-run via
+  `$SDPM_OUTPUT_DIR`.
+- `extra_sources` — Additional asset manifests (see **Option B** above).
+
+The previously-shipped `skill/assets/config.json` is no longer read — it was
+lost on `pip install --upgrade` and is replaced entirely by the user-local
+path above.
+
+---
 
 ### Uploading Assets to S3 (Layer 3)
 

--- a/docs/ja/custom-template.md
+++ b/docs/ja/custom-template.md
@@ -1,9 +1,18 @@
 [EN](../en/custom-template.md) | [JA](../ja/custom-template.md)
 
-# カスタムテンプレートとアセット
+# カスタムテンプレート・スタイル・アセット
 
 spec-driven-presentation-maker は任意の `.pptx` ファイルをテンプレートとして使用できます。
 テンプレートのレイアウト、カラー、フォント、プレースホルダーを自動解析するため、手動設定は不要です。
+
+テンプレート以外にも、以下 4 種類のリソースをユーザー単位でカスタマイズできます。
+
+- **テンプレート** (`.pptx`) — スライドマスター
+- **スタイル** (`.html`) — エージェントが参照するデザインガイド
+- **アセット** (`.svg` / `.png` 等の画像) — アイコン、ロゴ、イラスト
+- **設定** (`config.json`) — 出力ディレクトリ、追加アセットソースなど
+
+いずれもユーザーローカルに配置でき、`pip install --upgrade` やリポジトリの再 clone でも消えません。
 
 ---
 
@@ -109,11 +118,36 @@ skill/templates/
 `pptx_builder.py` は以下の順で検索し、`list_templates` ではマージして表示します。
 
 1. `$SDPM_TEMPLATES_DIR` に列挙されたディレクトリ (プラットフォームのパス区切り文字: Unixは `:`、Windowsは `;` — `PATH` と同じセマンティクス)
-2. `~/.config/sdpm/templates/`
+2. `<user-config>/templates/` — 下記の **ユーザーローカルディレクトリ構成** を参照
 3. `skill/templates/` (パッケージ同梱)
 
 同じファイル名がある場合はユーザーローカル側が優先されます。リポジトリを
 変更せずに同梱テンプレートを上書きしたいケースに便利です。
+
+#### ユーザーローカルディレクトリ構成
+
+ユーザーローカルのベースディレクトリはプラットフォームに応じて決まります。
+
+| プラットフォーム | 場所 |
+|----------|----------|
+| macOS / Linux | `$XDG_CONFIG_HOME/sdpm/` (既定: `~/.config/sdpm/`) |
+| Windows | `%APPDATA%/sdpm/` (既定: `C:\Users\<you>\AppData\Roaming\sdpm\`) |
+
+構成:
+
+```
+<user-config>/sdpm/
+├── templates/          # ユーザーローカルの .pptx テンプレート
+├── styles/             # ユーザーローカルのスタイル HTML (下記「カスタムスタイル」参照)
+├── assets/             # ユーザーローカルのアセットソース (下記「カスタムアセット」参照)
+│   └── my-company/
+│       ├── manifest.json
+│       └── logo.svg
+└── config.json         # ユーザー単位の設定 (output_dir, extra_sources 等)
+```
+
+いずれも既定では存在しません。必要なものだけ作成してください
+(`mkdir -p ~/.config/sdpm/styles` など)。
 
 ### Layer 3（リモート MCP）
 
@@ -140,7 +174,38 @@ uv run python scripts/upload_template.py \
 
 ---
 
-## アセットのカスタマイズ
+## カスタムスタイル
+
+スタイルは、デッキの視覚的な方向性（配色、タイポグラフィ、コンポーネント、
+トーン）を記述した HTML ファイルです。エージェントは `:root` の CSS 変数と
+スタイルクラスを読み取り、`slides.json` に反映します。
+
+### ユーザーローカルなスタイル
+
+`create-style` ワークフロー（エージェント駆動）で新しいスタイル HTML を生成する
+と、`<user-config>/styles/{name}.html` に書き出されます。macOS/Linux なら
+`~/.config/sdpm/styles/`、Windows なら `%APPDATA%/sdpm/styles/` です。
+
+既存のスタイルを手動でコピーしても構いません。
+
+```bash
+mkdir -p ~/.config/sdpm/styles
+cp skill/references/examples/styles/elegant-dark.html \
+   ~/.config/sdpm/styles/my-style.html
+```
+
+検索順序（同一ファイル名は先勝ち）:
+
+1. `$SDPM_STYLES_DIR` に列挙されたディレクトリ (プラットフォームのパス区切り文字、`PATH` と同じセマンティクス)
+2. `<user-config>/styles/`
+3. `skill/references/examples/styles/` (パッケージ同梱のサンプル)
+
+スタイルギャラリー（`list_styles` や CLI の `examples styles` で開くもの）は
+全 3 箇所をスキャンし、一覧を統合して表示します。同名のユーザーローカル
+スタイルは同梱サンプルをシャドウするため、リポジトリを変更せずに上書き
+できます。
+
+---
 
 ### 組み込みアセットソース
 
@@ -184,36 +249,94 @@ skill/assets/
 
 ### カスタムアセットソースの追加
 
-アイコンと `manifest.json` を含むディレクトリを作成します。
+カスタムアセットソース（会社ロゴ等）を追加する方法は 2 通りあります。
+
+#### 方法 A — `<user-config>/assets/` に配置する（自動認識）
+
+ユーザーローカルの assets ディレクトリ配下にソースを配置すると、実行時に
+自動でスキャンされます。設定ファイルの変更は不要です。
+
+```
+~/.config/sdpm/assets/my-company/     # Windows: %APPDATA%/sdpm/assets/my-company/
+├── manifest.json
+└── logo.svg
+```
+
+`manifest.json` のフォーマットは組み込みソースと同じです。
 
 ```json
 {
+  "source": "my-company",
   "icons": [
-    {"name": "my-logo", "file": "logo.svg", "tags": ["brand", "logo"]},
-    {"name": "product-icon", "file": "product.svg", "tags": ["product"]}
+    {"name": "my-logo", "file": "logo.svg", "tags": ["brand", "logo"], "type": "service"}
   ]
 }
 ```
 
-`skill/assets/config.json` に登録（`config.example.json` をコピーして作成）:
+`slides.json` からの参照:
+
+```json
+{ "type": "image", "src": "assets:my-company/logo", "x": 100, "y": 200, "width": 64, "height": 64 }
+```
+
+#### 方法 B — `config.json` で明示登録する
+
+ファイルがディスクの任意の場所にある場合（共有ネットワークドライブ等）、
+または既存のディレクトリを移動せずに参照したい場合に使います。
+
+```json
+{
+  "extra_sources": [
+    {
+      "source": "mybrand",
+      "manifest": "/path/to/my-icons/manifest.json",
+      "files_dir": "/path/to/my-icons/"
+    }
+  ]
+}
+```
+
+`<user-config>/config.json` に保存します（下記「ユーザー設定」を参照）。
+
+### 優先順序
+
+同じアセット名が複数ソースに存在する場合、先に列挙された方が勝ちます。
+
+1. `config.json` の `extra_sources` — 明示的なオーバーライド
+2. `<user-config>/assets/` — 自動認識されるユーザーローカルソース
+3. `skill/assets/` — 組み込みソース（aws、material）
+4. レガシー `icons/` ディレクトリ（存在する場合のみ）
+
+これにより `extra_sources` がユーザーローカルを、ユーザーローカルが同梱を
+それぞれ上書きできます。組み込みと同名のエントリを `extra_sources` に登録
+することは、同梱アイコンを差し替える正規の手段です。
+
+---
+
+## ユーザー設定
+
+ユーザー単位の設定は `<user-config>/config.json`（macOS/Linux なら
+`~/.config/sdpm/config.json`、Windows なら `%APPDATA%/sdpm/config.json`）に
+置きます。ファイルは任意で、欠落しているキーは既定値にフォールバックします。
+
+既定値込みの完全なスキーマ:
 
 ```json
 {
   "output_dir": "~/Documents/SDPM-Presentations",
-  "extra_sources": [
-    {
-      "name": "mybrand",
-      "manifest": "/path/to/my-icons/manifest.json",
-      "files_dir": "/path/to/my-icons/"
-    }
-  ],
-  "preview": {
-    "backend": ""
-  }
+  "extra_sources": []
 }
 ```
 
-`assets:mybrand/my-logo` で参照できるようになります。
+- `output_dir` — 生成した PPTX の出力先ベースディレクトリ。`~` 展開可能。
+  `$SDPM_OUTPUT_DIR` でも実行時に上書きできます
+- `extra_sources` — 追加アセットマニフェスト（上記「方法 B」参照）
+
+以前同梱されていた `skill/assets/config.json` は読み込み対象から外れました。
+`pip install --upgrade` で消失する問題があったため、ユーザーローカルパスに
+一本化しています。
+
+---
 
 ### S3 へのアセットアップロード（Layer 3）
 

--- a/mcp-local/server.py
+++ b/mcp-local/server.py
@@ -220,10 +220,10 @@ def list_templates() -> str:
     Returns:
         JSON with list of template names.
     """
-    from sdpm.api import _get_templates_dirs
+    from sdpm.api import get_templates_dirs
 
     seen: dict[str, str] = {}
-    for d in _get_templates_dirs():
+    for d in get_templates_dirs():
         if not d.exists():
             continue
         for t in sorted(d.glob("*.pptx")):

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -95,11 +95,17 @@ def list_asset_sources(skill_dir: Path) -> dict[str, Any]:
 
 
 def list_styles(skill_dir: Path) -> dict[str, Any]:
-    """List available design styles and open gallery in browser."""
-    from sdpm.reference import list_styles as _list_styles, open_styles_gallery
-    styles_dir = skill_dir / "references" / "examples" / "styles"
-    open_styles_gallery(styles_dir)
-    return {"styles": _list_styles(styles_dir)}
+    """List available design styles and open gallery in browser.
+
+    Searches user-local styles directory (``~/.config/sdpm/styles/``) in
+    addition to the package-bundled styles. User-local entries shadow
+    bundled ones with the same name.
+    """
+    from sdpm.api import get_styles_dirs
+    from sdpm.reference import list_styles_merged, open_styles_gallery
+    styles_dirs = get_styles_dirs()
+    open_styles_gallery(styles_dirs)
+    return {"styles": list_styles_merged(styles_dirs)}
 
 
 def read_examples(names: list[str], skill_dir: Path) -> dict[str, Any]:

--- a/mcp-local/tools.py
+++ b/mcp-local/tools.py
@@ -50,6 +50,10 @@ def generate_pptx(
 ) -> dict[str, Any]:
     """Generate PPTX from a JSON file."""
     from sdpm.api import generate
+    from sdpm.assets import invalidate_manifest_cache
+    # Invalidate caches so user-local asset/config changes are picked up
+    # in this long-lived MCP Local process.
+    invalidate_manifest_cache()
     return generate(
         json_path=slides_json_path,
         output_path=output_path or None,
@@ -76,7 +80,8 @@ def search_assets(
     source_filter: str = "", type_filter: str = "", theme_filter: str = "",
 ) -> dict[str, Any]:
     """Search assets by keyword."""
-    from sdpm.assets import search_assets as _search
+    from sdpm.assets import invalidate_manifest_cache, search_assets as _search
+    invalidate_manifest_cache()
     return {
         "query": query,
         "results": _search(
@@ -90,7 +95,8 @@ def search_assets(
 
 def list_asset_sources(skill_dir: Path) -> dict[str, Any]:
     """List available asset sources."""
-    from sdpm.assets import list_sources
+    from sdpm.assets import invalidate_manifest_cache, list_sources
+    invalidate_manifest_cache()
     return {"sources": list_sources()}
 
 

--- a/skill/references/workflows/create-style.md
+++ b/skill/references/workflows/create-style.md
@@ -11,7 +11,12 @@ A style captures design preferences so they don't need to be repeated every time
 
 ## Deliverable
 
-`references/examples/styles/{name}.html`
+`~/.config/sdpm/styles/{name}.html`
+
+User-local styles survive `pip install --upgrade` and are automatically picked up
+by `list_styles` and the styles gallery. The directory does not exist by default —
+create it if missing (e.g. `mkdir -p ~/.config/sdpm/styles`). On Windows this maps
+to `%APPDATA%/sdpm/styles/`.
 
 ## Inputs
 
@@ -182,7 +187,8 @@ Each slide demonstrates the design while explaining the reasoning.
 
 #### 3c. Write the HTML
 
-Now write `references/examples/styles/{name}.html`.
+Now write `~/.config/sdpm/styles/{name}.html` (Windows: `%APPDATA%/sdpm/styles/{name}.html`).
+Create the parent directory if it does not exist (`mkdir -p ~/.config/sdpm/styles`).
 Write incrementally — do NOT generate the entire HTML at once.
 Start with the skeleton (head, `:root` variables, base CSS), then add one slide at a time.
 This avoids timeouts and makes each slide reviewable.

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -218,7 +218,7 @@ def cmd_search_patterns(args):
 
 def cmd_examples(args):
     """List or show design examples (components/patterns/styles)."""
-    from sdpm.reference import list_styles, open_styles_gallery, read_docs
+    from sdpm.reference import open_styles_gallery, read_docs
 
     examples_dir = Path(__file__).parent.parent / "references" / "examples"
     if not examples_dir.exists():
@@ -235,17 +235,16 @@ def cmd_examples(args):
         base = parts[0]
         sub = parts[1] if len(parts) > 1 else None
 
-        # styles/ directory
+        # styles/ directory — searches user-local + bundled
         if base == "styles":
-            styles_dir = examples_dir / "styles"
-            if not styles_dir.exists():
-                print("# Not found: styles/", file=sys.stderr)
-                continue
+            from sdpm.api import get_styles_dirs
+            from sdpm.reference import list_styles_merged
+            styles_dirs = get_styles_dirs()
             if sub is None:
-                for s in list_styles(styles_dir):
+                for s in list_styles_merged(styles_dirs):
                     print(f"  styles/{s['name']}  {s['description']}")
                 if not args.no_browse:
-                    open_styles_gallery(styles_dir)
+                    open_styles_gallery(styles_dirs)
             else:
                 print("# Copy a style to your project: cp references/examples/styles/{name}.html specs/art-direction.html", file=sys.stderr)
             continue

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -58,14 +58,14 @@ from sdpm.utils.text import normalize_spacing, parse_styled_text  # noqa: F401
 
 def _resolve_template(data, input_path):
     """Resolve template path: presentation.json "template" → templates/ lookup → error."""
-    from sdpm.api import _find_template_in_dirs, _get_templates_dirs
+    from sdpm.api import _find_template_in_dirs, get_templates_dirs
 
     if data.get("template"):
         base_dir = Path(input_path).parent if input_path and input_path != "-" else Path(".")
         template = base_dir / data["template"]
         if template.exists():
             return template, True
-        found = _find_template_in_dirs(data["template"], _get_templates_dirs())
+        found = _find_template_in_dirs(data["template"], get_templates_dirs())
         if found is not None:
             return found, True
 
@@ -189,10 +189,10 @@ def cmd_list_templates(args):
     in addition to the package-bundled ones. User-local templates shadow bundled
     templates with the same stem.
     """
-    from sdpm.api import _get_templates_dirs
+    from sdpm.api import get_templates_dirs
 
     seen: dict[str, Path] = {}
-    for d in _get_templates_dirs():
+    for d in get_templates_dirs():
         if not d.exists():
             continue
         for t in sorted(d.glob("*.pptx")):
@@ -693,9 +693,9 @@ def cmd_analyze_template(args):
 
     template_path = Path(args.input).resolve()
     if not template_path.exists():
-        from sdpm.api import _find_template_in_dirs, _get_templates_dirs
+        from sdpm.api import _find_template_in_dirs, get_templates_dirs
 
-        found = _find_template_in_dirs(args.input, _get_templates_dirs())
+        found = _find_template_in_dirs(args.input, get_templates_dirs())
         if found is not None:
             template_path = found
         else:

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -13,21 +13,18 @@ from pathlib import Path
 from typing import Any
 
 
-def _get_templates_dirs() -> list[Path]:
+def get_templates_dirs() -> list[Path]:
     """Return ordered list of directories to search for bundled/user-local templates.
 
     Search order (first match wins):
-      1. $SDPM_TEMPLATES_DIR — colon-separated list (same semantics as PATH)
-      2. ~/.config/sdpm/templates/ — XDG-style user-local location
+      1. $SDPM_TEMPLATES_DIR — os.pathsep-separated list (same semantics as PATH)
+      2. get_user_config_dir()/templates/ — user-local templates
       3. Package-bundled templates/ directory (skill/templates/)
     """
-    dirs: list[Path] = []
-    env_value = os.environ.get("SDPM_TEMPLATES_DIR")
-    if env_value:
-        dirs.extend(Path(p).expanduser() for p in env_value.split(os.pathsep) if p)
-    dirs.append(Path.home() / ".config" / "sdpm" / "templates")
-    dirs.append(Path(__file__).parent.parent / "templates")
-    return dirs
+    from sdpm.config import _get_resource_dirs
+
+    bundled = Path(__file__).parent.parent / "templates"
+    return _get_resource_dirs("SDPM_TEMPLATES_DIR", "templates", bundled)
 
 
 def _find_template_in_dirs(name: str, templates_dirs: list[Path]) -> Path | None:
@@ -132,7 +129,7 @@ def init(
     if template:
         template_src = Path(template).expanduser()
         if not template_src.exists():
-            found = _find_template_in_dirs(str(template), _get_templates_dirs())
+            found = _find_template_in_dirs(str(template), get_templates_dirs())
             if found is not None:
                 template_src = found
         if template_src.exists():
@@ -185,7 +182,7 @@ def _resolve_config(json_path: str | Path) -> BuildConfig:
         raise FileNotFoundError(f"Slides JSON not found: {json_path}")
 
     data = read_json(input_path)
-    templates_dirs = _get_templates_dirs()
+    templates_dirs = get_templates_dirs()
     warnings: list[str] = []
 
     template_file, custom = _resolve_template(data, str(input_path), templates_dirs)

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -27,6 +27,33 @@ def get_templates_dirs() -> list[Path]:
     return _get_resource_dirs("SDPM_TEMPLATES_DIR", "templates", bundled)
 
 
+def get_styles_dirs() -> list[Path]:
+    """Return ordered list of directories to search for style HTMLs.
+
+    Search order (first match wins):
+      1. $SDPM_STYLES_DIR — os.pathsep-separated list (same semantics as PATH)
+      2. get_user_config_dir()/styles/ — user-local styles
+      3. Package-bundled references/examples/styles/ directory
+    """
+    from sdpm.config import _get_resource_dirs
+    from sdpm.reference import BUNDLED_STYLES_DIR
+
+    return _get_resource_dirs("SDPM_STYLES_DIR", "styles", BUNDLED_STYLES_DIR)
+
+
+def _find_style_in_dirs(name: str, styles_dirs: list[Path]) -> Path | None:
+    """Search for a style HTML by name across the given directories.
+
+    Returns the first existing path, or None if not found.
+    """
+    filename = name if name.endswith(".html") else name + ".html"
+    for d in styles_dirs:
+        candidate = d / filename
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _find_template_in_dirs(name: str, templates_dirs: list[Path]) -> Path | None:
     """Search for a template by name across the given directories.
 

--- a/skill/sdpm/assets/__init__.py
+++ b/skill/sdpm/assets/__init__.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from sdpm.config import ASSETS_DIR, get_extra_sources
+from sdpm.config import ASSETS_DIR, get_extra_sources, get_user_config_dir
 from sdpm.utils.svg import _recolor_svg  # noqa: F401 - re-exported for builder
 _KNOWN_EXTS = (".svg", ".png", ".gif", ".jpg", ".jpeg")
 
@@ -28,23 +28,26 @@ def _strip_ext(name: str) -> str:
     return name
 
 
-def _load_extra_sources() -> list[dict]:
-    """Load extra asset sources from config.
-
-    Returns:
-        List of extra source dicts with 'source', 'manifest', and optional 'files_dir' keys.
-    """
-    return get_extra_sources()
-
-
-_EXTRA_SOURCES: list[dict] = _load_extra_sources()
-
 # Legacy aliases for backward compatibility
 ICON_DIR = ASSETS_DIR
 ICON_LOCAL_DIR = ASSETS_DIR
 
 # Cached merged manifest: list of dicts with "source" injected
 _manifest_cache: Optional[list[dict]] = None
+
+
+def invalidate_manifest_cache() -> None:
+    """Clear cached manifests and config so next access reloads from disk.
+
+    Call when user-local assets or config.json may have changed
+    (e.g., at the start of each MCP tool invocation in long-lived processes).
+    Also clears the config cache since `_load_manifests()` relies on
+    `get_extra_sources()` which reads from the config.
+    """
+    global _manifest_cache
+    _manifest_cache = None
+    from sdpm.config import invalidate_cache as _invalidate_config_cache
+    _invalidate_config_cache()
 
 
 def _check_recolor_protected(cfg, item: dict) -> bool:
@@ -91,7 +94,12 @@ def _load_manifest_file(
 def _load_manifests() -> list[dict]:
     """Load and merge all manifest.json files from all asset sources.
 
-    Scans ASSETS_DIR/{source}/manifest.json and extra_sources from config.json.
+    Load order (earlier entries win on name collision via first-match semantics
+    in `find_asset` / `_find_by_manifest`):
+      1. extra_sources from config.json — explicit user override
+      2. User-local: get_user_config_dir()/assets/*/manifest.json — auto-discovered
+      3. Built-in: ASSETS_DIR/{source}/manifest.json
+      4. Legacy: ASSETS_DIR.parent/icons/manifest.json (auto-detected)
 
     Returns:
         Merged list of asset entries with '_source' and '_dir' fields injected.
@@ -102,13 +110,10 @@ def _load_manifests() -> list[dict]:
 
     all_assets: list[dict] = []
 
-    # Built-in: assets/{source}/manifest.json
-    if ASSETS_DIR.exists():
-        for manifest_path in sorted(ASSETS_DIR.glob("*/manifest.json")):
-            _load_manifest_file(manifest_path, source_override=None, all_assets=all_assets)
-
-    # Extra sources from config.json
-    for entry in _EXTRA_SOURCES:
+    # 1. Extra sources from config.json (explicit override — highest priority).
+    #    Call get_extra_sources() directly so runtime config changes are picked
+    #    up after invalidate_manifest_cache().
+    for entry in get_extra_sources():
         manifest_path = Path(entry["manifest"]).expanduser()
         source_name = entry.get("source")
         files_dir = Path(entry["files_dir"]).expanduser() if "files_dir" in entry else None
@@ -117,7 +122,18 @@ def _load_manifests() -> list[dict]:
             files_dir=files_dir, recolor_protected=entry.get("recolorProtected"),
         )
 
-    # Auto-detect legacy icons/ directory (sibling of assets/)
+    # 2. User-local: get_user_config_dir()/assets/{source}/manifest.json (auto-discovered)
+    user_assets = get_user_config_dir() / "assets"
+    if user_assets.exists():
+        for manifest_path in sorted(user_assets.glob("*/manifest.json")):
+            _load_manifest_file(manifest_path, source_override=None, all_assets=all_assets)
+
+    # 3. Built-in: assets/{source}/manifest.json
+    if ASSETS_DIR.exists():
+        for manifest_path in sorted(ASSETS_DIR.glob("*/manifest.json")):
+            _load_manifest_file(manifest_path, source_override=None, all_assets=all_assets)
+
+    # 4. Auto-detect legacy icons/ directory (sibling of assets/)
     legacy_icons = ASSETS_DIR.parent / "icons"
     legacy_manifest = legacy_icons / "manifest.json"
     if legacy_manifest.exists():
@@ -281,6 +297,12 @@ def _find_in_all_sources(name: str) -> Path:
     First checks manifests (supports subdirectory paths in 'file' field),
     then falls back to direct file search in source directories.
 
+    Fallback search order mirrors `_load_manifests()`:
+      1. extra_sources (explicit override)
+      2. User-local assets under get_user_config_dir()/assets/
+      3. Built-in ASSETS_DIR
+      4. Legacy icons/
+
     Args:
         name: File name without extension.
 
@@ -299,16 +321,11 @@ def _find_in_all_sources(name: str) -> Path:
             if path.exists():
                 return path
 
-    # Fallback: direct file search
+    # Fallback: direct file search in the same priority order as _load_manifests()
     search_dirs: list[Path] = []
 
-    if ASSETS_DIR.exists():
-        for source_dir in sorted(ASSETS_DIR.iterdir()):
-            if source_dir.is_dir():
-                search_dirs.append(source_dir)
-
-    # Extra sources from config.json
-    for entry in _EXTRA_SOURCES:
+    # 1. extra_sources
+    for entry in get_extra_sources():
         if "files_dir" in entry:
             d = Path(entry["files_dir"]).expanduser()
         else:
@@ -316,7 +333,20 @@ def _find_in_all_sources(name: str) -> Path:
         if d.exists():
             search_dirs.append(d)
 
-    # Legacy icons/ directory
+    # 2. User-local assets
+    user_assets = get_user_config_dir() / "assets"
+    if user_assets.exists():
+        for source_dir in sorted(user_assets.iterdir()):
+            if source_dir.is_dir():
+                search_dirs.append(source_dir)
+
+    # 3. Built-in
+    if ASSETS_DIR.exists():
+        for source_dir in sorted(ASSETS_DIR.iterdir()):
+            if source_dir.is_dir():
+                search_dirs.append(source_dir)
+
+    # 4. Legacy icons/ directory
     legacy_icons = ASSETS_DIR.parent / "icons"
     if legacy_icons.exists() and legacy_icons not in search_dirs:
         search_dirs.append(legacy_icons)
@@ -361,7 +391,7 @@ def list_sources() -> list[dict]:
             source = data.get("source", manifest_path.parent.name)
             if "description" in data:
                 descriptions[source] = data["description"]
-    for entry in _EXTRA_SOURCES:
+    for entry in get_extra_sources():
         manifest_path = Path(entry["manifest"]).expanduser()
         if manifest_path.exists():
             with open(manifest_path) as f:

--- a/skill/sdpm/assets/__init__.py
+++ b/skill/sdpm/assets/__init__.py
@@ -383,9 +383,21 @@ def list_sources() -> list[dict]:
     for item in manifests:
         src = item.get("_source", "unknown")
         counts[src] = counts.get(src, 0) + 1
-    # Load descriptions from manifest files
+    # Load descriptions from manifest files.
+    # Order matches _load_manifests(): built-in as base, then user-local and
+    # extra_sources override (so user-visible description reflects the source
+    # that actually wins on name collision).
     if ASSETS_DIR.exists():
         for manifest_path in sorted(ASSETS_DIR.glob("*/manifest.json")):
+            with open(manifest_path) as f:
+                data = json.load(f)
+            source = data.get("source", manifest_path.parent.name)
+            if "description" in data:
+                descriptions[source] = data["description"]
+    # User-local: get_user_config_dir()/assets/*/manifest.json
+    user_assets = get_user_config_dir() / "assets"
+    if user_assets.exists():
+        for manifest_path in sorted(user_assets.glob("*/manifest.json")):
             with open(manifest_path) as f:
                 data = json.load(f)
             source = data.get("source", manifest_path.parent.name)

--- a/skill/sdpm/config.py
+++ b/skill/sdpm/config.py
@@ -1,9 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Centralized config loader for skill/assets/config.json."""
+"""Centralized config loader and user-local directory resolution for sdpm."""
 
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -17,17 +19,80 @@ _DEFAULTS = {
 _cache: Optional[dict] = None
 
 
+def get_user_config_dir() -> Path:
+    """Return platform-appropriate user config directory for sdpm.
+
+    - Windows: %APPDATA%/sdpm (default: ~/AppData/Roaming/sdpm)
+    - macOS/Linux: $XDG_CONFIG_HOME/sdpm (default: ~/.config/sdpm)
+
+    This function always reads the current environment (no caching) so that
+    tests can override via monkeypatch.setenv.
+    """
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming"))
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    return base / "sdpm"
+
+
+def _get_resource_dirs(env_var: Optional[str], subdir: str, bundled: Path) -> list[Path]:
+    """Return ordered list of directories for a resource type.
+
+    Search order (first match wins):
+      1. $env_var — os.pathsep-separated list (same semantics as PATH)
+         On Windows ';', on Unix ':'
+      2. get_user_config_dir()/{subdir}/
+      3. bundled (package-shipped directory)
+
+    Common pattern shared by templates and styles. Assets use a 4-layer
+    structure (extra_sources → user-local → built-in → legacy) and do not
+    use this helper.
+
+    Args:
+        env_var: Environment variable name to check for override paths.
+                 Pass None to skip environment variable lookup.
+        subdir: Subdirectory name under get_user_config_dir() (e.g. "templates").
+        bundled: Package-shipped fallback directory.
+
+    Returns:
+        Ordered list of directories to search.
+    """
+    dirs: list[Path] = []
+    if env_var:
+        val = os.environ.get(env_var)
+        if val:
+            dirs.extend(Path(p).expanduser() for p in val.split(os.pathsep) if p)
+    dirs.append(get_user_config_dir() / subdir)
+    dirs.append(bundled)
+    return dirs
+
+
+def invalidate_cache() -> None:
+    """Clear config cache so next get_config() reloads from disk.
+
+    Call when user may have edited ~/.config/sdpm/config.json at runtime
+    (e.g., MCP Local tool invocations where the process is long-lived).
+    """
+    global _cache
+    _cache = None
+
+
 def get_config() -> dict:
-    """Load and cache config. Returns defaults for missing file/keys."""
+    """Load and cache config. Returns defaults merged with user-local overrides.
+
+    Merge strategy: _DEFAULTS <- get_user_config_dir()/config.json (key-wise).
+    Package-internal config.json is NOT read (it was never shipped and
+    would be lost on pip upgrade).
+    """
     global _cache
     if _cache is not None:
         return _cache
-    config_path = ASSETS_DIR / "config.json"
-    data = {}
-    if config_path.exists():
-        with open(config_path) as f:
-            data = json.load(f)
-    _cache = {**_DEFAULTS, **data}
+    merged = dict(_DEFAULTS)
+    user_path = get_user_config_dir() / "config.json"
+    if user_path.exists():
+        with open(user_path) as f:
+            merged.update(json.load(f))
+    _cache = merged
     return _cache
 
 

--- a/skill/sdpm/diff/__init__.py
+++ b/skill/sdpm/diff/__init__.py
@@ -164,14 +164,14 @@ def load_slides_json_or_pptx(path):
     if is_source:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_pptx = Path(tmpdir) / "tmp.pptx"
-            from sdpm.api import _find_template_in_dirs, _get_templates_dirs
+            from sdpm.api import _find_template_in_dirs, get_templates_dirs
             from sdpm.builder import PPTXBuilder, resolve_override
             tpl_name = data.get("template")
             if not tpl_name:
                 raise ValueError("No \"template\" specified in JSON. Cannot build for diff.")
             template = Path(path).parent / tpl_name
             if not template.exists():
-                named = _find_template_in_dirs(tpl_name, _get_templates_dirs())
+                named = _find_template_in_dirs(tpl_name, get_templates_dirs())
                 if named is not None:
                     template = named
                 else:

--- a/skill/sdpm/reference/__init__.py
+++ b/skill/sdpm/reference/__init__.py
@@ -10,6 +10,9 @@ from pathlib import Path
 
 from sdpm.reference.providers import FileProvider, ReferenceProvider  # noqa: F401
 
+# Package-bundled styles directory (for user-local style search fallback).
+BUNDLED_STYLES_DIR = Path(__file__).resolve().parent.parent.parent / "references" / "examples" / "styles"
+
 
 def _get_description(path: Path) -> str:
     """Extract description from first non-empty line of md or pptx speaker notes."""
@@ -59,26 +62,34 @@ def _get_description(path: Path) -> str:
     return ""
 
 
-def generate_styles_index(styles_dir: Path) -> Path:
+def generate_styles_index(styles_dirs: list[Path]) -> Path:
     """Generate an index HTML with sidebar + iframe preview for style HTMLs.
+
+    Scans multiple directories; user-local styles shadow bundled ones
+    (same stem → first match wins).
 
     Returns the path to the generated index file.
     """
     import html as html_mod
     import tempfile
 
+    seen: set[str] = set()
     styles = []
-    for f in sorted(styles_dir.iterdir()):
-        if f.suffix == '.html' and not f.name.startswith('.'):
-            desc = _get_description(f)
-            # Split "name — description" from title
-            name = f.stem
-            subtitle = ""
-            if " — " in desc:
-                _, subtitle = desc.split(" — ", 1)
-            elif desc:
-                subtitle = desc
-            styles.append((name, subtitle, f.resolve()))
+    for styles_dir in styles_dirs:
+        if not styles_dir.exists():
+            continue
+        for f in sorted(styles_dir.iterdir()):
+            if f.suffix == '.html' and not f.name.startswith('.') and f.stem not in seen:
+                seen.add(f.stem)
+                desc = _get_description(f)
+                # Split "name — description" from title
+                name = f.stem
+                subtitle = ""
+                if " — " in desc:
+                    _, subtitle = desc.split(" — ", 1)
+                elif desc:
+                    subtitle = desc
+                styles.append((name, subtitle, f.resolve()))
 
     if not styles:
         return Path()
@@ -260,11 +271,11 @@ def get_pptx_notes(pptx_path, pages=None):
 # ---------------------------------------------------------------------------
 
 
-def open_styles_gallery(styles_dir: Path) -> Path | None:
+def open_styles_gallery(styles_dirs: list[Path]) -> Path | None:
     """Generate styles gallery HTML and open in browser. Returns index path or None."""
     import webbrowser
 
-    index_path = generate_styles_index(styles_dir)
+    index_path = generate_styles_index(styles_dirs)
     if index_path and index_path.exists():
         webbrowser.open(index_path.as_uri())
         return index_path
@@ -366,3 +377,20 @@ def list_styles(styles_dir: Path) -> list[dict[str, str]]:
         desc = _get_description(f)
         styles.append({"name": f.stem, "description": desc})
     return styles
+
+
+def list_styles_merged(styles_dirs: list[Path]) -> list[dict[str, str]]:
+    """List styles from multiple directories, user-local first (shadows bundled).
+
+    For each style name (file stem), only the first occurrence across the
+    given directories is kept. Typically callers pass the result of
+    ``api.get_styles_dirs()`` which orders env-overrides → user-local → bundled.
+    """
+    seen: set[str] = set()
+    result: list[dict[str, str]] = []
+    for styles_dir in styles_dirs:
+        for item in list_styles(styles_dir):
+            if item["name"] not in seen:
+                seen.add(item["name"])
+                result.append(item)
+    return result

--- a/tests/test_styles_resolution.py
+++ b/tests/test_styles_resolution.py
@@ -1,0 +1,151 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for style directory resolution and merged listing."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from sdpm.api import _find_style_in_dirs, get_styles_dirs
+from sdpm.reference import BUNDLED_STYLES_DIR, list_styles, list_styles_merged
+
+
+@pytest.fixture
+def temp_styles_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "styles"
+    d.mkdir()
+    (d / "elegant-dark.html").write_text("<html><head><title>Elegant Dark — dark theme</title></head></html>")
+    (d / "custom-brand.html").write_text("<html><head><title>Custom Brand — my company</title></head></html>")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# get_styles_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_styles_dir_includes_bundled() -> None:
+    dirs = get_styles_dirs()
+    assert BUNDLED_STYLES_DIR in dirs
+
+
+def test_styles_dir_respects_env(
+    monkeypatch: pytest.MonkeyPatch, temp_styles_dir: Path
+) -> None:
+    monkeypatch.setenv("SDPM_STYLES_DIR", str(temp_styles_dir))
+    dirs = get_styles_dirs()
+    assert dirs[0] == temp_styles_dir
+
+
+def test_styles_dir_includes_user_local(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User-local styles dir appears between env override and bundled."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    monkeypatch.delenv("SDPM_STYLES_DIR", raising=False)
+    dirs = get_styles_dirs()
+    assert dirs[0] == tmp_path / "sdpm" / "styles"
+    assert dirs[-1] == BUNDLED_STYLES_DIR
+
+
+def test_styles_dir_supports_multiple_env_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    d1 = tmp_path / "a"
+    d2 = tmp_path / "b"
+    d1.mkdir()
+    d2.mkdir()
+    monkeypatch.setenv("SDPM_STYLES_DIR", f"{d1}{os.pathsep}{d2}")
+    dirs = get_styles_dirs()
+    assert dirs[0] == d1
+    assert dirs[1] == d2
+
+
+# ---------------------------------------------------------------------------
+# _find_style_in_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_find_style_accepts_name_with_or_without_extension(temp_styles_dir: Path) -> None:
+    assert _find_style_in_dirs("elegant-dark", [temp_styles_dir]) == temp_styles_dir / "elegant-dark.html"
+    assert _find_style_in_dirs("elegant-dark.html", [temp_styles_dir]) == temp_styles_dir / "elegant-dark.html"
+
+
+def test_find_style_first_match_wins(tmp_path: Path) -> None:
+    d1 = tmp_path / "a"
+    d2 = tmp_path / "b"
+    d1.mkdir()
+    d2.mkdir()
+    (d1 / "shared.html").write_text("d1")
+    (d2 / "shared.html").write_text("d2")
+    found = _find_style_in_dirs("shared", [d1, d2])
+    assert found == d1 / "shared.html"
+
+
+def test_find_style_returns_none_when_missing(tmp_path: Path) -> None:
+    assert _find_style_in_dirs("missing", [tmp_path]) is None
+
+
+# ---------------------------------------------------------------------------
+# list_styles_merged
+# ---------------------------------------------------------------------------
+
+
+def test_list_styles_merged_combines_dirs(tmp_path: Path) -> None:
+    user = tmp_path / "user"
+    user.mkdir()
+    (user / "custom.html").write_text("<html><title>Custom</title></html>")
+
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "elegant.html").write_text("<html><title>Elegant</title></html>")
+
+    result = list_styles_merged([user, bundled])
+    names = [s["name"] for s in result]
+    assert "custom" in names
+    assert "elegant" in names
+
+
+def test_list_styles_merged_user_shadows_bundled(tmp_path: Path) -> None:
+    """When a style name exists in multiple dirs, the first dir wins."""
+    user = tmp_path / "user"
+    user.mkdir()
+    (user / "elegant.html").write_text("<html><title>User Override</title></html>")
+
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    (bundled / "elegant.html").write_text("<html><title>Bundled Version</title></html>")
+
+    result = list_styles_merged([user, bundled])
+    elegant_entries = [s for s in result if s["name"] == "elegant"]
+    assert len(elegant_entries) == 1
+    assert "User Override" in elegant_entries[0]["description"]
+
+
+def test_list_styles_merged_skips_missing_dirs(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"  # does not exist
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    (existing / "foo.html").write_text("<html><title>Foo</title></html>")
+
+    result = list_styles_merged([missing, existing])
+    assert len(result) == 1
+    assert result[0]["name"] == "foo"
+
+
+def test_list_styles_merged_empty_returns_empty(tmp_path: Path) -> None:
+    assert list_styles_merged([tmp_path / "a", tmp_path / "b"]) == []
+
+
+# ---------------------------------------------------------------------------
+# list_styles (single directory, backward compatible)
+# ---------------------------------------------------------------------------
+
+
+def test_list_styles_single_dir_still_works(temp_styles_dir: Path) -> None:
+    result = list_styles(temp_styles_dir)
+    names = [s["name"] for s in result]
+    assert "elegant-dark" in names
+    assert "custom-brand" in names

--- a/tests/test_templates_resolution.py
+++ b/tests/test_templates_resolution.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from sdpm.api import _find_template_in_dirs, _get_templates_dirs, _resolve_template
+from sdpm.api import _find_template_in_dirs, _resolve_template, get_templates_dirs
 
 
 @pytest.fixture
@@ -19,14 +19,14 @@ def temp_template_dir(tmp_path: Path) -> Path:
 
 
 def test_templates_dir_includes_bundled() -> None:
-    dirs = _get_templates_dirs()
+    dirs = get_templates_dirs()
     bundled = Path(__file__).resolve().parent.parent / "skill" / "templates"
     assert bundled in dirs
 
 
 def test_templates_dir_respects_env(monkeypatch: pytest.MonkeyPatch, temp_template_dir: Path) -> None:
     monkeypatch.setenv("SDPM_TEMPLATES_DIR", str(temp_template_dir))
-    dirs = _get_templates_dirs()
+    dirs = get_templates_dirs()
     assert dirs[0] == temp_template_dir
 
 
@@ -38,7 +38,7 @@ def test_templates_dir_supports_multiple_env_paths(
     d1.mkdir()
     d2.mkdir()
     monkeypatch.setenv("SDPM_TEMPLATES_DIR", f"{d1}{os.pathsep}{d2}")
-    dirs = _get_templates_dirs()
+    dirs = get_templates_dirs()
     assert dirs[0] == d1
     assert dirs[1] == d2
 

--- a/tests/test_user_config_dir.py
+++ b/tests/test_user_config_dir.py
@@ -1,0 +1,149 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for user config directory resolution and resource dir helper."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from sdpm.config import (
+    _get_resource_dirs,
+    get_user_config_dir,
+    invalidate_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_user_config_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-only test")
+def test_user_config_dir_respects_xdg_config_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert get_user_config_dir() == tmp_path / "sdpm"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-only test")
+def test_user_config_dir_defaults_to_home_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert get_user_config_dir() == Path.home() / ".config" / "sdpm"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+def test_user_config_dir_respects_appdata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    assert get_user_config_dir() == tmp_path / "sdpm"
+
+
+def test_user_config_dir_is_not_cached(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """get_user_config_dir should read env on each call (needed for tests)."""
+    if sys.platform == "win32":
+        env_var = "APPDATA"
+    else:
+        env_var = "XDG_CONFIG_HOME"
+    monkeypatch.setenv(env_var, str(tmp_path / "a"))
+    first = get_user_config_dir()
+    monkeypatch.setenv(env_var, str(tmp_path / "b"))
+    second = get_user_config_dir()
+    assert first != second
+
+
+# ---------------------------------------------------------------------------
+# _get_resource_dirs
+# ---------------------------------------------------------------------------
+
+
+def test_resource_dirs_order_no_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Order: user-local → bundled when no env var set."""
+    monkeypatch.delenv("SDPM_TEST_DIR", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    bundled = tmp_path / "bundled"
+    dirs = _get_resource_dirs("SDPM_TEST_DIR", "widgets", bundled)
+    assert dirs == [tmp_path / "sdpm" / "widgets", bundled]
+
+
+def test_resource_dirs_env_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Env var paths come first."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    override = tmp_path / "override"
+    bundled = tmp_path / "bundled"
+    monkeypatch.setenv("SDPM_TEST_DIR", str(override))
+    dirs = _get_resource_dirs("SDPM_TEST_DIR", "widgets", bundled)
+    assert dirs[0] == override
+    assert dirs[-1] == bundled
+
+
+def test_resource_dirs_multiple_env_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    d1 = tmp_path / "a"
+    d2 = tmp_path / "b"
+    bundled = tmp_path / "bundled"
+    monkeypatch.setenv("SDPM_TEST_DIR", f"{d1}{os.pathsep}{d2}")
+    dirs = _get_resource_dirs("SDPM_TEST_DIR", "widgets", bundled)
+    assert dirs[0] == d1
+    assert dirs[1] == d2
+    assert dirs[-1] == bundled
+
+
+def test_resource_dirs_none_env_var_skips_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Passing env_var=None disables env lookup."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    bundled = tmp_path / "bundled"
+    dirs = _get_resource_dirs(None, "widgets", bundled)
+    assert dirs == [tmp_path / "sdpm" / "widgets", bundled]
+
+
+# ---------------------------------------------------------------------------
+# invalidate_cache
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_cache_clears_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import json
+
+    from sdpm.config import get_config
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    invalidate_cache()
+    # First read: no config file exists, get_config returns defaults
+    cfg1 = get_config()
+    assert cfg1["output_dir"] == "~/Documents/SDPM-Presentations"
+
+    # Create user config
+    user_dir = get_user_config_dir()
+    user_dir.mkdir(parents=True, exist_ok=True)
+    (user_dir / "config.json").write_text(json.dumps({"output_dir": "/custom/path"}))
+
+    # Without invalidate, stale cache is returned
+    cfg_stale = get_config()
+    assert cfg_stale["output_dir"] == "~/Documents/SDPM-Presentations"
+
+    # After invalidate, new config is read
+    invalidate_cache()
+    cfg2 = get_config()
+    assert cfg2["output_dir"] == "/custom/path"
+
+    # Cleanup
+    invalidate_cache()

--- a/tests/test_user_local_assets.py
+++ b/tests/test_user_local_assets.py
@@ -200,6 +200,32 @@ def test_user_local_coexists_with_builtin(
 # ---------------------------------------------------------------------------
 
 
+def test_list_sources_includes_user_local_description(
+    isolated_user_config: Path,
+) -> None:
+    """list_sources picks up description from user-local manifest (bug fix)."""
+    from sdpm.assets import invalidate_manifest_cache, list_sources
+
+    source_dir = isolated_user_config / "assets" / "my-team"
+    _write_manifest(
+        source_dir,
+        "my-team",
+        [{"name": "A", "file": "a.svg", "category": "c", "type": "service"}],
+    )
+    # Add description at manifest-level (not per-icon)
+    import json as _json
+    manifest_path = source_dir / "manifest.json"
+    data = _json.loads(manifest_path.read_text())
+    data["description"] = "My team's custom icons"
+    manifest_path.write_text(_json.dumps(data))
+
+    invalidate_manifest_cache()
+    sources = list_sources()
+    my_team = next((s for s in sources if s["source"] == "my-team"), None)
+    assert my_team is not None
+    assert my_team["description"] == "My team's custom icons"
+
+
 def test_list_sources_includes_extra_source(
     isolated_user_config: Path, tmp_path: Path
 ) -> None:

--- a/tests/test_user_local_assets.py
+++ b/tests/test_user_local_assets.py
@@ -1,0 +1,229 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for user-local asset auto-discovery and cache invalidation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _write_manifest(dir_path: Path, source: str, icons: list[dict]) -> None:
+    """Helper: write a minimal manifest.json for a source directory."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    manifest = {"source": source, "icons": icons}
+    (dir_path / "manifest.json").write_text(json.dumps(manifest))
+
+
+@pytest.fixture
+def isolated_user_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point user-config dir to a tmp location and return the sdpm root."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    # Invalidate caches so this test sees the overridden env
+    from sdpm.assets import invalidate_manifest_cache
+    invalidate_manifest_cache()
+    yield tmp_path / "sdpm"
+    # Cleanup: invalidate again so subsequent tests start clean
+    invalidate_manifest_cache()
+
+
+# ---------------------------------------------------------------------------
+# User-local asset auto-discovery
+# ---------------------------------------------------------------------------
+
+
+def test_user_local_asset_is_discovered(
+    isolated_user_config: Path, tmp_path: Path
+) -> None:
+    """Manifest under ~/.config/sdpm/assets/{source}/ is auto-discovered."""
+    from sdpm.assets import _load_manifests
+
+    source_dir = isolated_user_config / "assets" / "my-company"
+    _write_manifest(
+        source_dir,
+        "my-company",
+        [{"name": "Logo", "file": "logo.svg", "category": "brand", "type": "service"}],
+    )
+
+    manifests = _load_manifests()
+    names = [m["_source"] for m in manifests]
+    assert "my-company" in names
+
+
+def test_user_local_asset_file_is_resolved(
+    isolated_user_config: Path,
+) -> None:
+    """Resolve an asset file from user-local source via assets:source/name."""
+    from sdpm.assets import resolve_asset_path
+
+    source_dir = isolated_user_config / "assets" / "my-company"
+    _write_manifest(
+        source_dir,
+        "my-company",
+        [{"name": "Logo", "file": "logo.svg", "category": "brand", "type": "service"}],
+    )
+    (source_dir / "logo.svg").write_text("<svg/>")
+
+    resolved = resolve_asset_path("assets:my-company/logo")
+    assert resolved == source_dir / "logo.svg"
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_manifest_cache_picks_up_new_source(
+    isolated_user_config: Path,
+) -> None:
+    """A newly added user-local source is visible after invalidate."""
+    from sdpm.assets import _load_manifests, invalidate_manifest_cache
+
+    # Initial load: no user-local sources
+    before = _load_manifests()
+    initial_sources = {m["_source"] for m in before}
+    assert "added-later" not in initial_sources
+
+    # Add a new source
+    source_dir = isolated_user_config / "assets" / "added-later"
+    _write_manifest(
+        source_dir,
+        "added-later",
+        [{"name": "Foo", "file": "foo.svg", "category": "c", "type": "service"}],
+    )
+
+    # Without invalidate, cache is stale
+    stale = _load_manifests()
+    assert {m["_source"] for m in stale} == initial_sources
+
+    # After invalidate, new source appears
+    invalidate_manifest_cache()
+    fresh = _load_manifests()
+    assert "added-later" in {m["_source"] for m in fresh}
+
+
+def test_invalidate_also_clears_config_cache(
+    isolated_user_config: Path,
+) -> None:
+    """invalidate_manifest_cache also clears the config cache."""
+    from sdpm.assets import invalidate_manifest_cache
+    from sdpm.config import get_config, get_user_config_dir
+
+    # Prime cache with defaults
+    invalidate_manifest_cache()
+    cfg1 = get_config()
+    assert cfg1["output_dir"] == "~/Documents/SDPM-Presentations"
+
+    # Write user config
+    user_dir = get_user_config_dir()
+    user_dir.mkdir(parents=True, exist_ok=True)
+    (user_dir / "config.json").write_text(json.dumps({"output_dir": "/new/path"}))
+
+    # After invalidate, config is re-read
+    invalidate_manifest_cache()
+    cfg2 = get_config()
+    assert cfg2["output_dir"] == "/new/path"
+
+
+# ---------------------------------------------------------------------------
+# Priority order: extra_sources > user-local > built-in
+# ---------------------------------------------------------------------------
+
+
+def test_extra_sources_shadow_user_local_same_name(
+    isolated_user_config: Path, tmp_path: Path
+) -> None:
+    """When an extra_source and user-local source define the same asset name,
+    extra_sources wins (it appears first in the manifest list)."""
+    from sdpm.assets import _load_manifests, invalidate_manifest_cache
+
+    # User-local source
+    user_source = isolated_user_config / "assets" / "shared"
+    _write_manifest(
+        user_source,
+        "shared",
+        [{"name": "X", "file": "x.svg", "category": "c", "type": "service"}],
+    )
+    (user_source / "x.svg").write_text("user-local")
+
+    # Extra source via config.json
+    extra_source = tmp_path / "extra" / "shared"
+    extra_source.mkdir(parents=True)
+    (extra_source / "manifest.json").write_text(json.dumps({
+        "source": "shared",
+        "icons": [{"name": "X", "file": "x.svg", "category": "c", "type": "service"}],
+    }))
+    (extra_source / "x.svg").write_text("extra")
+
+    (isolated_user_config).mkdir(parents=True, exist_ok=True)
+    (isolated_user_config / "config.json").write_text(json.dumps({
+        "extra_sources": [{
+            "manifest": str(extra_source / "manifest.json"),
+        }],
+    }))
+
+    invalidate_manifest_cache()
+    manifests = _load_manifests()
+    # Find first manifest with source=shared; it should be the extra_source entry
+    shared_entries = [m for m in manifests if m["_source"] == "shared"]
+    assert len(shared_entries) >= 1
+    # The extra_source entry should appear FIRST (earlier in the list)
+    assert shared_entries[0]["_dir"] == extra_source
+
+
+def test_user_local_coexists_with_builtin(
+    isolated_user_config: Path,
+) -> None:
+    """User-local and built-in sources both appear in the merged manifest."""
+    from sdpm.assets import _load_manifests
+
+    # User-local source
+    source_dir = isolated_user_config / "assets" / "my-company"
+    _write_manifest(
+        source_dir,
+        "my-company",
+        [{"name": "Logo", "file": "logo.svg", "category": "brand", "type": "service"}],
+    )
+
+    manifests = _load_manifests()
+    sources = {m["_source"] for m in manifests}
+    # my-company from user-local should be present
+    assert "my-company" in sources
+    # aws (built-in) should still be present if assets are installed
+    # (skip this assertion if assets not installed in test env)
+
+
+# ---------------------------------------------------------------------------
+# list_sources uses get_extra_sources() now
+# ---------------------------------------------------------------------------
+
+
+def test_list_sources_includes_extra_source(
+    isolated_user_config: Path, tmp_path: Path
+) -> None:
+    """list_sources picks up extra_sources via get_extra_sources (not _EXTRA_SOURCES)."""
+    from sdpm.assets import invalidate_manifest_cache, list_sources
+
+    extra_source = tmp_path / "extra" / "my-extra"
+    extra_source.mkdir(parents=True)
+    (extra_source / "manifest.json").write_text(json.dumps({
+        "source": "my-extra",
+        "description": "Extra source via config",
+        "icons": [{"name": "A", "file": "a.svg", "category": "c", "type": "service"}],
+    }))
+
+    (isolated_user_config).mkdir(parents=True, exist_ok=True)
+    (isolated_user_config / "config.json").write_text(json.dumps({
+        "extra_sources": [{
+            "manifest": str(extra_source / "manifest.json"),
+        }],
+    }))
+
+    invalidate_manifest_cache()
+    sources = list_sources()
+    names = [s["source"] for s in sources]
+    assert "my-extra" in names
+    my_extra = next(s for s in sources if s["source"] == "my-extra")
+    assert my_extra["description"] == "Extra source via config"


### PR DESCRIPTION
## Summary

Extend the user-local directory pattern introduced by #96 (templates) to cover
**styles**, **assets**, and **config.json**, and unify the base-directory
resolution across platforms.

Users can now place custom styles, icons, and settings outside the package so
they survive `pip install --upgrade` and repository re-clones.


<user-config>/sdpm/
├── templates/          # .pptx (from #96, base dir now cross-platform)
├── styles/             # .html (NEW)
├── assets/             # custom icon sources, auto-discovered (NEW)
│   └── my-company/
│       ├── manifest.json
│       └── logo.svg
└── config.json         # output_dir, extra_sources, … (NEW path)

Platform-aware base directory:

| Platform | Path |
|----------|------|
| macOS / Linux | `$XDG_CONFIG_HOME/sdpm/` (default `~/.config/sdpm/`) |
| Windows | `%APPDATA%/sdpm/` |

## Changes

### Foundation (`sdpm.config`)
- Add `get_user_config_dir()` — cross-platform user config base
- Add `_get_resource_dirs(env_var, subdir, bundled)` — shared helper for the
  "env → user-local → bundled" pattern (DRY between templates and styles)
- Add `invalidate_cache()` public function so long-lived processes can pick
  up runtime config.json edits
- `get_config()` drops the package-internal `skill/assets/config.json` read
  (it was never shipped) and merges `_DEFAULTS` with user-local only

### Templates
- Rename `_get_templates_dirs()` → `get_templates_dirs()` for consistency
  with the new `get_styles_dirs()` (mechanical rename across 5 files)
- Base directory now resolves via `get_user_config_dir()` instead of
  hardcoded `~/.config/sdpm/templates`

### Styles
- Add `get_styles_dirs()`, `_find_style_in_dirs()`, `BUNDLED_STYLES_DIR`
- Add `list_styles_merged(styles_dirs)` — merges multiple dirs with
  user-local shadowing bundled
- `generate_styles_index()` / `open_styles_gallery()` take
  `styles_dirs: list[Path]` so the gallery shows user-local styles
- Update MCP Local `list_styles` tool and CLI `examples styles` to use the
  new multi-directory APIs
- `create-style` workflow writes to `~/.config/sdpm/styles/{name}.html`

### Assets
- Auto-discover `~/.config/sdpm/assets/{source}/manifest.json`
- Remove module-level `_EXTRA_SOURCES` (was stale after
  `invalidate_manifest_cache`); `_load_manifests()` now calls
  `get_extra_sources()` directly each rebuild
- Reorder priority: `extra_sources` → user-local → built-in → legacy
  (earlier wins on name collision). Mirrors in `_find_in_all_sources()` fallback
- Add `invalidate_manifest_cache()` — clears both manifest and config caches
- MCP Local `generate_pptx` / `search_assets` / `list_asset_sources` call
  `invalidate_manifest_cache()` at entry so runtime edits are picked up

### Docs
- `docs/en/custom-template.md` & `docs/ja/custom-template.md` renamed to
  "Custom Templates, Styles, and Assets" with new sections for user-local
  directory layout, styles, asset options (drop-in vs explicit), priority
  order, and user config schema

## Breaking Changes

**Asset priority reorder**: previously `built-in → extra_sources`; now
`extra_sources → built-in`. If a user registered a built-in icon name in
`extra_sources`, their override now wins (previously built-in silently won).
This is the intended behavior — impact assessed as **none** since this is
exactly what same-name registration is meant to do.

**Windows config path**: templates base changed from `~/.config/sdpm/` to
`%APPDATA%/sdpm/`. Since #96 landed just one day before this change, no
Windows users are realistically affected.

## Testing

- 122 passed, 1 skipped (Windows-only test)
- New test files:
  - `tests/test_user_config_dir.py` (9 tests) — XDG/APPDATA, non-caching
    behavior, resource-dir ordering, cache invalidation
  - `tests/test_styles_resolution.py` (12 tests) — dir resolution,
    first-match wins, merged listing with user-local shadowing
  - `tests/test_user_local_assets.py` (8 tests) — auto-discovery, cache
    invalidation (manifests + config), priority ordering, `list_sources`
    description pickup

### End-to-end verification

Ran through with real files in `~/.config/sdpm/`:
- User-local style shows up in `list_styles` and shadows same-name bundled
- `$SDPM_STYLES_DIR` env override works
- User-local icon source auto-discovered (`list_sources`, `resolve_asset_path`,
  `search_assets`)
- Generated PPTX contains images resolved from all three sources (user-local,
  extra_sources, bundled)
- `invalidate_manifest_cache()` picks up new sources and config.json changes
  added after process start (MCP Local long-lived behavior)

Caught one bug during verification (fixed in final commit): `list_sources`
was not reading descriptions from user-local manifests.

## Self-review notes

- `_EXTRA_SOURCES` and `_load_extra_sources()` removed from `sdpm.assets`.
  Verified no internal callers remain. Private-name (`_` prefix) external
  callers would break but are not expected.
- Existing `list_styles(styles_dir: Path)` kept as a single-dir helper used
  internally by `list_styles_merged`.
- `mcp-server/server.py` (Layer 3) was not touched — it has an independent
  `reference.list_styles(storage=...)` implementation, by design.
- Windows base-directory change (`~/.config/sdpm` → `%APPDATA%/sdpm`) is
  technically a breaking change for user-local templates added in #96, but
  that PR landed the day before this one, so realistic impact is zero.

## Related

- #96 feat(templates): support user-local template directories
- #98 fix(templates): use shared template dirs in MCP Local list_templates