### PR TITLE
🐛 fix(checks): support directory input for fontSize token check

### DIFF
--- a/skill/references/workflows/create-new-2-compose.md
+++ b/skill/references/workflows/create-new-2-compose.md
@@ -87,10 +87,7 @@ For each slide, think through what to say and how to show it — together.
 
 ### Token Discipline
 
-The **active style** is the Source of Truth for design tokens. Resolution order:
-
-1. `specs/art-direction.html` in the project directory (created by Phase 1) — if present, this is the active style. It is a living document: new tokens can be added during Phase 2 when the design requires values not yet defined (e.g. a new accent color for a diagram, a new font size role). Add the token to `:root` first, then use it in slide JSON.
-2. Global default style from `~/.kiro/local/pptx-assets/styles/` — used as starting point when no project style exists
+The **active style** is `specs/art-direction.html` (created in Phase 1) — the Source of Truth for design tokens. It is a living document: new tokens can be added during Phase 2 when the design requires values not yet defined (e.g. a new accent color for a diagram, a new font size role). Add the token to `:root` first, then use it in slide JSON.
 
 Every `fontSize` and hex color in `presentation.json` **must** come from a token defined in
 the active style's `:root`. No ad-hoc values.

--- a/skill/references/workflows/create-new-2-compose.md
+++ b/skill/references/workflows/create-new-2-compose.md
@@ -89,7 +89,7 @@ For each slide, think through what to say and how to show it — together.
 
 The **active style** is `specs/art-direction.html` (created in Phase 1) — the Source of Truth for design tokens. It is a living document: new tokens can be added during Phase 2 when the design requires values not yet defined (e.g. a new accent color for a diagram, a new font size role). Add the token to `:root` first, then use it in slide JSON.
 
-Every `fontSize` and hex color in `presentation.json` **must** come from a token defined in
+Every `fontSize` and hex color in the slide JSON **must** come from a token defined in
 the active style's `:root`. No ad-hoc values.
 
 - **fontSize** — use only values that appear as `--fs-*` variables (e.g. 14, 20, 24, 28, 36, 48).
@@ -99,9 +99,8 @@ the active style's `:root`. No ad-hoc values.
     Out-of-token values produce warnings (build still succeeds). Resolve before delivery.
 - **hex color** — use only values that appear as `--*` color variables. If the design needs a
   color that doesn't exist, add a new token to art-direction.html first, then use it.
-- Colors embedded in inline directives (e.g. `{{#FF9900:text}}`) are subject to the same rule.
-- After composing all slides, run the project's drift analysis (if available) to verify
-  zero undefined tokens remain.
+  Colors embedded in inline directives (e.g. `{{#FF9900:text}}`) are subject to the same rule.
+  - Not automatically validated at build time — self-check before delivery.
 
 ## Build
 

--- a/skill/sdpm/checks/font_size.py
+++ b/skill/sdpm/checks/font_size.py
@@ -99,7 +99,8 @@ def check_font_size_tokens(
     for slide_idx, slide in enumerate(slides, start=1):
         for path, fs in _walk_font_sizes(slide):
             if fs not in allowed:
-                location = f"page{slide_idx:02d}"
+                slug = slide.get("id", "")
+                location = f"page{slide_idx:02d}({slug})" if slug else f"page{slide_idx:02d}"
                 if path:
                     location += " " + ".".join(path)
                 violations.setdefault(fs, []).append(location)

--- a/skill/sdpm/checks/font_size.py
+++ b/skill/sdpm/checks/font_size.py
@@ -37,6 +37,10 @@ def _walk_font_sizes(node) -> Iterable[tuple[list[str], int]]:
     """Yield (path, fontSize) tuples found anywhere in a JSON-like structure.
 
     `path` is a list of keys/indices for diagnostic display.
+
+    Known limitation: does not detect fontSize specified via inline
+    directives inside text strings (e.g. ``{{14pt:small text}}``).
+    Those are parsed at render time by ``sdpm.utils.text.parse_styled_text``.
     """
     if isinstance(node, dict):
         if "fontSize" in node and isinstance(node["fontSize"], (int, float)):

--- a/skill/sdpm/checks/font_size.py
+++ b/skill/sdpm/checks/font_size.py
@@ -53,11 +53,19 @@ def _walk_font_sizes(node) -> Iterable[tuple[list[str], int]]:
 def find_art_direction(json_path: Path) -> Path | None:
     """Locate `specs/art-direction.html` relative to the slide JSON.
 
-    Looks in the JSON's directory and one level up.
+    Handles both input modes supported by ``sdpm.api._resolve_config``:
+
+    - File input (legacy): ``project/presentation.json`` — look in
+      ``project/specs/`` and one level up.
+    - Directory input (current): ``project/`` containing ``deck.json`` +
+      ``slides/`` — look in ``project/specs/`` and one level up.
+
+    Returns the first existing candidate, or None if not found.
     """
+    base = json_path if json_path.is_dir() else json_path.parent
     candidates = [
-        json_path.parent / "specs" / "art-direction.html",
-        json_path.parent.parent / "specs" / "art-direction.html",
+        base / "specs" / "art-direction.html",
+        base.parent / "specs" / "art-direction.html",
     ]
     for c in candidates:
         if c.exists():
@@ -95,10 +103,17 @@ def check_font_size_tokens(
     if not violations:
         return []
 
+    # Display the art-direction path relative to the deck root (file's parent
+    # or the directory itself) so the warning is easy to locate.
+    display_base = json_path if json_path.is_dir() else json_path.parent
+    try:
+        display_path = art_direction.relative_to(display_base)
+    except ValueError:
+        display_path = art_direction.name
     allowed_str = ", ".join(f"{n}pt" for n in sorted(allowed))
     warnings = [
         f"fontSize token discipline: allowed sizes = [{allowed_str}] "
-        f"(from {art_direction.relative_to(json_path.parent) if json_path.parent in art_direction.parents else art_direction.name})"
+        f"(from {display_path})"
     ]
     for fs in sorted(violations):
         locs = violations[fs]

--- a/tests/test_checks_font_size.py
+++ b/tests/test_checks_font_size.py
@@ -1,0 +1,265 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for sdpm.checks.font_size."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sdpm.checks.font_size import (
+    _walk_font_sizes,
+    check_font_size_tokens,
+    find_art_direction,
+    parse_allowed_font_sizes,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+_ART_DIRECTION_HTML = """<!doctype html>
+<html><head><style>
+:root {
+    --fs-cover-title: 48pt;
+    --fs-slide-title: 32pt;
+    --fs-heading: 24pt;
+    --fs-body: 16pt;
+    --fs-caption: 12pt;
+    --fs-alias: var(--fs-body);  /* var refs should be ignored */
+}
+</style></head><body></body></html>
+"""
+
+_SLIDES_WITH_VIOLATIONS = {
+    "slides": [
+        # Slide 1: valid
+        {"elements": [{"type": "text", "fontSize": 24, "text": "OK"}]},
+        # Slide 2: one violation (22 not allowed)
+        {"elements": [{"type": "text", "fontSize": 22, "text": "BAD"}]},
+        # Slide 3: two violations (18 twice) at different paths
+        {
+            "title": {"fontSize": 18, "text": "bad-title"},
+            "elements": [
+                {"type": "text", "fontSize": 18, "text": "also-bad"},
+                {"type": "text", "fontSize": 16, "text": "good"},
+            ],
+        },
+    ]
+}
+
+_SLIDES_ALL_VALID = {
+    "slides": [
+        {"elements": [{"type": "text", "fontSize": 48}]},
+        {"elements": [{"type": "text", "fontSize": 16}]},
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# parse_allowed_font_sizes
+# ---------------------------------------------------------------------------
+
+class TestParseAllowedFontSizes:
+    def test_extracts_all_tokens(self, tmp_path):
+        p = tmp_path / "art-direction.html"
+        p.write_text(_ART_DIRECTION_HTML, encoding="utf-8")
+        assert parse_allowed_font_sizes(p) == {48, 32, 24, 16, 12}
+
+    def test_missing_file_returns_empty_set(self, tmp_path):
+        assert parse_allowed_font_sizes(tmp_path / "nope.html") == set()
+
+    def test_no_fs_tokens_returns_empty(self, tmp_path):
+        p = tmp_path / "plain.html"
+        p.write_text(":root { --color-primary: #000; }", encoding="utf-8")
+        assert parse_allowed_font_sizes(p) == set()
+
+    def test_var_references_not_captured(self, tmp_path):
+        """`--fs-x: var(--fs-y);` must not be captured as a pt value."""
+        p = tmp_path / "art.html"
+        p.write_text(":root { --fs-base: 16pt; --fs-alias: var(--fs-base); }", encoding="utf-8")
+        assert parse_allowed_font_sizes(p) == {16}
+
+    def test_whitespace_tolerant(self, tmp_path):
+        p = tmp_path / "art.html"
+        p.write_text(":root {\n  --fs-body :   18pt  ;\n}", encoding="utf-8")
+        assert parse_allowed_font_sizes(p) == {18}
+
+
+# ---------------------------------------------------------------------------
+# _walk_font_sizes
+# ---------------------------------------------------------------------------
+
+class TestWalkFontSizes:
+    def test_flat_dict(self):
+        result = list(_walk_font_sizes({"fontSize": 24}))
+        assert result == [([], 24)]
+
+    def test_nested_dict(self):
+        node = {"title": {"fontSize": 32, "text": "hi"}}
+        result = list(_walk_font_sizes(node))
+        assert result == [(["title"], 32)]
+
+    def test_list_indexed(self):
+        node = {"elements": [{"fontSize": 16}, {"fontSize": 20}]}
+        result = list(_walk_font_sizes(node))
+        assert ([("elements"), "[0]"], 16) in [(p, fs) for p, fs in result]
+        paths = [".".join(p) for p, _ in result]
+        assert "elements.[0]" in paths
+        assert "elements.[1]" in paths
+
+    def test_ignores_non_numeric_font_size(self):
+        node = {"fontSize": "large"}
+        assert list(_walk_font_sizes(node)) == []
+
+    def test_float_is_truncated_to_int(self):
+        # Floats are cast to int for comparison (22.9 → 22).
+        result = list(_walk_font_sizes({"fontSize": 22.9}))
+        assert result == [([], 22)]
+
+
+# ---------------------------------------------------------------------------
+# find_art_direction  (regression coverage for directory-input path)
+# ---------------------------------------------------------------------------
+
+class TestFindArtDirection:
+    def _setup_project(self, root: Path) -> Path:
+        """Create a project with specs/art-direction.html. Returns the art path."""
+        specs = root / "specs"
+        specs.mkdir(parents=True)
+        art = specs / "art-direction.html"
+        art.write_text(_ART_DIRECTION_HTML, encoding="utf-8")
+        return art
+
+    def test_file_input_finds_sibling_specs(self, tmp_path):
+        """Legacy file input: presentation.json → project/specs/art-direction.html."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        art = self._setup_project(project)
+        pres = project / "presentation.json"
+        pres.write_text("{}", encoding="utf-8")
+
+        assert find_art_direction(pres) == art
+
+    def test_directory_input_finds_child_specs(self, tmp_path):
+        """Directory input: deck/ → deck/specs/art-direction.html.
+
+        This is the primary MCP agent path and was silently skipping before
+        the fix — this test guards against regression.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        art = self._setup_project(project)
+        (project / "deck.json").write_text("{}", encoding="utf-8")
+        (project / "slides").mkdir()
+
+        assert find_art_direction(project) == art
+
+    def test_file_input_finds_parent_specs(self, tmp_path):
+        """File input where JSON lives in a sub-directory of the project."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        art = self._setup_project(project)
+        sub = project / "build"
+        sub.mkdir()
+        pres = sub / "presentation.json"
+        pres.write_text("{}", encoding="utf-8")
+
+        assert find_art_direction(pres) == art
+
+    def test_directory_input_finds_parent_specs(self, tmp_path):
+        """Directory input where deck lives under the style's parent."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        art = self._setup_project(project)
+        sub = project / "deck"
+        sub.mkdir()
+
+        assert find_art_direction(sub) == art
+
+    def test_returns_none_when_not_found(self, tmp_path):
+        stray = tmp_path / "stray"
+        stray.mkdir()
+        assert find_art_direction(stray) is None
+
+
+# ---------------------------------------------------------------------------
+# check_font_size_tokens — end-to-end
+# ---------------------------------------------------------------------------
+
+class TestCheckFontSizeTokens:
+    def _make_project(self, root: Path, *, layout: str) -> Path:
+        """Create project layout with art-direction.html.
+
+        layout="file": returns path to presentation.json
+        layout="dir":  returns path to project directory
+        """
+        project = root / "proj"
+        project.mkdir()
+        specs = project / "specs"
+        specs.mkdir()
+        (specs / "art-direction.html").write_text(_ART_DIRECTION_HTML, encoding="utf-8")
+
+        if layout == "file":
+            pres = project / "presentation.json"
+            pres.write_text("{}", encoding="utf-8")
+            return pres
+        else:
+            (project / "deck.json").write_text("{}", encoding="utf-8")
+            (project / "slides").mkdir()
+            return project
+
+    def test_file_input_detects_violations(self, tmp_path):
+        path = self._make_project(tmp_path, layout="file")
+        warnings = check_font_size_tokens(_SLIDES_WITH_VIOLATIONS, path)
+
+        assert warnings, "expected violations to be reported"
+        header = warnings[0]
+        assert "fontSize token discipline" in header
+        assert "12pt" in header and "48pt" in header  # allowed set
+        # Two distinct bad sizes: 18 (×2) and 22 (×1)
+        assert any("18pt" in w and "2 occurrence" in w for w in warnings[1:])
+        assert any("22pt" in w and "1 occurrence" in w for w in warnings[1:])
+
+    def test_directory_input_detects_violations(self, tmp_path):
+        """Regression guard: directory input must trigger the check.
+
+        Before the fix, this returned [] because find_art_direction only
+        checked `json_path.parent` and `json_path.parent.parent`, missing
+        the deck-dir/specs/ case.
+        """
+        path = self._make_project(tmp_path, layout="dir")
+        warnings = check_font_size_tokens(_SLIDES_WITH_VIOLATIONS, path)
+
+        assert warnings, "directory input must detect violations after fix"
+        assert "fontSize token discipline" in warnings[0]
+
+    def test_no_violations_returns_empty(self, tmp_path):
+        path = self._make_project(tmp_path, layout="dir")
+        assert check_font_size_tokens(_SLIDES_ALL_VALID, path) == []
+
+    def test_missing_art_direction_skipped(self, tmp_path):
+        # No specs/ at all.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "deck.json").write_text("{}", encoding="utf-8")
+        assert check_font_size_tokens(_SLIDES_WITH_VIOLATIONS, project) == []
+
+    def test_no_fs_tokens_in_style_skipped(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        specs = project / "specs"
+        specs.mkdir()
+        (specs / "art-direction.html").write_text(
+            ":root { --color-primary: #000; }", encoding="utf-8"
+        )
+        assert check_font_size_tokens(_SLIDES_WITH_VIOLATIONS, project) == []
+
+    def test_location_format_includes_page_and_path(self, tmp_path):
+        path = self._make_project(tmp_path, layout="dir")
+        warnings = check_font_size_tokens(_SLIDES_WITH_VIOLATIONS, path)
+
+        # Slide 3 has a violation at `title.fontSize` — verify the path appears.
+        joined = "\n".join(warnings)
+        assert "page02" in joined  # slide 2 (22pt)
+        assert "page03" in joined  # slide 3 (18pt × 2)
+        assert "title" in joined   # nested path from slide 3 title.fontSize


### PR DESCRIPTION
## Summary

Follow-up to #133. Fixes and improvements for the fontSize token discipline check:

1. **Fix: `find_art_direction` handles directory input** — the primary MCP agent path was silently skipping the check
2. **Feat: show slug in violation locations** — `page03(closing)` instead of bare `page03`
3. **Docs: remove fictional paths and correct wording** in Token Discipline section

## Changes

| File | Change |
|---|---|
| `skill/sdpm/checks/font_size.py` | `find_art_direction` branches on `is_dir()`; display path uses correct base; slug shown in locations; known-limitation docstring for inline directives |
| `tests/test_checks_font_size.py` | 21 new tests (parse / walk / resolve / end-to-end for file and directory modes) |
| `skill/references/workflows/create-new-2-compose.md` | Remove `~/.kiro/local/pptx-assets/styles/` (non-existent path); remove "drift analysis" (non-existent feature); `presentation.json` → `the slide JSON`; clarify hex color is not auto-validated |

## Known limitations

related: #135 
- **Inline directives not checked**: `{{14pt:text}}` and `{{#FF9900:text}}` inside `text` strings are parsed at render time by `sdpm.utils.text.parse_styled_text`, not at JSON-walk time. The current check only catches `fontSize` as a JSON key. Documented in code comment.

## Example output (directory input with slugs)

```
fontSize token discipline: allowed sizes = [16pt, 32pt] (from specs/art-direction.html)
  14pt → 1 occurrence(s): page04 elements.[0]
  18pt → 1 occurrence(s): page03(closing) elements.[0]
  22pt → 1 occurrence(s): page01(intro) elements.[0]
```

## Test plan

- [x] `uv run pytest tests/` — 153 passed, 1 skipped
- [x] Smoke test both input modes — identical detection, slug displayed when available
- [x] Ruff clean
