### PR TITLE
Fix deck deletion in Local mode

### DIFF
--- a/web-ui/src/app/api/decks/[id]/route.ts
+++ b/web-ui/src/app/api/decks/[id]/route.ts
@@ -9,7 +9,7 @@
 
 import fs from "fs"
 import path from "path"
-import { resolveDeckDir } from "@/lib/local/deck-paths"
+import { resolveDeckDir, DECK_ROOT } from "@/lib/local/deck-paths"
 
 function safeRead(p: string): string | null {
   try { return fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : null } catch { return null }
@@ -109,4 +109,26 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
     collaborators: [],
     collaboratorAliases: {},
   })
+}
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: deckId } = await params
+  const dp = resolveDeckDir(deckId)
+  if (!dp || !fs.existsSync(dp)) return new Response("Not found", { status: 404 })
+
+  fs.rmSync(dp, { recursive: true, force: true })
+
+  // Remove from decks.json index if present
+  const indexPath = path.join(DECK_ROOT, "decks.json")
+  if (fs.existsSync(indexPath)) {
+    try {
+      const index = JSON.parse(fs.readFileSync(indexPath, "utf-8"))
+      if (Array.isArray(index.decks)) {
+        index.decks = index.decks.filter((d: { deckId?: string }) => d.deckId !== deckId)
+        fs.writeFileSync(indexPath, JSON.stringify(index, null, 2))
+      }
+    } catch { /* index file corrupt — skip */ }
+  }
+
+  return Response.json({ deleted: true })
 }

--- a/web-ui/src/services/deckService.ts
+++ b/web-ui/src/services/deckService.ts
@@ -325,6 +325,11 @@ export async function searchUsers(query: string, idToken: string): Promise<UserS
  * @param idToken - Cognito ID token
  */
 export async function deleteDeck(deckId: string, idToken: string): Promise<void> {
+  if (IS_LOCAL) {
+    const resp = await fetch(`/api/decks/${deckId}`, { method: "DELETE" })
+    if (!resp.ok) throw new Error(`Failed to delete deck: ${resp.status}`)
+    return
+  }
   const base = await getApiBaseUrl()
   const resp = await fetch(`${base}decks/${deckId}`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary

Deck deletion from the deck list fails in Local mode.

## Root Cause

deckService.ts's deleteDeck() lacked an IS_LOCAL branch, and the API Route
decks/[id]/route.ts had no DELETE handler — so the DELETE request hit a non-
existent endpoint.

## Changes

- **web-ui/src/app/api/decks/[id]/route.ts** — Add DELETE handler. Validates path
via resolveDeckDir, removes the deck directory, and cleans up the decks.json
index.
- **web-ui/src/services/deckService.ts** — Add IS_LOCAL early return in
deleteDeck().

## Testing

- Local mode: create deck → delete from list → confirmed deletion succeeds
- No impact on Cloud build (API Routes are excluded by build:cloud)