### PR TITLE
🐛 fix(agent): add model_profiles.py to Dockerfile COPY

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -13,7 +13,7 @@ RUN uv pip install --no-cache -r requirements.txt
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-COPY basic_agent.py cost_logger.py factory.py composition.py mcp_clients.py resilience.py session.py streaming.py ./
+COPY basic_agent.py cost_logger.py factory.py composition.py mcp_clients.py model_profiles.py resilience.py session.py streaming.py ./
 COPY prompts/ prompts/
 COPY modes/ modes/
 COPY tools/ tools/


### PR DESCRIPTION
## Summary
Agent Runtime failed to start with `ModuleNotFoundError: No module named 'model_profiles'` (HTTP 424).

## Root Cause
`model_profiles.py` was added to `agent/` but not included in the Dockerfile `COPY` instruction.

## Fix
Add `model_profiles.py` to the COPY line in `agent/Dockerfile`.

## Verified
- CloudWatch Logs confirmed the error: `/aws/bedrock-agentcore/runtimes/sdpm_agent-byVNlP2IPc-DEFAULT`
- MCP Server Runtime (`sdpm`) was starting normally — issue was Agent-only.