### PR TITLE
feat: per-user model switching via Settings Sheet

### DIFF
--- a/agent/basic_agent.py
+++ b/agent/basic_agent.py
@@ -35,6 +35,29 @@ logger = logging.getLogger("sdpm.agent")
 
 app = BedrockAgentCoreApp()
 
+_ALLOWED_MODEL_IDS: set[str] = set(json.loads(os.environ.get("ALLOWED_MODEL_IDS", "[]")))
+_DEFAULT_MODEL_ID: str = os.environ.get("MODEL_ID", "global.anthropic.claude-sonnet-4-6")
+
+
+def _resolve_model_id(requested: str | None) -> str:
+    """Resolve the effective Bedrock model ID for this invocation.
+
+    Resolution order:
+        1. If the allowed list is empty (feature not enabled),
+           ignore requested and return the default.
+        2. If requested is in the allowed list, use it.
+        3. Otherwise, use the default (log warning if requested was present but stale).
+    """
+    if not _ALLOWED_MODEL_IDS:
+        if requested:
+            logger.warning("modelId %r received but allowed list is empty; feature not enabled", requested)
+        return _DEFAULT_MODEL_ID
+    if requested and requested in _ALLOWED_MODEL_IDS:
+        return requested
+    if requested:
+        logger.warning("Requested modelId %r not in allowed list; falling back to default", requested)
+    return _DEFAULT_MODEL_ID
+
 
 # ---------------------------------------------------------------------------
 # MCP Servers
@@ -211,7 +234,7 @@ def _collect_mcp_instructions(mcp_servers: list[MCPClient]) -> str:
     return "\n\n".join(sections)
 
 
-def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, list[dict]]:
+def create_agent(user_id: str, session_id: str, jwt_token: str, model_id: str | None = None) -> tuple[Agent, list[dict]]:
     """Create a Strands Agent with MCP tools and memory.
 
     MCP servers are initialized first so that server_instructions can be
@@ -246,7 +269,7 @@ def create_agent(user_id: str, session_id: str, jwt_token: str) -> tuple[Agent, 
         )
 
     model = BedrockModel(
-        model_id=os.environ.get("MODEL_ID", "global.anthropic.claude-sonnet-4-6"),
+        model_id=_resolve_model_id(model_id),
         temperature=0.1,
         cache_config=CacheConfig(strategy="auto"),
     )
@@ -449,7 +472,8 @@ async def agent_stream(payload, context):
 
     try:
         os.environ["_CURRENT_SESSION_ID"] = session_id
-        agent, mcp_status = create_agent(user_id=user_id, session_id=session_id, jwt_token=jwt_token)
+        requested_model_id = payload.get("modelId") if isinstance(payload, dict) else None
+        agent, mcp_status = create_agent(user_id=user_id, session_id=session_id, jwt_token=jwt_token, model_id=requested_model_id)
 
         # Emit MCP status as the first SSE event
         yield {"mcp_status": mcp_status}

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,15 @@ phases:
       - cd infra && npm ci && cd ..
   pre_build:
     commands:
-      # Generate config.yaml from environment variables
+      # Use config.yaml from source if present; otherwise generate from env vars.
+      # This allows local deploys to use their own config.yaml (with model settings,
+      # WAF, auth, etc.) while CloudShell/fresh-clone deploys still work via env vars.
       - |
-        cat > infra/config.yaml <<EOF
+        if [ -f infra/config.yaml ]; then
+          echo "Using config.yaml from source"
+        else
+          echo "Generating config.yaml from environment variables"
+          cat > infra/config.yaml <<EOF
         stacks:
           data: true
           runtime: true
@@ -21,45 +27,45 @@ phases:
           searchSlides: ${FEATURE_SEARCH_SLIDES:-false}
           observability: ${FEATURE_OBSERVABILITY:-false}
         EOF
-        sed -i 's/^        //' infra/config.yaml
-      - |
-        if [ -n "${WAF_IPV4}" ] || [ -n "${WAF_IPV6}" ]; then
-          echo "waf:" >> infra/config.yaml
-          if [ -n "${WAF_IPV4}" ]; then
-            echo "  allowedIpV4AddressRanges:" >> infra/config.yaml
-            IFS=',' read -ra CIDRS <<< "${WAF_IPV4}"
-            for c in "${CIDRS[@]}"; do
-              echo "    - \"${c}\"" >> infra/config.yaml
-            done
+          sed -i 's/^        //' infra/config.yaml
+          if [ -n "${WAF_IPV4}" ] || [ -n "${WAF_IPV6}" ]; then
+            echo "waf:" >> infra/config.yaml
+            if [ -n "${WAF_IPV4}" ]; then
+              echo "  allowedIpV4AddressRanges:" >> infra/config.yaml
+              IFS=',' read -ra CIDRS <<< "${WAF_IPV4}"
+              for c in "${CIDRS[@]}"; do
+                echo "    - \"${c}\"" >> infra/config.yaml
+              done
+            fi
+            if [ -n "${WAF_IPV6}" ]; then
+              echo "  allowedIpV6AddressRanges:" >> infra/config.yaml
+              IFS=',' read -ra CIDRS <<< "${WAF_IPV6}"
+              for c in "${CIDRS[@]}"; do
+                echo "    - \"${c}\"" >> infra/config.yaml
+              done
+            fi
           fi
-          if [ -n "${WAF_IPV6}" ]; then
-            echo "  allowedIpV6AddressRanges:" >> infra/config.yaml
-            IFS=',' read -ra CIDRS <<< "${WAF_IPV6}"
-            for c in "${CIDRS[@]}"; do
-              echo "    - \"${c}\"" >> infra/config.yaml
-            done
-          fi
-        fi
-      - |
-        if [ -n "${AUTH_OIDC_URL}" ] && [ -n "${AUTH_ALLOWED_CLIENTS}" ]; then
-          cat >> infra/config.yaml <<AUTHEOF
+          if [ -n "${AUTH_OIDC_URL}" ] && [ -n "${AUTH_ALLOWED_CLIENTS}" ]; then
+            cat >> infra/config.yaml <<AUTHEOF
         auth:
           oidcDiscoveryUrl: "${AUTH_OIDC_URL}"
           allowedClients:
         AUTHEOF
-          sed -i '/^auth:/,$ s/^        //' infra/config.yaml
-          IFS=',' read -ra CLIENTS <<< "${AUTH_ALLOWED_CLIENTS}"
-          for c in "${CLIENTS[@]}"; do
-            echo "  - \"${c}\"" >> infra/config.yaml
-          done
+            sed -i '/^auth:/,$ s/^        //' infra/config.yaml
+            IFS=',' read -ra CLIENTS <<< "${AUTH_ALLOWED_CLIENTS}"
+            for c in "${CLIENTS[@]}"; do
+              echo "  - \"${c}\"" >> infra/config.yaml
+            done
+          fi
         fi
       - cat infra/config.yaml
   build:
     commands:
-      # Build web-ui if Layer 4 (webUi) is enabled
+      # Build web-ui if Layer 4 (webUi) is enabled.
       - |
         if grep -q "webUi: true" infra/config.yaml 2>/dev/null; then
           echo "Building web-ui..."
+          eval "$(cd infra && node lib/resolve-model-env.js)"
           cd web-ui && npm ci && npm run build && cd ..
         fi
       # Bootstrap CDK if not already done (idempotent)

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -26,6 +26,7 @@ import { RuntimeStack } from "../lib/runtime-stack";
 import { AgentStack } from "../lib/agent-stack";
 import { WebUiStack } from "../lib/web-ui-stack";
 import { CloudFrontWafStack } from "../lib/cloudfront-waf-stack";
+import { MODEL_METADATA } from "../lib/model-metadata";
 
 // Load deployment configuration
 const configPath = path.join(__dirname, "../config.yaml");
@@ -78,6 +79,39 @@ const runtime = new RuntimeStack(app, "SdpmRuntime", {
   vectorIndexName: data.vectorIndexName || undefined,
 });
 
+// --- Model configuration & validation ---
+const defaultModelId: string = config.model?.modelId ?? "global.anthropic.claude-sonnet-4-6";
+const allowedModelIds: string[] = config.model?.allowedModelIds ?? [];
+
+if (allowedModelIds.length > 0) {
+  if (!allowedModelIds.includes(defaultModelId)) {
+    throw new Error(
+      `Config error: model.modelId "${defaultModelId}" is not in model.allowedModelIds. ` +
+      `Add it to the list, or remove allowedModelIds.`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const id of allowedModelIds) {
+    if (seen.has(id)) {
+      throw new Error(`Config error: model.allowedModelIds contains duplicate "${id}".`);
+    }
+    seen.add(id);
+    if (!(id in MODEL_METADATA)) {
+      throw new Error(
+        `Config error: modelId "${id}" is not registered in infra/lib/model-metadata.ts. ` +
+        `Add an entry there, or remove "${id}" from model.allowedModelIds. ` +
+        `Known IDs: ${Object.keys(MODEL_METADATA).sort().join(", ")}`,
+      );
+    }
+  }
+}
+
+const allowedModels = allowedModelIds.map((id) => ({
+  modelId: id,
+  displayName: MODEL_METADATA[id].displayName,
+  description: MODEL_METADATA[id].description,
+}));
+
 // --- WAF IP restriction (optional) ---
 const allowedIpV4AddressRanges: string[] | undefined = config.waf?.allowedIpV4AddressRanges;
 const allowedIpV6AddressRanges: string[] | undefined = config.waf?.allowedIpV6AddressRanges;
@@ -104,6 +138,7 @@ if (config.stacks?.agent) {
     oidcDiscoveryUrl,
     allowedClients,
     modelId: config.model?.modelId,
+    allowedModelIds,
   });
 
   if (config.stacks?.webUi) {
@@ -127,6 +162,8 @@ if (config.stacks?.agent) {
       webAclId: cloudFrontWafStack?.webAclArn,
       allowedIpV4AddressRanges,
       allowedIpV6AddressRanges,
+      defaultModelId,
+      allowedModels,
     });
   }
 }

--- a/infra/config.example.yaml
+++ b/infra/config.example.yaml
@@ -28,6 +28,20 @@ model:
   modelId: "global.anthropic.claude-sonnet-4-6"
   # modelId: "global.anthropic.claude-opus-4-6-v1"
 
+  # Optional — enable per-user model switching in the Settings Sheet.
+  # Comment out any model you don't want to expose to end users.
+  # All entries must be registered in infra/lib/model-metadata.ts.
+  # The modelId above must appear in this list when set.
+  # allowedModelIds:
+  #   - "global.anthropic.claude-sonnet-4-6"           # recommended (matches modelId)
+  #   - "global.anthropic.claude-opus-4-7"
+  #   - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+  #   - "moonshotai.kimi-k2.5"
+  #   - "deepseek.v3.2"
+  #   - "qwen.qwen3-235b-a22b-2507-v1:0"
+  #   - "us.amazon.nova-pro-v1:0"
+  #   - "us.amazon.nova-lite-v1:0"
+
 # WAF IP address restriction (optional).
 # When specified, only the listed IP ranges can access CloudFront and API Gateway.
 # waf:

--- a/infra/lib/agent-stack.ts
+++ b/infra/lib/agent-stack.ts
@@ -31,6 +31,8 @@ interface AgentStackProps extends cdk.StackProps {
   allowedClients: string[];
   /** Bedrock model ID from config.yaml. Overridable via CDK context -c modelId=... */
   modelId?: string;
+  /** Allowed model IDs for per-user model switching; empty = feature disabled. */
+  allowedModelIds: string[];
 }
 
 export class AgentStack extends cdk.Stack {
@@ -158,6 +160,7 @@ export class AgentStack extends cdk.Stack {
       environmentVariables: {
         MCP_RUNTIME_ARN: props.mcpRuntimeArn,
         MODEL_ID: this.node.tryGetContext("modelId") || props.modelId || "global.anthropic.claude-sonnet-4-6",
+        ALLOWED_MODEL_IDS: JSON.stringify(props.allowedModelIds ?? []),
         MEMORY_ID: memoryId,
         DECKS_TABLE: props.table.tableName,
         PPTX_BUCKET: props.pptxBucket.bucketName,

--- a/infra/lib/model-metadata.ts
+++ b/infra/lib/model-metadata.ts
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * Display metadata for Bedrock models supported by SDPM.
+ *
+ * To add a new model:
+ *   1. Add an entry below with the Bedrock inference profile ID as the key.
+ *   2. Add the ID to `model.allowedModelIds` in `infra/config.yaml`.
+ *   3. Redeploy (`cdk deploy`).
+ */
+
+export interface ModelMetadata {
+  displayName: string;
+  description?: string;
+}
+
+export const MODEL_METADATA: Record<string, ModelMetadata> = {
+  // --- Anthropic Claude ---
+  "global.anthropic.claude-opus-4-7": {
+    displayName: "Claude Opus 4.7",
+    description: "Highest quality, complex tasks",
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    displayName: "Claude Sonnet 4.6",
+    description: "Balanced quality and speed",
+  },
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    displayName: "Claude Haiku 4.5",
+    description: "Fast and economical",
+  },
+  // --- Moonshot AI ---
+  "moonshotai.kimi-k2.5": {
+    displayName: "Kimi K2.5",
+    description: "High performance, 256K context, cost-efficient",
+  },
+  // --- DeepSeek ---
+  "deepseek.v3.2": {
+    displayName: "DeepSeek V3.2",
+    description: "Strong reasoning, very low cost",
+  },
+  // --- Qwen ---
+  "qwen.qwen3-235b-a22b-2507-v1:0": {
+    displayName: "Qwen3 235B",
+    description: "Alibaba's flagship, agent-capable",
+  },
+  // --- Amazon Nova ---
+  "us.amazon.nova-pro-v1:0": {
+    displayName: "Nova Pro",
+    description: "Amazon's multimodal model",
+  },
+  "us.amazon.nova-lite-v1:0": {
+    displayName: "Nova Lite",
+    description: "Lightweight, fastest and cheapest",
+  },
+};

--- a/infra/lib/resolve-model-env.js
+++ b/infra/lib/resolve-model-env.js
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+/**
+ * Resolve NEXT_PUBLIC_* env vars from config.yaml + model-metadata.ts.
+ * Used by buildspec.yml to inject model config into the web-ui build.
+ *
+ * Usage: cd infra && node lib/resolve-model-env.js
+ * Output: export KEY=VALUE lines suitable for `eval "$(...)"`.
+ */
+const fs = require("fs");
+const path = require("path");
+const yaml = require("yaml");
+
+// Parse MODEL_METADATA from the .ts source directly (simple regex, no TS compiler needed).
+const metadataSource = fs.readFileSync(path.join(__dirname, "model-metadata.ts"), "utf8");
+const metadata = {};
+const re = /"([^"]+)":\s*\{[^}]*displayName:\s*"([^"]*)"(?:[^}]*description:\s*"([^"]*)")?/g;
+let match;
+while ((match = re.exec(metadataSource)) !== null) {
+  metadata[match[1]] = { displayName: match[2], description: match[3] };
+}
+
+const config = yaml.parse(fs.readFileSync(path.join(__dirname, "../config.yaml"), "utf8"));
+const ids = config.model?.allowedModelIds ?? [];
+const models = ids.map((id) => ({
+  modelId: id,
+  displayName: metadata[id]?.displayName,
+  description: metadata[id]?.description,
+}));
+
+console.log(`export NEXT_PUBLIC_ALLOWED_MODELS=${JSON.stringify(JSON.stringify(models))}`);
+console.log(`export NEXT_PUBLIC_DEFAULT_MODEL_ID=${config.model?.modelId || ""}`);

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -57,6 +57,10 @@ interface WebUiStackProps extends cdk.StackProps {
   allowedIpV4AddressRanges?: string[];
   /** Allowed IPv6 CIDR ranges for regional WAF. */
   allowedIpV6AddressRanges?: string[];
+  /** Default model ID (for "Recommended" badge in Settings). */
+  defaultModelId: string;
+  /** Allowed models with resolved display metadata. */
+  allowedModels: Array<{ modelId: string; displayName: string; description?: string }>;
 }
 
 export class WebUiStack extends cdk.Stack {
@@ -328,11 +332,17 @@ function handler(event) {
     // Bundle the web-ui at synth time so changes are auto-picked up without a
     // manual `npm run build`. Prefers local Node.js; falls back to Docker.
     const webUiDir = path.join(__dirname, "../../web-ui");
+    const allowedModelsJson = JSON.stringify(props.allowedModels);
+    const defaultModelIdStr = props.defaultModelId;
     const deployment = new s3deploy.BucketDeployment(this, "DeploySite", {
       sources: [
         s3deploy.Source.asset(webUiDir, {
           bundling: {
             image: cdk.DockerImage.fromRegistry("node:20-slim"),
+            environment: {
+              NEXT_PUBLIC_ALLOWED_MODELS: allowedModelsJson,
+              NEXT_PUBLIC_DEFAULT_MODEL_ID: defaultModelIdStr,
+            },
             command: [
               "bash", "-c",
               "npm ci && npm run build && cp -r build/. /asset-output/",
@@ -345,8 +355,13 @@ function handler(event) {
                 } catch {
                   return false;
                 }
-                execSync("npm ci", { cwd: webUiDir, stdio: "inherit" });
-                execSync("npm run build", { cwd: webUiDir, stdio: "inherit" });
+                const envForBuild = {
+                  ...process.env,
+                  NEXT_PUBLIC_ALLOWED_MODELS: allowedModelsJson,
+                  NEXT_PUBLIC_DEFAULT_MODEL_ID: defaultModelIdStr,
+                };
+                execSync("npm ci", { cwd: webUiDir, stdio: "inherit", env: envForBuild });
+                execSync("npm run build", { cwd: webUiDir, stdio: "inherit", env: envForBuild });
                 execSync(`cp -r ${webUiDir}/build/. ${outputDir}/`, { stdio: "inherit" });
                 return true;
               },

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-progress": "^1.1.7",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/typography": "^0.5.19",
@@ -169,6 +170,7 @@
       "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.16.1.tgz",
       "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.973.1",
@@ -1639,6 +1641,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3465,6 +3468,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7136,6 +7140,7 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7145,6 +7150,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7155,6 +7161,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7229,6 +7236,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -7748,6 +7756,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8295,6 +8304,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9443,6 +9453,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9628,6 +9639,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10053,6 +10065,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10902,6 +10915,7 @@
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11891,7 +11905,6 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14459,6 +14472,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14468,6 +14482,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16133,7 +16148,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -16453,6 +16469,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17114,6 +17131,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/typography": "^0.5.19",

--- a/web-ui/src/components/AppShell.tsx
+++ b/web-ui/src/components/AppShell.tsx
@@ -19,8 +19,8 @@
 
 import { ReactNode, useState, useRef, useEffect, useCallback } from "react"
 import { useAuth } from "@/hooks/useAuth"
-import { usePreferences } from "@/hooks/usePreferences"
-import { Layers, ChevronLeft, MessageSquare, CircleUser, LogOut } from "lucide-react"
+import { Layers, ChevronLeft, MessageSquare, CircleUser, LogOut, Settings as SettingsIcon } from "lucide-react"
+import { Settings } from "@/components/Settings"
 
 interface AppShellProps {
   children: ReactNode
@@ -39,7 +39,7 @@ export function AppShell({ children, deckName, onBack, chatOpen = false, onChatT
   const menuRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const itemsRef = useRef<(HTMLButtonElement | null)[]>([])
-  const { sendWithEnter, setSendWithEnter } = usePreferences()
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   // Chat pulse: show only until first click
   const [chatSeen, setChatSeen] = useState(true)
@@ -180,18 +180,16 @@ export function AppShell({ children, deckName, onBack, chatOpen = false, onChatT
 
                 <div className="my-1 border-t border-white/[0.06]" />
 
-                {/* Preferences */}
+                {/* Settings */}
                 <button
                   ref={el => { itemsRef.current[0] = el }}
                   role="menuitem"
-                  onClick={() => setSendWithEnter(!sendWithEnter)}
-                  className="w-full flex items-center justify-between px-3.5 py-2 text-[12px] font-medium text-foreground/70 hover:bg-white/[0.06] transition-colors menu-item-stagger"
+                  onClick={() => { closeMenu(); setSettingsOpen(true) }}
+                  className="w-full flex items-center gap-2 px-3.5 py-2 text-[12px] font-medium text-foreground/70 hover:bg-white/[0.06] transition-colors menu-item-stagger"
                   style={{ "--stagger": "0ms" } as React.CSSProperties}
                 >
-                  <span>Send with Enter</span>
-                  <span className={`w-8 h-[18px] rounded-full flex items-center px-0.5 transition-colors ${sendWithEnter ? "bg-brand-teal justify-end" : "bg-white/10 justify-start"}`}>
-                    <span className="w-3.5 h-3.5 rounded-full bg-white shadow-sm transition-all duration-200" />
-                  </span>
+                  <SettingsIcon className="h-3.5 w-3.5" />
+                  <span>Settings</span>
                 </button>
 
                 <div className="my-1 border-t border-white/[0.06]" />
@@ -215,6 +213,8 @@ export function AppShell({ children, deckName, onBack, chatOpen = false, onChatT
 
       {/* ── Content area ── */}
       {children}
+
+      <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
     </div>
   )
 }

--- a/web-ui/src/components/Settings.tsx
+++ b/web-ui/src/components/Settings.tsx
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+"use client"
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { usePreferences } from "@/hooks/usePreferences"
+import { getAllowedModels, getDefaultModelId } from "@/lib/allowedModels"
+import { toast } from "sonner"
+import { Check, Star } from "lucide-react"
+import { useEffect, useMemo } from "react"
+
+interface SettingsProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function Settings({ open, onOpenChange }: SettingsProps) {
+  const { sendWithEnter, setSendWithEnter, modelId, setModelId } = usePreferences()
+  const allowed = useMemo(() => getAllowedModels(), [])
+  const defaultId = useMemo(() => getDefaultModelId(), [])
+
+  // Silently drop stale modelId (admin may have removed it from config).
+  useEffect(() => {
+    if (modelId && allowed.length > 0 && !allowed.some((m) => m.modelId === modelId)) {
+      setModelId(undefined)
+    }
+  }, [modelId, allowed, setModelId])
+
+  const selectedId = modelId ?? defaultId
+
+  const onPick = (value: string) => {
+    const m = allowed.find((a) => a.modelId === value)
+    if (!m) return
+    setModelId(m.modelId)
+    toast.success(`Model changed to ${m.displayName}`)
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[400px] sm:w-[480px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Settings</SheetTitle>
+        </SheetHeader>
+
+        {allowed.length > 0 && (
+          <section aria-labelledby="model-heading" className="mt-2 px-4">
+            <h3 id="model-heading" className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Model
+            </h3>
+            <p className="text-xs text-muted-foreground/70 mt-1 mb-3">
+              Choose which AI model generates your slides.
+            </p>
+            <RadioGroupPrimitive.Root
+              value={selectedId}
+              onValueChange={onPick}
+              aria-label="Select AI model"
+              className="space-y-1.5"
+            >
+              {allowed.map((m) => {
+                const isSelected = selectedId === m.modelId
+                const isDefault = m.modelId === defaultId
+                return (
+                  <RadioGroupPrimitive.Item
+                    key={m.modelId}
+                    value={m.modelId}
+                    className={[
+                      "group w-full text-left rounded-lg border p-3 outline-none",
+                      "motion-safe:transition-[border-color,background-color] motion-safe:duration-150",
+                      "focus-visible:ring-2 focus-visible:ring-brand-teal/40 focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                      isSelected
+                        ? "border-brand-teal/60 bg-brand-teal-soft"
+                        : "border-white/[0.06] hover:border-white/[0.12] hover:bg-white/[0.03]",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-start gap-3">
+                      {/* Radio indicator */}
+                      <span
+                        aria-hidden="true"
+                        className={[
+                          "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
+                          "motion-safe:transition-colors motion-safe:duration-150",
+                          isSelected
+                            ? "border-brand-teal bg-brand-teal"
+                            : "border-white/20 group-hover:border-white/30",
+                        ].join(" ")}
+                      >
+                        {isSelected && <Check className="h-2.5 w-2.5 text-white" strokeWidth={3} />}
+                      </span>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">{m.displayName}</span>
+                          {isDefault && (
+                            <span
+                              className="inline-flex items-center gap-0.5 rounded-full bg-brand-teal/10 px-1.5 py-px text-[10px] font-medium text-brand-teal"
+                              aria-label="Recommended"
+                            >
+                              <Star className="h-2.5 w-2.5" />
+                              Recommended
+                            </span>
+                          )}
+                        </div>
+                        {m.description && (
+                          <p className="text-xs text-muted-foreground/70 mt-0.5 leading-relaxed">{m.description}</p>
+                        )}
+                      </div>
+                    </div>
+                  </RadioGroupPrimitive.Item>
+                )
+              })}
+            </RadioGroupPrimitive.Root>
+          </section>
+        )}
+
+        <section aria-labelledby="chat-heading" className="mt-8 px-4">
+          <h3 id="chat-heading" className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Chat behavior
+          </h3>
+          <button
+            role="switch"
+            aria-checked={sendWithEnter}
+            onClick={() => setSendWithEnter(!sendWithEnter)}
+            className="w-full flex items-center justify-between mt-3 py-1.5 text-sm text-foreground/80 hover:text-foreground motion-safe:transition-colors motion-safe:duration-150"
+          >
+            <span>Send with Enter</span>
+            <span
+              aria-hidden="true"
+              className={[
+                "relative w-8 h-[18px] rounded-full flex items-center px-0.5",
+                "motion-safe:transition-colors motion-safe:duration-200",
+                sendWithEnter ? "bg-brand-teal justify-end" : "bg-white/10 justify-start",
+              ].join(" ")}
+            >
+              <span className="w-3.5 h-3.5 rounded-full bg-white shadow-sm motion-safe:transition-all motion-safe:duration-200" />
+            </span>
+          </button>
+        </section>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/web-ui/src/hooks/usePreferences.ts
+++ b/web-ui/src/hooks/usePreferences.ts
@@ -14,6 +14,7 @@ interface Prefs {
   sendWithEnter: boolean
   viewMode: "full" | "grid"
   fetchWebImages: boolean
+  modelId?: string
 }
 
 const DEFAULTS: Prefs = { sendWithEnter: false, viewMode: "full", fetchWebImages: false }
@@ -51,5 +52,7 @@ export function usePreferences() {
     setViewMode: useCallback((v: "full" | "grid") => update({ viewMode: v }), [update]),
     fetchWebImages: prefs.fetchWebImages,
     setFetchWebImages: useCallback((v: boolean) => update({ fetchWebImages: v }), [update]),
+    modelId: prefs.modelId,
+    setModelId: useCallback((v: string | undefined) => update({ modelId: v }), [update]),
   }
 }

--- a/web-ui/src/lib/allowedModels.ts
+++ b/web-ui/src/lib/allowedModels.ts
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+export interface AllowedModel {
+  modelId: string;
+  displayName: string;
+  description?: string;
+}
+
+export function getAllowedModels(): AllowedModel[] {
+  try {
+    const raw = process.env.NEXT_PUBLIC_ALLOWED_MODELS;
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as AllowedModel[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getDefaultModelId(): string | undefined {
+  return process.env.NEXT_PUBLIC_DEFAULT_MODEL_ID || undefined;
+}

--- a/web-ui/src/services/agentCoreService.js
+++ b/web-ui/src/services/agentCoreService.js
@@ -11,6 +11,21 @@
  * To support other agent frameworks, create a new parser file and update config.yaml.
  */
 
+import { getAllowedModels } from "@/lib/allowedModels";
+
+// Read the user's selected model from localStorage, validated against the allowed list.
+function readSelectedModelId() {
+  try {
+    const allowed = getAllowedModels();
+    if (allowed.length === 0) return undefined;
+    const prefs = JSON.parse(localStorage.getItem("sdpm-prefs") || "{}");
+    if (prefs.modelId && allowed.some((m) => m.modelId === prefs.modelId)) {
+      return prefs.modelId;
+    }
+  } catch { /* ignore */ }
+  return undefined;
+}
+
 // Generate a UUID
 const generateId = () => {
   return crypto.randomUUID();
@@ -74,10 +89,12 @@ export const invokeAgentCore = async (query, sessionId, onStreamUpdate, accessTo
     }
 
     // Create the payload
+    const selectedModelId = readSelectedModelId();
     const payload = {
       prompt: query,
       runtimeSessionId: sessionId,
       userId: userId,
+      ...(selectedModelId ? { modelId: selectedModelId } : {}),
     }
 
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Administrators declare allowed Bedrock models in `config.yaml`; end users pick one from a new Settings Sheet. Selection persists in localStorage and is sent to the Agent at inference time.

## Changes

### Infra
- **model-metadata.ts** (new): display dictionary for 8 models (Claude Opus 4.7 / Sonnet 4.6 / Haiku 4.5, Kimi K2.5, DeepSeek V3.2, Qwen3 235B, Nova Pro / Lite)
- **resolve-model-env.js** (new): generates `NEXT_PUBLIC_*` env vars from `config.yaml` + `model-metadata.ts` for buildspec
- **infra.ts**: synth-time validation — default ∈ list, all IDs ∈ metadata, no duplicates
- **agent-stack.ts**: `ALLOWED_MODEL_IDS` env var to AgentCore Runtime
- **web-ui-stack.ts**: `NEXT_PUBLIC_ALLOWED_MODELS` / `NEXT_PUBLIC_DEFAULT_MODEL_ID` injected at build time
- **config.example.yaml**: documented `allowedModelIds` block

### Agent
- **basic_agent.py**: `_resolve_model_id()` — validates against allowed list, falls back to default with warning

### Web UI
- **Settings.tsx** (new): right-side Sheet with model radio cards + Send with Enter toggle
- **allowedModels.ts** (new): build-env accessor for `NEXT_PUBLIC_ALLOWED_MODELS`
- **usePreferences.ts**: `modelId` / `setModelId` accessors
- **agentCoreService.js**: attaches selected `modelId` to AgentCore payload
- **AppShell.tsx**: Settings menu item replaces inline toggle

### Build
- **buildspec.yml**: use source `config.yaml` if present (single source of truth); fall back to env-var generation for CloudShell deploys. `resolve-model-env.js` injects `NEXT_PUBLIC_*` before `npm run build`.

## Backward compatibility

Deployments without `model.allowedModelIds` behave exactly as before — Settings Sheet shows only Chat behavior, Agent uses `MODEL_ID` env var.

## How to enable

```yaml
# infra/config.yaml
model:
 modelId: "global.anthropic.claude-sonnet-4-6"
 allowedModelIds:
    - "global.anthropic.claude-sonnet-4-6"
    - "global.anthropic.claude-opus-4-7"
   # ... add/remove as needed
```

## Testing

- [ ] Deploy with `allowedModelIds` → Settings Sheet shows models with Recommended badge
- [ ] Pick a model → toast confirms, persists on reload, Agent uses it
- [ ] Deploy without `allowedModelIds` → Settings shows only Chat behavior
- [ ] Bad config (missing default, unknown ID, duplicate) → `cdk synth` fails with clear message