### PR TITLE
fix: add sdpm-mcp/invoke scope to WebClient OAuth config

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -206,6 +206,7 @@ if (config.stacks?.agent) {
       defaultChatModelId,
       defaultCreateModelId,
       allowedModels,
+      mcpCustomScope: authStack.mcpCustomScope,
     });
   }
 }

--- a/infra/lib/web-ui-stack.ts
+++ b/infra/lib/web-ui-stack.ts
@@ -63,6 +63,8 @@ interface WebUiStackProps extends cdk.StackProps {
   defaultCreateModelId: string;
   /** Allowed models with resolved display metadata. */
   allowedModels: Array<{ modelId: string; displayName: string; description?: string }>;
+  /** Custom OAuth scope for MCP access (e.g. `sdpm-mcp/invoke`). */
+  mcpCustomScope?: string;
 }
 
 export class WebUiStack extends cdk.Stack {
@@ -403,7 +405,7 @@ function handler(event) {
       redirect_uri: "${SiteUrl}",
       post_logout_redirect_uri: "${SiteUrl}",
       response_type: "code",
-      scope: "openid profile email",
+      scope: "openid profile email${McpScope}",
       automaticSilentRenew: true,
       agentRuntimeArn: "${AgentRuntimeArn}",
       apiBaseUrl: "${ApiBaseUrl}",
@@ -414,6 +416,7 @@ function handler(event) {
       SiteUrl: this.siteUrl,
       AgentRuntimeArn: props.agentRuntimeArn,
       ApiBaseUrl: api.url,
+      McpScope: props.mcpCustomScope ? ` ${props.mcpCustomScope}` : "",
     });
 
     const awsExports = new cr.AwsCustomResource(this, "WriteAwsExports", {
@@ -446,6 +449,7 @@ function handler(event) {
     awsExports.node.addDependency(deployment);
 
     // --- Add Amazon CloudFront URL to Amazon Cognito callback/logout URLs ---
+    const oauthScopes = ["openid", "profile", "email", ...(props.mcpCustomScope ? [props.mcpCustomScope] : [])];
     new cr.AwsCustomResource(this, "UpdateCognitoCallbackUrls", {
       onCreate: {
         service: "CognitoIdentityServiceProvider",
@@ -455,7 +459,7 @@ function handler(event) {
           ClientId: props.userPoolClient.userPoolClientId,
           SupportedIdentityProviders: ["COGNITO"],
           AllowedOAuthFlows: ["code"],
-          AllowedOAuthScopes: ["openid", "profile", "email"],
+          AllowedOAuthScopes: oauthScopes,
           AllowedOAuthFlowsUserPoolClient: true,
           CallbackURLs: ["http://localhost:3000", this.siteUrl],
           LogoutURLs: ["http://localhost:3000", this.siteUrl],
@@ -475,7 +479,7 @@ function handler(event) {
           ClientId: props.userPoolClient.userPoolClientId,
           SupportedIdentityProviders: ["COGNITO"],
           AllowedOAuthFlows: ["code"],
-          AllowedOAuthScopes: ["openid", "profile", "email"],
+          AllowedOAuthScopes: oauthScopes,
           AllowedOAuthFlowsUserPoolClient: true,
           CallbackURLs: ["http://localhost:3000", this.siteUrl],
           LogoutURLs: ["http://localhost:3000", this.siteUrl],


### PR DESCRIPTION
## Summary

PR #83 introduced scope-based auth for the MCP Server (`allowedScopes: ["sdpm-mcp/invoke"]`), but did not add that scope to the WebClient's allowed OAuth scopes. As a result, tokens issued to WebUI users are missing `sdpm-mcp/invoke`, and Agent → MCP Server requests fail with `401 Unauthorized`. Chat stops streaming and the user sees a perpetual loading indicator.

This PR adds `sdpm-mcp/invoke` to the WebClient via the existing `UpdateCognitoCallbackUrls` custom resource in WebUiStack. This approach avoids any changes to `AuthStack`'s `UserPoolClient` construct — which matters because modifying `oAuth.scopes` on the CDK construct triggers a CloudFormation `UserPoolClient` replacement, and the client's ID is exported via auto-generated `Fn::ImportValue` to SdpmAgent / SdpmRuntime / SdpmWebUi. A replacement would fail with "Cannot delete export" on any in-place upgrade.

## Changes

| File | Change |
|---|---|
| `infra/lib/web-ui-stack.ts` | Add `mcpCustomScope` prop; include it in `AllowedOAuthScopes` of the `UpdateCognitoCallbackUrls` custom resource; append it to the `scope` field written to `aws-exports.json` so that the browser OIDC library explicitly requests it on token refresh |
| `infra/bin/infra.ts` | Pass `authStack.mcpCustomScope` to `WebUiStack` |

`AuthStack` is intentionally left untouched. The Cognito Resource Server and the WebClient itself are not modified — only the `AllowedOAuthScopes` value on the existing client is updated via a Cognito API call, which is an in-place update with no replacement.

## Why custom resource instead of CDK oAuth.scopes

Changing `oAuth.scopes` on `userPool.addClient(...)` causes CDK to emit a `UserPoolClient` replacement. CloudFormation then tries to delete the outgoing client's auto-generated export (`SdpmAuth:ExportsOutputRefUserPoolWebClient...`), which is currently imported by three downstream stacks. The delete fails, and the entire Auth stack rolls back. The custom resource route sidesteps that by leaving CloudFormation resource definitions unchanged and just patching the live Cognito client.

## Verification

- `npx tsc --noEmit` passes
- Deployed to `us-east-1` via `bash scripts/deploy.sh` — all stacks `CREATE_COMPLETE` / `UPDATE_COMPLETE`
- Verified post-deploy that the WebClient now has `sdpm-mcp/invoke` in its allowed scopes
- Users must sign out, clear site data, and sign back in once after the fix rolls out so their token is reissued with the new scope

## Follow-up

There is a broader refactor being considered to stop using auto-generated CloudFormation exports for cross-stack references and migrate to SSM Parameter Store instead. That work will be tracked in a separate PR (#113). The current PR is deliberately minimal and only fixes the immediate 401 regression.