### PR TITLE
fix(web-ui): surface agent-level errors in chat UI

### DIFF
--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -892,11 +892,21 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
       if (err instanceof DOMException && err.name === "AbortError") {
         // Keep partial response as-is
       } else {
+        const errorMessage = err instanceof Error ? err.message : String(err)
+        const isRetryable = errorMessage.includes("ThrottlingException") || errorMessage.includes("throttl")
+          || errorMessage.includes("timed out") || errorMessage.includes("timeout")
+          || errorMessage.includes("not ready") || errorMessage.includes("ServiceUnavailable")
+        const isConversationLimit = errorMessage.includes("Too much media") || errorMessage.includes("too long")
+        const displayMessage = isConversationLimit
+          ? "This conversation is too long for the model to process. Please start a new chat to continue."
+          : isRetryable
+            ? "The service is temporarily busy or timed out. Please wait a moment and try again."
+            : "Sorry, something went wrong. Please try again."
         setMessages((prev) => {
           const updated = [...prev]
           updated[updated.length - 1] = {
             ...updated[updated.length - 1],
-            content: "Sorry, something went wrong. Please try again.",
+            content: displayMessage,
           }
           return updated
         })

--- a/web-ui/src/services/strandsParser.js
+++ b/web-ui/src/services/strandsParser.js
@@ -50,6 +50,28 @@ export const parseStreamingChunk = (line, currentCompletion, updateCallback, too
     // Keep-alive
     if (json.keepalive) return currentCompletion;
 
+    // Agent-level error (e.g. Bedrock ValidationException, image/token limit exceeded)
+    if (json.status === 'error' && json.error) {
+      const msg = json.error;
+      let errorMessage;
+      if (msg.includes("Too much media") || msg.includes("too long")) {
+        errorMessage = "⚠️ This conversation is too long for the model to process. Please start a new chat to continue.";
+      } else if (msg.includes("ThrottlingException") || msg.includes("throttl")) {
+        errorMessage = "⚠️ The service is temporarily busy. Please wait a moment and try again.";
+      } else if (msg.includes("ModelTimeoutException") || msg.includes("timed out") || msg.includes("timeout")) {
+        errorMessage = "⚠️ The model took too long to respond. Please try again.";
+      } else if (msg.includes("ModelNotReadyException") || msg.includes("not ready")) {
+        errorMessage = "⚠️ The model is not ready yet. Please wait a moment and try again.";
+      } else if (msg.includes("ServiceUnavailable")) {
+        errorMessage = "⚠️ The service is temporarily unavailable. Please try again later.";
+      } else {
+        errorMessage = `⚠️ ${msg}`;
+      }
+      const newCompletion = currentCompletion + errorMessage;
+      updateCallback(newCompletion);
+      return newCompletion;
+    }
+
     // MCP status event — pass to toolCallback with special type
     if (json.mcp_status) {
       if (toolCallback) toolCallback('__mcp_status__', { mcpStatus: json.mcp_status });


### PR DESCRIPTION
## Summary

Previously, Bedrock API errors (ValidationException, throttling, timeout)
were silently swallowed by the SSE parser, leaving users with an infinite
loading spinner and no feedback.

## Changes

- `strandsParser.js`: Handle `{"status": "error"}` SSE events with
  category-specific user-friendly messages (conversation limit,
  throttling, model timeout, service unavailable, generic)
- `ChatPanel.tsx`: Detect retryable vs conversation-limit errors and
  show appropriate guidance

## Testing

- Verified with a session hitting "Too much media: 101 images > 100"
- UI now shows: "⚠️ This conversation is too long for the model to
  process. Please start a new chat to continue."