### PR TITLE
ci(require-blog-label): surface 'contributors can ignore' in CI failure notifications

### DIFF
--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -1,3 +1,16 @@
+# ============================================================================
+# ℹ️  Contributors: you can ignore this CI check if it fails on your PR.
+#
+# This workflow enforces that every PR has a `blog:pending`, `blog:skip`, or
+# `blog:done` label so maintainers can decide whether to publish a blog post
+# about the change. Adding these labels requires maintainer permissions, so
+# external contributors cannot pass this check themselves.
+#
+# A maintainer will add the appropriate label during review. Until then, this
+# single CI will stay red — it does NOT block the PR and you do not need to
+# do anything. Please feel free to ignore the failure email.
+# ============================================================================
+
 name: Require blog label
 
 on:
@@ -21,7 +34,8 @@ jobs:
           if echo "$LABELS" | grep -qE '"blog:(pending|skip|done)"'; then
             echo "✅ Blog label found"
           else
-            echo "::error::PR に blog:pending または blog:skip または blog:done ラベルを付けてください"
+            echo "::notice::ℹ️  External contributors can ignore this failure. A maintainer will add a blog:pending / blog:skip / blog:done label during review."
+            echo "::error::Missing blog label (blog:pending, blog:skip, or blog:done). Maintainers: please add one. Contributors: no action needed — you can ignore this."
             exit 1
           fi
 

--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -1,19 +1,17 @@
 # ============================================================================
-# ℹ️  Blog label reminder (NON-BLOCKING)
+# ℹ️  Blog label check — maintainer action required, contributors can ignore.
 #
-# This workflow is a soft reminder for maintainers to tag each PR with a
-# `blog:pending`, `blog:skip`, or `blog:done` label so they can decide
+# This workflow intentionally fails until a maintainer adds a
+# `blog:pending`, `blog:skip`, or `blog:done` label so the team can decide
 # whether to publish a blog post about the change.
 #
-# It never fails the CI check. If a label is missing, the workflow just
-# emits a ::warning:: in the Actions log. This prevents GitHub from sending
-# CI failure emails to contributors for something only maintainers can fix.
-#
-# Maintainers: add the appropriate label during review.
-# Contributors: you don't need to do anything with this check.
+# External contributors cannot add these labels, so if you receive a CI
+# failure email from this workflow you do NOT need to do anything. A
+# maintainer will add the label during review. This check is not a required
+# status check and does not block merge.
 # ============================================================================
 
-name: Require blog label
+name: "Require blog label (maintainer only — contributors can ignore failures)"
 
 on:
   pull_request:
@@ -23,6 +21,7 @@ permissions: {}
 
 jobs:
   check:
+    name: "Blog label (contributors: ignore this if it fails)"
     runs-on: ubuntu-latest
     # Skip for dependabot / renovate
     if: >-
@@ -36,10 +35,12 @@ jobs:
           if echo "$LABELS" | grep -qE '"blog:(pending|skip|done)"'; then
             echo "✅ Blog label found"
           else
-            echo "::warning::Missing blog label (blog:pending, blog:skip, or blog:done). Maintainers: please add one during review. Contributors: you can ignore this — no action needed."
+            echo "::error title=Contributors can ignore — maintainer action required::This check fails until a maintainer adds a blog:pending / blog:skip / blog:done label. External contributors cannot add these labels and do not need to do anything; a maintainer will add the label during review."
+            exit 1
           fi
 
   auto-skip-bots:
+    name: "Blog label (auto-skip for bots)"
     runs-on: ubuntu-latest
     if: >-
       github.actor == 'dependabot[bot]' ||

--- a/.github/workflows/require-blog-label.yml
+++ b/.github/workflows/require-blog-label.yml
@@ -1,14 +1,16 @@
 # ============================================================================
-# ℹ️  Contributors: you can ignore this CI check if it fails on your PR.
+# ℹ️  Blog label reminder (NON-BLOCKING)
 #
-# This workflow enforces that every PR has a `blog:pending`, `blog:skip`, or
-# `blog:done` label so maintainers can decide whether to publish a blog post
-# about the change. Adding these labels requires maintainer permissions, so
-# external contributors cannot pass this check themselves.
+# This workflow is a soft reminder for maintainers to tag each PR with a
+# `blog:pending`, `blog:skip`, or `blog:done` label so they can decide
+# whether to publish a blog post about the change.
 #
-# A maintainer will add the appropriate label during review. Until then, this
-# single CI will stay red — it does NOT block the PR and you do not need to
-# do anything. Please feel free to ignore the failure email.
+# It never fails the CI check. If a label is missing, the workflow just
+# emits a ::warning:: in the Actions log. This prevents GitHub from sending
+# CI failure emails to contributors for something only maintainers can fix.
+#
+# Maintainers: add the appropriate label during review.
+# Contributors: you don't need to do anything with this check.
 # ============================================================================
 
 name: Require blog label
@@ -34,9 +36,7 @@ jobs:
           if echo "$LABELS" | grep -qE '"blog:(pending|skip|done)"'; then
             echo "✅ Blog label found"
           else
-            echo "::notice::ℹ️  External contributors can ignore this failure. A maintainer will add a blog:pending / blog:skip / blog:done label during review."
-            echo "::error::Missing blog label (blog:pending, blog:skip, or blog:done). Maintainers: please add one. Contributors: no action needed — you can ignore this."
-            exit 1
+            echo "::warning::Missing blog label (blog:pending, blog:skip, or blog:done). Maintainers: please add one during review. Contributors: you can ignore this — no action needed."
           fi
 
   auto-skip-bots:


### PR DESCRIPTION
## Problem

The `Require blog label` workflow fails until a maintainer adds a `blog:pending` / `blog:skip` / `blog:done` label, and GitHub sends a CI failure email to the PR author every time. External contributors cannot add these labels themselves and receive the email with no actionable steps, which is confusing.

## Approach

Keep the failure behavior (it is useful triage signal for maintainers and does not block merge), but make the "contributors can ignore" guidance visible in every place GitHub surfaces this workflow:

- **Workflow `name:`** → `Require blog label (maintainer only — contributors can ignore failures)`. Appears in the CI failure email subject line and in the Checks UI.
- **Job `name:`** → `Blog label (contributors: ignore this if it fails)`. Appears in the job list section of the email.
- **Error annotation title** → `Contributors can ignore — maintainer action required`. Appears at the top of the Annotations section in both the email and PR Checks UI.
- **File header comment** → retained so maintainers editing this workflow later understand the intent.

## Not changing

- Merge behavior. This workflow was never a required status check, so a failing run does not block merges.
- Label enforcement for maintainers. A missing label still produces a visible red Check so the triage signal survives.
