### PR TITLE
🐛 fix(acp-local): prevent premature session stop during subagent execution

### DIFF
--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -335,6 +335,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         if (!ct.includes("text/event-stream")) return
       } catch { return }
 
+      setIsLoading(true)  // Immediately show loading — agent is running in background
+
       const { parseStreamingChunk, resetParserState } = await import("@/services/strandsParser")
       if (resetParserState) resetParserState()
 
@@ -344,7 +346,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       let receivedData = false
       let replayDone = false
       es.onmessage = (event) => {
-        if (!receivedData) { receivedData = true; setIsLoading(true) }
+        if (!receivedData) { receivedData = true }
         // After replay, live events arrive with delay. Once we get data
         // and toolOrder has been populated, replay is effectively done.
         if (!replayDone && toolOrder.length > 0) {

--- a/web-ui/src/components/chat/compose/parseComposeState.ts
+++ b/web-ui/src/components/chat/compose/parseComposeState.ts
@@ -47,8 +47,7 @@ export function parseComposeState(
   streamMessages: Record<string, unknown>[],
   input?: Record<string, unknown>,
 ): ComposeState {
-  const rawGroups = input?.slide_groups
-  const slideGroups: SlideGroup[] = Array.isArray(rawGroups) ? rawGroups : []
+  const slideGroups = (input?.slide_groups as SlideGroup[] | undefined) || []
 
   // Discover agents from either input (if already present) or stream events.
   // Key by groupIndex (authoritative from backend); slugs may be missing on some events.

--- a/web-ui/src/lib/local/acp-process.ts
+++ b/web-ui/src/lib/local/acp-process.ts
@@ -163,6 +163,12 @@ function handleLine(ps: ProcessState, line: string) {
     const p = msg.params as Record<string, unknown>
     const sid = p?.sessionId as string
     if (sid && sid !== ps.sessionId) ps.subSessionIds.add(sid)
+    // Detect subagent turn_end → remove from active set
+    const upd = p?.update as Record<string, unknown> | undefined
+    const updType = upd?.sessionUpdate as string | undefined
+    if ((updType === "turn_end" || updType === "end_turn") && sid && sid !== ps.sessionId) {
+      ps.subSessionIds.delete(sid)
+    }
     ps.notifications.push({ id: ++ps.eventIdCounter, msg })
     if (ps.notifications.length > 2000) ps.notifications.shift()
   }
@@ -171,8 +177,9 @@ function handleLine(ps: ProcessState, line: string) {
   if (msg.id != null && msg.result) {
     const r = msg.result as Record<string, unknown>
     if (r.stopReason === "end_turn" || r.stopReason === "cancelled") {
-
-      ps.running = false
+      if (ps.subSessionIds.size === 0) {
+        ps.running = false
+      }
     }
   }
 

--- a/web-ui/src/lib/local/sse-bridge.ts
+++ b/web-ui/src/lib/local/sse-bridge.ts
@@ -174,7 +174,9 @@ export function createSSEStream({ sessionId, subscribe, onDeckId, onDone, replay
           }
         }
 
-        if (type === "turn_end" || type === "end_turn") { if (!replaying) close() }
+        // Don't close on session/update turn_end — it may fire before
+        // compose_slides tool_call_update(completed). Close only on
+        // RPC response end_turn (line 62 above).
       }
     },
   })


### PR DESCRIPTION
## Problem

After switching tabs during compose (subagent execution), the session was incorrectly marked as stopped:
- `running` flag set to `false` on `end_turn` even while subagents were still active
- SSE stream closed on `session/update turn_end` before `compose_slides tool_call_update(completed)` arrived
- UI showed 'stopped' state momentarily on reconnect

## Fix

- **acp-process.ts**: Don't set `running=false` on `end_turn` if `subSessionIds.size > 0`. Track subagent completion via `turn_end` in `session/update`.
- **sse-bridge.ts**: Don't close SSE on `session/update turn_end`. Close only on RPC response `end_turn`.
- **ChatPanel.tsx**: Set `isLoading(true)` immediately on reconnect (not on first data).
- **parseComposeState.ts**: Fix `slide_groups` type cast.

## Testing

1. Start deck A with compose (subagents)
2. Switch to deck B
3. Switch back to deck A — should show loading, not stopped
4. Wait for compose to complete — ComposeCard should show done, not thinking

No cloud impact — all changes in `lib/local/` and Local-mode guards.