### PR TITLE
Fix argparse crash on Python 3.14

### DIFF
--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -953,7 +953,7 @@ def main():
     p_prev = subparsers.add_parser("preview", help="Export slides as PNG images")
     p_prev.add_argument("input", help="Input JSON file")
     p_prev.add_argument("-p", "--pages", help="Pages to export (e.g. 1,3,5)")
-    p_prev.add_argument("--no-grid", action="store_true", help="Disable 5% grid overlay")
+    p_prev.add_argument("--no-grid", action="store_true", help="Disable 5%% grid overlay")
 
     p_meas = subparsers.add_parser("measure", help="Measure text bounding boxes from slides JSON")
     p_meas.add_argument("input", help="Input JSON file")


### PR DESCRIPTION
## Fix argparse crash on Python 3.14

Escape `%` in argparse help string to prevent `ValueError` on Python 3.14+.

Python 3.14 added validation in `argparse._check_help()` that expands help strings with `%`-formatting at `add_argument()` time. The literal `5%` was interpreted as an invalid format specifier.

### Changes

- `skill/scripts/pptx_builder.py`: `5%` → `5%%` in `--no-grid` help string

Fixes #127