### PR TITLE
🐛 fix(fix-acp-session-memory-loss): sessionId-based process routing

### DIFF
--- a/web-ui/src/app/api/agent/invoke/route.ts
+++ b/web-ui/src/app/api/agent/invoke/route.ts
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local ACP Agent Invoke — sends prompt to deck-specific kiro-cli process.
- * Each deck gets its own process; switching decks doesn't interrupt others.
+ * Local ACP Agent Invoke — sends prompt to sessionId-keyed kiro-cli process.
  */
-import { sendPrompt, newProcess, associateDeck, saveSessionToDeck } from "@/lib/local/acp-process"
+import { sendPrompt, createNewProcessFor, hasProcess, getOrCreateProcess, saveSessionToDeck } from "@/lib/local/acp-process"
 import { createSSEStream } from "@/lib/local/sse-bridge"
 
 const MODE_TO_AGENT: Record<string, string> = {
@@ -17,39 +16,33 @@ const MODE_TO_AGENT: Record<string, string> = {
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: Request) {
-  const { query, mode, deckId } = await req.json()
+  const { query, mode, deckId, sessionId: clientSessionId } = await req.json()
   const agentName = MODE_TO_AGENT[mode || "spec"] || "sdpm-spec"
 
-  let effectiveDeckId: string
-  let tempKey: string | null = null
-
-  if (deckId && deckId !== "new") {
-    effectiveDeckId = deckId
-  } else {
-    // New deck — spawn process with temp key
-    const { tempKey: tk } = await newProcess(agentName)
-    tempKey = tk
-    effectiveDeckId = tk
+  // Ensure a process exists for this clientSessionId
+  if (clientSessionId && !hasProcess(clientSessionId)) {
+    if (deckId && deckId !== "new") {
+      // Existing deck reopened after evict — restore via session/load
+      await getOrCreateProcess(clientSessionId, agentName)
+    } else {
+      // Fresh session — spawn new process, register under client's sessionId
+      await createNewProcessFor(clientSessionId, agentName)
+    }
+  } else if (!clientSessionId) {
+    // No sessionId at all (shouldn't happen, but handle gracefully)
+    await createNewProcessFor(crypto.randomUUID(), agentName)
   }
 
-  const { sessionId, subscribe, send } = await sendPrompt(effectiveDeckId, query, agentName)
+  const { sessionId, subscribe, send } = await sendPrompt(clientSessionId!, query, agentName)
 
-  // Create SSE stream (registers listener) BEFORE sending prompt
   const stream = createSSEStream({
     sessionId,
     subscribe,
     onDeckId: (createdDeckId) => {
-      if (tempKey) {
-        associateDeck(tempKey, createdDeckId)
-        tempKey = null
-      }
-      saveSessionToDeck(createdDeckId)
+      saveSessionToDeck(createdDeckId, sessionId)
     },
-    // onDone intentionally omitted — SSE close happens when browser navigates away,
-    // not when agent finishes. running=false is set by handleLine on end_turn.
   })
 
-  // Now send the prompt — listener is already registered
   send()
 
   return new Response(stream, {

--- a/web-ui/src/app/api/agent/models/route.ts
+++ b/web-ui/src/app/api/agent/models/route.ts
@@ -4,20 +4,18 @@
  * Local Model List/Select API.
  * Spawns a process if none exist (for initial model list).
  */
-import { getModels, setConfigOption, getActiveDeckId, newProcess } from "@/lib/local/acp-process"
+import { getModels, setConfigOption, createNewProcess } from "@/lib/local/acp-process"
 
 export async function GET() {
   const models = getModels()
   if (!models.available.length) {
-    // No process yet — spawn one so model list is populated
-    await newProcess()
+    await createNewProcess()
   }
   return Response.json(getModels())
 }
 
 export async function PUT(req: Request) {
-  const { modelId } = await req.json()
-  const deckId = getActiveDeckId()
-  if (deckId) await setConfigOption(deckId, "model", modelId)
+  const { modelId, sessionId } = await req.json()
+  if (sessionId) await setConfigOption(sessionId, "model", modelId)
   return Response.json({ ok: true })
 }

--- a/web-ui/src/app/api/agent/stop/route.ts
+++ b/web-ui/src/app/api/agent/stop/route.ts
@@ -1,22 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 /**
- * Local ACP Agent Stop — cancel a specific deck's prompt.
+ * Local ACP Agent Stop — cancel a specific session's prompt.
  * newChat=true is a no-op (process is spawned on first invoke).
  */
-import { cancelDeck } from "@/lib/local/acp-process"
+import { cancelSession, cancelAll } from "@/lib/local/acp-process"
 
 export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}))
 
   if (body.newChat) {
-    // No-op: new process will be spawned when user sends first message
     return Response.json({ ok: true })
   }
 
-  if (body.deckId) {
-    cancelDeck(body.deckId)
+  if (body.sessionId) {
+    cancelSession(body.sessionId)
+  } else {
+    cancelAll()
   }
-  // Without deckId, do nothing — don't cancel all background processes
   return Response.json({ ok: true })
 }

--- a/web-ui/src/app/api/agent/stream/route.ts
+++ b/web-ui/src/app/api/agent/stream/route.ts
@@ -4,27 +4,26 @@
  * Local ACP Stream — SSE endpoint with Last-Event-ID resume support.
  * Replays buffered events after the given ID, then streams live.
  */
-import { isSessionRunning, getBufferedEvents, subscribeToDeck } from "@/lib/local/acp-process"
+import { isSessionRunning, getBufferedEvents, subscribeToSession } from "@/lib/local/acp-process"
 import { createSSEStream } from "@/lib/local/sse-bridge"
 
 export const dynamic = 'force-dynamic'
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const deckId = url.searchParams.get("deckId")
-  if (!deckId) return Response.json({ error: "deckId required" }, { status: 400 })
+  const sessionId = url.searchParams.get("sessionId")
+  if (!sessionId) return Response.json({ error: "sessionId required" }, { status: 400 })
 
-  if (!isSessionRunning(deckId)) {
+  if (!isSessionRunning(sessionId)) {
     return Response.json({ running: false })
   }
 
-  const sub = subscribeToDeck(deckId)
+  const sub = subscribeToSession(sessionId)
   if (!sub?.sessionId) return Response.json({ running: false })
 
-  // Resume from Last-Event-ID if provided
   const lastEventId = req.headers.get("Last-Event-ID")
   const afterId = lastEventId ? parseInt(lastEventId, 10) : undefined
-  const buffered = getBufferedEvents(deckId, afterId)
+  const buffered = getBufferedEvents(sessionId, afterId)
 
   const stream = createSSEStream({
     sessionId: sub.sessionId,

--- a/web-ui/src/app/api/upload/route.ts
+++ b/web-ui/src/app/api/upload/route.ts
@@ -10,18 +10,16 @@ import { spawn } from "child_process"
 import fs from "fs"
 import os from "os"
 import path from "path"
-import { getSessionId, getActiveDeckId, getProcess } from "@/lib/local/acp-process"
 
 const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
 
 export async function POST(req: Request): Promise<Response> {
-  const did = getActiveDeckId(); if (did) await getProcess(did)
-  const sessionId = getSessionId()
+  const form = await req.formData()
+  const sessionId = form.get("sessionId") as string | null
   if (!sessionId) {
     return Response.json({ error: "No active session" }, { status: 400 })
   }
 
-  const form = await req.formData()
   const file = form.get("file")
   if (!(file instanceof File)) {
     return Response.json({ error: "file field missing" }, { status: 400 })

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -327,9 +327,11 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
     }
 
     const timer = setTimeout(async () => {
-      // Check if running
+      // Check if running — use sessionId for process lookup
+      const sid = sessionId
+      if (!sid) return
       try {
-        const check = await fetch(`/api/agent/stream?deckId=${encodeURIComponent(deckId)}`)
+        const check = await fetch(`/api/agent/stream?sessionId=${encodeURIComponent(sid)}`)
         const ct = check.headers.get("content-type") || ""
         try { check.body?.getReader()?.cancel() } catch {}
         if (!ct.includes("text/event-stream")) return
@@ -341,7 +343,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       if (resetParserState) resetParserState()
 
       reconnectingRef.current = true
-      es = new EventSource(`/api/agent/stream?deckId=${encodeURIComponent(deckId)}`)
+      es = new EventSource(`/api/agent/stream?sessionId=${encodeURIComponent(sid)}`)
 
       let receivedData = false
       let replayDone = false
@@ -912,7 +914,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   const handleStop = () => {
     abortControllerRef.current?.abort()
     if (IS_LOCAL) {
-      fetch("/api/agent/stop", { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" }).catch(() => {})
+      fetch("/api/agent/stop", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ sessionId }) }).catch(() => {})
     } else {
       const token = auth.user?.access_token
       if (token) stopRuntimeSession(sessionId, token)

--- a/web-ui/src/lib/local/acp-process.ts
+++ b/web-ui/src/lib/local/acp-process.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 /**
  * ACP Process Manager — manages multiple kiro-cli acp child processes,
- * one per active deck. Enables background processing: switching decks
+ * keyed by sessionId. Enables background processing: switching decks
  * does not interrupt running agents.
  *
  * Max MAX_PROCESSES concurrent processes. Idle processes are evicted LRU.
@@ -31,15 +31,12 @@ interface ProcessState {
   running: boolean
   notifications: { id: number; msg: Record<string, unknown> }[]
   eventIdCounter: number
-  // Server-side chat state — updated from notifications, saved to .chat.json
-  chatMessages: Record<string, unknown>[]
-  chatDirty: boolean
   lastActivity: number
   subSessionIds: Set<string>
 }
 
+/** Map keyed by sessionId */
 const processes = new Map<string, ProcessState>()
-let activeDeckId: string | null = null
 
 // Model info (shared, populated from first process)
 export interface AcpModel { modelId: string; name: string; description?: string }
@@ -58,92 +55,7 @@ function handleLine(ps: ProcessState, line: string) {
     const resolve = ps.pending.get(msg.id as number)!
     ps.pending.delete(msg.id as number)
     resolve(msg.result)
-    // Server-side chat state tracking — updates .chat.json independent of browser
-  if (msg.method === "session/update" || msg.method === "_kiro.dev/session/update") {
-    const p = msg.params as Record<string, unknown>
-    const update = p?.update as Record<string, unknown>
-    if (update) {
-      const type = update.sessionUpdate as string
-      const msgSid = p?.sessionId as string
-
-      // Only track main session messages (not subagent)
-      if (msgSid === ps.sessionId) {
-        if (type === "agent_message_chunk") {
-          const content = update.content as Record<string, unknown>
-          if (content?.text) {
-            // Append text to last assistant message
-            let last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
-            if (!last || last.role !== "assistant") {
-              last = { role: "assistant", content: "", toolUses: [], blocks: [] }
-              ps.chatMessages.push(last)
-            }
-            last.content = (last.content as string || "") + (content.text as string)
-            ps.chatDirty = true
-          }
-        }
-        if (type === "tool_call" || type === "tool_call_chunk") {
-          const toolCallId = (update.toolCallId || "") as string
-          const title = (update.title || update.name || "") as string
-          const name = title.replace(/^Running:\s*@sdpm\//, "").replace(/^Running:\s*/, "") || title
-          const input = (update.rawInput || update.input || {}) as Record<string, unknown>
-          let last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
-          if (!last || last.role !== "assistant") {
-            last = { role: "assistant", content: "", toolUses: [], blocks: [] }
-            ps.chatMessages.push(last)
-          }
-          const toolUses = (last.toolUses as Record<string, unknown>[]) || []
-          if (!toolUses.some(t => t.toolUseId === toolCallId)) {
-            toolUses.push({ toolUseId: toolCallId, name, input, streamMessages: [] })
-            last.toolUses = toolUses
-            ps.chatDirty = true
-          }
-        }
-        if (type === "tool_call_update") {
-          const status = update.status as string
-          const toolCallId = (update.toolCallId || "") as string
-          if (status === "completed" || status === "error") {
-            const last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
-            if (last) {
-              const toolUses = (last.toolUses as Record<string, unknown>[]) || []
-              const tool = toolUses.find(t => t.toolUseId === toolCallId)
-              if (tool) {
-                tool.status = status === "completed" ? "success" : "error"
-                ps.chatDirty = true
-              }
-            }
-          }
-        }
-      }
-
-      // Track subagent toolStream events
-      if (msgSid !== ps.sessionId && ps.subSessionIds.has(msgSid)) {
-        const last = ps.chatMessages[ps.chatMessages.length - 1] as Record<string, unknown> | undefined
-        if (last) {
-          const toolUses = (last.toolUses as Record<string, unknown>[]) || []
-          // Find compose_slides tool (the one with streamMessages)
-          const composeTool = toolUses.find(t => (t.streamMessages as unknown[])?.length >= 0 && (t.name === "compose_slides" || t.name === "subagent" || (t.name as string)?.includes("subagent")))
-          if (composeTool) {
-            const sm = (composeTool.streamMessages as Record<string, unknown>[]) || []
-            if (type === "tool_call") {
-              const title = (update.title || "") as string
-              const toolName = title.replace(/^Running:\s*@sdpm\//, "").replace(/^Running:\s*/, "") || title
-              sm.push({ tool: toolName, group: 0, toolUseId: update.toolCallId })
-              composeTool.streamMessages = sm
-              ps.chatDirty = true
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Periodically flush dirty chat to .chat.json
-  if (ps.chatDirty && ps.deckId && !ps.deckId.startsWith("_new_")) {
-    ps.chatDirty = false
-    saveChatToDeck(ps.deckId, ps.chatMessages)
-  }
-
-  for (const fn of ps.listeners) fn(msg)
+    for (const fn of ps.listeners) fn(msg)
     return
   }
 
@@ -198,11 +110,9 @@ function rpcNotifyTo(ps: ProcessState, method: string, params: Record<string, un
   ps.child.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n")
 }
 
-async function spawnProcess(deckId: string, agentName: string, adapter?: AgentConfig): Promise<ProcessState> {
+async function spawnProcess(agentName: string, existingSessionId?: string, adapter?: AgentConfig): Promise<ProcessState> {
   const cfg = adapter || getActiveAgent()
-  // For kiro-cli, replace agent name in args if agentFlag is set
   let args = [...cfg.args]
-  // For kiro-cli, replace agent name in args (--agent <name>)
   const flagIdx = args.indexOf("--agent")
   if (flagIdx >= 0 && flagIdx + 1 < args.length) {
     args[flagIdx + 1] = agentName
@@ -214,10 +124,9 @@ async function spawnProcess(deckId: string, agentName: string, adapter?: AgentCo
   })
 
   const ps: ProcessState = {
-    child, deckId, sessionId: null, agentName,
+    child, deckId: "", sessionId: null, agentName,
     requestId: 0, pending: new Map(), listeners: new Set(),
     lineBuffer: "", running: false, notifications: [], eventIdCounter: 0,
-    chatMessages: [], chatDirty: false,
     lastActivity: Date.now(), subSessionIds: new Set(),
   }
 
@@ -230,10 +139,11 @@ async function spawnProcess(deckId: string, agentName: string, adapter?: AgentCo
   })
 
   child.stderr!.setEncoding("utf-8")
-  child.stderr!.on("data", (d: string) => console.warn("[acp:%s] stderr: %s", deckId, d.trim()))
+  child.stderr!.on("data", (d: string) => console.warn("[acp] stderr: %s", d.trim()))
 
-  child.on("close", () => {
-    processes.delete(deckId)
+  child.on("close", (code) => {
+    console.log("[acp close] sessionId=%s code=%s", ps.sessionId, code)
+    if (ps.sessionId) processes.delete(ps.sessionId)
   })
 
   // Initialize ACP
@@ -246,6 +156,14 @@ async function spawnProcess(deckId: string, agentName: string, adapter?: AgentCo
   // Create session
   const result = await rpcRequestTo(ps, "session/new", { cwd: MCP_LOCAL_DIR, mcpServers: [], agent: agentName }) as Record<string, unknown>
   ps.sessionId = result.sessionId as string
+
+  // Restore existing session context if provided (Obsidian agent-client pattern)
+  if (existingSessionId) {
+    await rpcRequestTo(ps, "session/load", { sessionId: existingSessionId, cwd: MCP_LOCAL_DIR, mcpServers: [] })
+    // After session/load, prompts must use the old sessionId
+    processes.delete(ps.sessionId!)
+    ps.sessionId = existingSessionId
+  }
 
   // Extract model info from first process
   if (!availableModels.length) {
@@ -262,73 +180,61 @@ async function spawnProcess(deckId: string, agentName: string, adapter?: AgentCo
 
 async function evictIfNeeded(): Promise<void> {
   if (processes.size < MAX_PROCESSES) return
-  // Find oldest idle process (not running, not active)
   let oldest: ProcessState | null = null
   for (const ps of processes.values()) {
-    if (ps.running || ps.deckId === activeDeckId) continue
+    if (ps.running) continue
     if (!oldest || ps.lastActivity < oldest.lastActivity) oldest = ps
   }
   if (oldest) {
     oldest.child.kill()
-    processes.delete(oldest.deckId)
-    // Wait briefly for cleanup
+    if (oldest.sessionId) processes.delete(oldest.sessionId)
     await new Promise(r => setTimeout(r, 500))
   }
 }
 
 // ── Public API ──
 
-/** Get or create a process for a deck. */
-export async function getProcess(deckId: string, agentName: string = "sdpm-spec"): Promise<ProcessState> {
-  let ps = processes.get(deckId)
+/** Check if a live process exists for a sessionId. */
+export function hasProcess(sessionId: string): boolean {
+  return processes.has(sessionId)
+}
+
+/** Get or create a process for a sessionId. Restores context if existingSessionId provided. */
+export async function getOrCreateProcess(sessionId: string, agentName: string = "sdpm-spec"): Promise<ProcessState> {
+  let ps = processes.get(sessionId)
   if (ps) {
     ps.lastActivity = Date.now()
     return ps
   }
+  // No live process — spawn new one and restore session context
   await evictIfNeeded()
-  ps = await spawnProcess(deckId, agentName)
-  processes.set(deckId, ps)
-  activeDeckId = deckId
+  ps = await spawnProcess(agentName, sessionId)
+  processes.set(sessionId, ps)
   return ps
 }
 
-/** Get or create a process for a new deck (no deckId yet). Returns temp key. */
-export async function newProcess(agentName: string = "sdpm-spec"): Promise<{ ps: ProcessState; tempKey: string }> {
-  // Reuse existing idle temp process if available
-  for (const [key, ps] of processes) {
-    if (key.startsWith("_new_") && !ps.running && ps.agentName === agentName) {
-      activeDeckId = key
-      return { ps, tempKey: key }
-    }
-  }
-  const tempKey = `_new_${Date.now()}`
+/** Spawn a brand-new process (no existing session). Returns the new sessionId. */
+export async function createNewProcess(agentName: string = "sdpm-spec"): Promise<ProcessState> {
   await evictIfNeeded()
-  const ps = await spawnProcess(tempKey, agentName)
-  processes.set(tempKey, ps)
-  activeDeckId = tempKey
-  return { ps, tempKey }
+  const ps = await spawnProcess(agentName)
+  processes.set(ps.sessionId!, ps)
+  return ps
 }
 
-/** Re-key a temp process to a real deckId. */
-export function associateDeck(tempKey: string, deckId: string): void {
-  const ps = processes.get(tempKey)
-  if (!ps) return
-  processes.delete(tempKey)
-  ps.deckId = deckId
-  processes.set(deckId, ps)
-  if (activeDeckId === tempKey) activeDeckId = deckId
+/** Spawn a new process and register it under a client-provided key. */
+export async function createNewProcessFor(clientSessionId: string, agentName: string = "sdpm-spec"): Promise<ProcessState> {
+  await evictIfNeeded()
+  const ps = await spawnProcess(agentName)
+  processes.set(clientSessionId, ps)
+  return ps
 }
 
-/** Send a prompt to a deck's process. */
-export async function sendPrompt(deckId: string, text: string, agentName?: string): Promise<{ sessionId: string; subscribe: (fn: NotifyListener) => () => void; send: () => void }> {
-  const ps = await getProcess(deckId, agentName)
+/** Send a prompt to a session's process. */
+export async function sendPrompt(sessionId: string, text: string, agentName?: string): Promise<{ sessionId: string; subscribe: (fn: NotifyListener) => () => void; send: () => void }> {
+  const ps = await getOrCreateProcess(sessionId, agentName || "sdpm-spec")
   ps.running = true
   ps.notifications = []; ps.eventIdCounter = 0
   ps.lastActivity = Date.now()
-
-  // Initialize server-side chat state with user message
-  ps.chatMessages = [{ role: "user", content: text, toolUses: [] }]
-  ps.chatDirty = false
 
   return {
     sessionId: ps.sessionId!,
@@ -345,9 +251,9 @@ export async function sendPrompt(deckId: string, text: string, agentName?: strin
   }
 }
 
-/** Cancel a deck's active prompt. */
-export function cancelDeck(deckId: string): void {
-  const ps = processes.get(deckId)
+/** Cancel a session's active prompt. */
+export function cancelSession(sessionId: string): void {
+  const ps = processes.get(sessionId)
   if (!ps) return
   if (ps.sessionId) {
     rpcNotifyTo(ps, "session/cancel", { sessionId: ps.sessionId })
@@ -358,7 +264,7 @@ export function cancelDeck(deckId: string): void {
   }
 }
 
-/** Cancel all processes (stop button with no specific deck). */
+/** Cancel all processes (stop button with no specific session). */
 export function cancelAll(): void {
   for (const ps of processes.values()) {
     if (ps.running && ps.sessionId) {
@@ -371,28 +277,22 @@ export function cancelAll(): void {
   }
 }
 
-/** Check if a deck has a running process. */
-export function isSessionRunning(deckId: string): boolean {
-  return processes.get(deckId)?.running ?? false
+/** Check if a session has a running process. */
+export function isSessionRunning(sessionId: string): boolean {
+  return processes.get(sessionId)?.running ?? false
 }
 
-/** Mark running state. */
-export function markSessionRunning(deckId: string, running: boolean): void {
-  const ps = processes.get(deckId)
-  if (ps) ps.running = running
-}
-
-/** Drain buffered notifications for a deck. */
-export function getBufferedEvents(deckId: string, afterId?: number): { id: number; msg: Record<string, unknown> }[] {
-  const ps = processes.get(deckId)
+/** Drain buffered notifications for a session. */
+export function getBufferedEvents(sessionId: string, afterId?: number): { id: number; msg: Record<string, unknown> }[] {
+  const ps = processes.get(sessionId)
   if (!ps) return []
   if (afterId == null) return [...ps.notifications]
   return ps.notifications.filter(e => e.id > afterId)
 }
 
-/** Subscribe to a deck's process notifications. */
-export function subscribeToDeck(deckId: string): { sessionId: string | null; subscribe: (fn: NotifyListener) => () => void } | null {
-  const ps = processes.get(deckId)
+/** Subscribe to a session's process notifications. */
+export function subscribeToSession(sessionId: string): { sessionId: string | null; subscribe: (fn: NotifyListener) => () => void } | null {
+  const ps = processes.get(sessionId)
   if (!ps) return null
   return {
     sessionId: ps.sessionId,
@@ -403,34 +303,22 @@ export function subscribeToDeck(deckId: string): { sessionId: string | null; sub
   }
 }
 
-/** Get session ID for a deck. */
-export function getSessionId(deckId?: string): string | null {
-  const id = deckId || activeDeckId
-  if (!id) return null
-  return processes.get(id)?.sessionId ?? null
-}
-
-export function getActiveDeckId(): string | null { return activeDeckId }
-export function setActiveDeckId(id: string): void { activeDeckId = id }
-
 export function getModels(): { current: string; available: AcpModel[] } {
   return { current: currentModelId, available: availableModels }
 }
 
-export async function setConfigOption(deckId: string, configId: string, value: string): Promise<void> {
-  const ps = processes.get(deckId)
+export async function setConfigOption(sessionId: string, configId: string, value: string): Promise<void> {
+  const ps = processes.get(sessionId)
   if (!ps?.sessionId) return
   await rpcRequestTo(ps, "session/set_config_option", { sessionId: ps.sessionId, configId, value })
 }
 
 /** Save sessionId to deck's .session file. */
-export function saveSessionToDeck(deckId: string): void {
-  const sid = getSessionId(deckId)
-  if (!sid) return
+export function saveSessionToDeck(deckId: string, sessionId: string): void {
   const fs = require("fs") as typeof import("fs")
   const dir = resolveDeckDir(deckId)
   if (!dir || !fs.existsSync(dir)) return
-  fs.writeFileSync(path.join(dir, ".session"), sid, "utf-8")
+  fs.writeFileSync(path.join(dir, ".session"), sessionId, "utf-8")
 }
 
 /** Read sessionId from deck's .session file. */

--- a/web-ui/src/services/agentCoreService.js
+++ b/web-ui/src/services/agentCoreService.js
@@ -283,10 +283,10 @@ const invokeLocalAgent = async (query, sessionId, onStreamUpdate, onToolUse, sig
  * Supports Last-Event-ID for seamless resume after disconnect.
  * Returns a cleanup function, or null if no session is running.
  */
-export const reconnectLocalSession = (deckId, onStreamUpdate, onToolUse) => {
+export const reconnectLocalSession = (sessionId, onStreamUpdate, onToolUse) => {
   if (!IS_LOCAL) return null;
 
-  const url = `/api/agent/stream?deckId=${encodeURIComponent(deckId)}`;
+  const url = `/api/agent/stream?sessionId=${encodeURIComponent(sessionId)}`;
   const es = new EventSource(url);
   let completion = '';
   if (parser.resetParserState) parser.resetParserState();

--- a/web-ui/src/services/uploadService.ts
+++ b/web-ui/src/services/uploadService.ts
@@ -94,6 +94,7 @@ export async function uploadFile(
   if (IS_LOCAL) {
     const form = new FormData()
     form.append("file", file)
+    form.append("sessionId", sessionId)
 
     const uploaded: UploadedFile = {
       uploadId: "",


### PR DESCRIPTION
## Summary
Fix ACP (Local mode) session memory loss where the agent forgot all
conversation context on every message send.

## Root Cause
PR#97 changed the process map key from `sessionId` to `deckId` for
multi-process support. New decks have `deckId=undefined`, so every
invoke spawned a fresh process with a new LLM session.

## Fix
Key the process map by the frontend-generated `sessionId` — consistent
with how Cloud mode works (AgentCore uses sessionId for session routing).
The kiro-cli internal sessionId is used only for RPC calls.

Also adds `session/load` support for restoring LLM context when a
process is evicted and the user returns to an existing deck.

## Changes (9 files, +105 −226)
- `acp-process.ts` — sessionId-keyed Map, removed `newProcess`/`associateDeck`/`activeDeckId`
- `invoke/route.ts` — sessionId routing (fresh vs evict-restore)
- `stream/route.ts` — `deckId` → `sessionId` param
- `stop/route.ts` — `cancelDeck` → `cancelSession`
- `models/route.ts` — removed `getActiveDeckId` dependency
- `upload/route.ts` — removed `acp-process` dependency
- `ChatPanel.tsx` — sessionId-based SSE URLs and stop
- `agentCoreService.js` — sessionId-based reconnect
- `uploadService.ts` — pass sessionId in FormData

## Testing
- [x] TypeScript build: 0 errors in changed files
- [ ] New deck: 3+ consecutive messages retain context
- [ ] Deck switch and return: same process reused
- [ ] New chat button: fresh session created
- [ ] Process evict + reopen: session/load restores context