### PR TITLE
Add server variant for clients without Server Instructions support

### DIFF
--- a/mcp-local/server_with_instruction.py
+++ b/mcp-local/server_with_instruction.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""MCP Server variant for clients that do NOT read Server Instructions.
+
+Adds a `start_presentation` tool that returns the workflow instructions.
+Clients that support Server Instructions should use server.py instead.
+
+Usage:
+    python server_with_instruction.py
+"""
+
+from server import mcp, _INSTRUCTIONS
+
+
+@mcp.tool()
+def start_presentation() -> str:
+    """REQUIRED FIRST STEP for creating any PowerPoint/presentation/slide deck.
+    Call this before using any other tool when the user wants to create, edit, or modify slides.
+
+    Returns the complete workflow options and step-by-step instructions.
+    """
+    return _INSTRUCTIONS
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary

Adds `mcp-local/server_with_instruction.py` — a thin wrapper over `server.py` for MCP clients (e.g., Amazon Quick) that don't read Server Instructions metadata.

## What it does

- Imports all existing tools from `server.py`
- Adds a `start_presentation` tool that returns the workflow instructions as its response
- Agents are guided to call this tool first via its description: *"REQUIRED FIRST STEP for creating any PowerPoint/presentation/slide deck"*

## Why

Some MCP clients display tools in a flat list without surfacing the server's `instructions` field. Without explicit guidance, agents skip the workflow and jump directly to `generate_pptx`, producing poor results. This variant ensures the workflow is always discoverable regardless of client capability.

## How to use

```
Command: uv
Arguments: run --directory <path>/mcp-local python server_with_instruction.py
Description: Primary tool for creating PowerPoint presentations and slides. Always use this first for any slide or presentation request.
```

## Testing

Verified on Amazon Quick desktop — tools load and `start_presentation` returns correct instructions.
