### PR TITLE
Fix deck crash when LLM passes slide_groups as string

### DIFF
--- a/agent/modes/separated/composer.py
+++ b/agent/modes/separated/composer.py
@@ -207,6 +207,9 @@ def make_compose_slides(mcp_servers: list, model, composer_mcp_factory=None):
         Prefetches all Phase 2 references once, then injects into composer prompt.
         Runs groups in parallel. Async generator: yields progress dicts, then returns final result str.
         """
+        # LLM sometimes passes slide_groups as a JSON string instead of a list
+        if isinstance(slide_groups, str):
+            slide_groups = json.loads(slide_groups)
         parent_tool_use_id = tool_context.tool_use["toolUseId"]
 
         generated = []

--- a/web-ui/src/components/chat/compose/parseComposeState.ts
+++ b/web-ui/src/components/chat/compose/parseComposeState.ts
@@ -47,7 +47,12 @@ export function parseComposeState(
   streamMessages: Record<string, unknown>[],
   input?: Record<string, unknown>,
 ): ComposeState {
-  const slideGroups = (input?.slide_groups as SlideGroup[] | undefined) || []
+  const rawGroups = input?.slide_groups
+  const slideGroups: SlideGroup[] = Array.isArray(rawGroups)
+    ? rawGroups
+    : typeof rawGroups === "string"
+      ? (() => { try { const p = JSON.parse(rawGroups); return Array.isArray(p) ? p : [] } catch { return [] } })()
+      : []
 
   // Discover agents from either input (if already present) or stream events.
   // Key by groupIndex (authoritative from backend); slugs may be missing on some events.


### PR DESCRIPTION
## Summary

Fixes "This page couldn't load" crash on deck detail page caused by
n.forEach is not a function TypeError.

## Root Cause

LLM occasionally passes compose_slides's slide_groups parameter as a JSON string (
"[{...}]") instead of an array ([{...}]). This stringified data is saved to chat
history and crashes parseComposeState when rendering the deck.

## Changes

- **agent/modes/separated/composer.py** — Normalize slide_groups from string to
list at tool entry point. Prevents corrupted data from being saved going forward.
- **web-ui/.../parseComposeState.ts** — Add Array.isArray guard with JSON.parse
fallback for already-saved corrupted chat history.

## Testing

- Python syntax check: pass
- TypeScript type check: pass (no new errors)
- Manual: verify affected deck loads without crash