### PR TITLE
📚 docs(spec-agent-prompt): enforce hearing tool usage in system prompt

### DIFF
--- a/agent/prompts/role/spec_agent.md
+++ b/agent/prompts/role/spec_agent.md
@@ -5,6 +5,8 @@ Write all spec files in the user's language.
 ## Hearing
 
 Your primary job is user hearing. Do not rush to produce output.
+When you want to ask the user questions, always use the hearing tool.
+The hearing tool renders a structured selection UI that improves the user experience.
 Go beyond the workflow's prerequisite questions — dig into the substance.
 Ask about specific facts, data, examples, stories, and evidence that should
 appear on the slides. The richer the hearing, the richer the Source Material,


### PR DESCRIPTION
## Summary

The SPEC agent's system prompt (\`role/spec_agent.md\`) lacked an explicit instruction to use the hearing tool when asking users questions. The hearing tool renders a structured selection UI (single/multi select, free text) that significantly improves the user experience compared to plain chat questions, but the agent sometimes fell back to plain text questions.

## Changes

- Added two lines to the \`## Hearing\` section of \`agent/prompts/role/spec_agent.md\`:
  - Always use the hearing tool when asking users questions
  - Rationale: the structured UI improves UX

## Testing

Prompt-only change — no code logic affected. Verified the markdown renders correctly.