### PR TITLE
Fix Open PPTX and add Open Folder to deck list (Local mode)

### DIFF
--- a/web-ui/src/app/(authenticated)/decks/page.tsx
+++ b/web-ui/src/app/(authenticated)/decks/page.tsx
@@ -217,6 +217,7 @@ export default function DecksPage() {
                 onDelete={list.handleDelete}
                 onToggleVisibility={list.handleToggleVisibility}
                 onDownload={list.handleDownload}
+                onOpenFolder={list.handleOpenFolder}
                 loading={list.loading}
               />
               {list.error && (

--- a/web-ui/src/app/api/decks/route.ts
+++ b/web-ui/src/app/api/decks/route.ts
@@ -50,7 +50,9 @@ export async function GET() {
         const first = fs.readdirSync(previewDir).filter(f => f.endsWith(".png")).sort()[0]
         if (first) thumbnailUrl = `/api/preview/${deckId}/preview/${first}`
       }
-      return { deckId, name, slideCount, updatedAt: new Date().toISOString(), thumbnailUrl }
+      const pptxPath = path.join(dp, "output.pptx")
+      const pptxUrl = fs.existsSync(pptxPath) ? `/api/preview/${deckId}/output.pptx` : null
+      return { deckId, name, slideCount, updatedAt: new Date().toISOString(), thumbnailUrl, pptxUrl }
     })
     .sort((a, b) => b.deckId.localeCompare(a.deckId))
 

--- a/web-ui/src/components/deck/DeckCard.tsx
+++ b/web-ui/src/components/deck/DeckCard.tsx
@@ -39,6 +39,7 @@ interface DeckCardProps {
   onToggleVisibility?: (deckId: string, visibility: "public" | "private") => void
   onShare?: (deckId: string) => void
   onDownload?: (deckId: string) => void
+  onOpenFolder?: (deckId: string) => void
 }
 
 /**
@@ -78,7 +79,7 @@ function meshGradient(id: string): string {
   ].join(", ")
 }
 
-export function DeckCard({ deck, index, isFavorite = false, isOwner = true, onOpen, onToggleFavorite, onDelete, onToggleVisibility, onShare, onDownload }: DeckCardProps) {
+export function DeckCard({ deck, index, isFavorite = false, isOwner = true, onOpen, onToggleFavorite, onDelete, onToggleVisibility, onShare, onDownload, onOpenFolder }: DeckCardProps) {
   return (
     <div
       role="button"
@@ -134,6 +135,12 @@ export function DeckCard({ deck, index, isFavorite = false, isOwner = true, onOp
               <Link className="h-3.5 w-3.5" />
               Copy URL
             </DropdownMenuItem>
+            {onOpenFolder && IS_LOCAL && (
+              <DropdownMenuItem onClick={() => onOpenFolder(deck.deckId)}>
+                <FolderOpen className="h-3.5 w-3.5" />
+                Open Folder
+              </DropdownMenuItem>
+            )}
             {onDownload && (
               <DropdownMenuItem onClick={() => onDownload(deck.deckId)}>
                 {IS_LOCAL ? <FolderOpen className="h-3.5 w-3.5" /> : <Download className="h-3.5 w-3.5" />}

--- a/web-ui/src/components/deck/DeckListView.tsx
+++ b/web-ui/src/components/deck/DeckListView.tsx
@@ -63,13 +63,14 @@ interface DeckListViewProps {
   onToggleVisibility?: (deckId: string, visibility: "public" | "private") => void
   onShare?: (deckId: string) => void
   onDownload?: (deckId: string) => void
+  onOpenFolder?: (deckId: string) => void
   loading: boolean
 }
 
 export function DeckListView({
   decks, activeTab, onTabChange, searchQuery, onSearchChange,
   searchResults, searching, onDeckOpen, onNewDeck, favoriteIds,
-  onToggleFavorite, onDelete, onToggleVisibility, onShare, onDownload, loading,
+  onToggleFavorite, onDelete, onToggleVisibility, onShare, onDownload, onOpenFolder, loading,
 }: DeckListViewProps) {
   // Tauri: no server-side slide search; filter decks by name client-side instead.
   const showSearch = !IS_LOCAL && searchQuery.length >= 2
@@ -195,6 +196,7 @@ export function DeckListView({
                   onToggleVisibility={onToggleVisibility}
                   onShare={onShare}
                   onDownload={onDownload}
+                  onOpenFolder={onOpenFolder}
                 />
               ))}
             </div>

--- a/web-ui/src/hooks/useDeckList.ts
+++ b/web-ui/src/hooks/useDeckList.ts
@@ -14,6 +14,7 @@
 "use client"
 
 import { useEffect, useState, useCallback, useRef } from "react"
+import { IS_LOCAL } from "@/lib/mode"
 import {
   listDecks, DeckSummary,
   listPublicDecks, listSharedDecks, listFavorites,
@@ -132,8 +133,17 @@ export function useDeckList(
   const handleDownload = useCallback((deckId: string) => {
     const target = decks.find((d) => d.deckId === deckId)
     if (!target?.pptxUrl) return
-    window.open(target.pptxUrl, "_blank")
+    if (IS_LOCAL) {
+      fetch("/api/open", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ deckId, file: "output.pptx" }) }).catch(() => {})
+    } else {
+      window.open(target.pptxUrl, "_blank")
+    }
   }, [decks])
+
+  const handleOpenFolder = useCallback((deckId: string) => {
+    if (!IS_LOCAL) return
+    fetch("/api/open", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ deckId }) }).catch(() => {})
+  }, [])
 
   const confirmDelete = useCallback(async () => {
     if (!deleteTarget || !idToken) return
@@ -156,7 +166,7 @@ export function useDeckList(
     decks, tabDecks, favoriteIds, activeListTab, setActiveListTab,
     loading, error, deleteTarget, setDeleteTarget,
     searchQuery, setSearchQuery, searchResults, searching,
-    handleToggleFavorite, handleDelete, handleToggleVisibility, handleDownload, confirmDelete,
+    handleToggleFavorite, handleDelete, handleToggleVisibility, handleDownload, handleOpenFolder, confirmDelete,
     setDecks,
   }
 }


### PR DESCRIPTION
### Summary

Fix non-functional "Open PPTX" button on deck list cards in Local mode and add an
"Open Folder" context menu action.

### Problem

The deck list API (/api/decks) did not include pptxUrl in its response, causing
handleDownload to early-return with no effect. Additionally, even if it had
worked, it used window.open which triggers a browser download rather than opening
the file with the OS default app — inconsistent with the workspace (detail) view
behavior.

### Changes

| File | Change |
|------|--------|
| web-ui/src/app/api/decks/route.ts | Add pptxUrl to list response |
| web-ui/src/hooks/useDeckList.ts | Use /api/open API in local mode; add
handleOpenFolder |
| web-ui/src/components/deck/DeckCard.tsx | Add Open Folder to context menu (
IS_LOCAL guard) |
| web-ui/src/components/deck/DeckListView.tsx | Thread onOpenFolder prop |
| web-ui/src/app/(authenticated)/decks/page.tsx | Pass handleOpenFolder |

### Cloud impact

None. All changes are behind IS_LOCAL guards or in /api/ routes (excluded from
cloud build).

### Testing

- [x] tsc --noEmit pass
- [ ] Local mode: Open PPTX from deck list → opens with default app
- [ ] Local mode: Open Folder from deck list → opens deck directory in Finder
- [ ] Cloud build unaffected