### PR TITLE
✨ feat(compose-slides-precheck): validate spec files before launching…

### DIFF
--- a/agent/modes/separated/composer.py
+++ b/agent/modes/separated/composer.py
@@ -212,6 +212,57 @@ def make_compose_slides(mcp_servers: list, model, composer_mcp_factory=None):
             slide_groups = json.loads(slide_groups)
         parent_tool_use_id = tool_context.tool_use["toolUseId"]
 
+        # Pre-check: verify required spec files exist before launching composers.
+        # Missing files indicate an incomplete Phase 1 — return the earliest
+        # workflow instruction so the SPEC agent resumes from the right sub-phase.
+        if mcp_client:
+            check_code = (
+                "import os, json\n"
+                "files = ['specs/brief.md', 'specs/outline.md', 'deck.json']\n"
+                "art = 'specs/art-direction.html' if os.path.exists('specs/art-direction.html') "
+                "else ('specs/art-direction.md' if os.path.exists('specs/art-direction.md') else None)\n"
+                "missing = [f for f in files if not os.path.exists(f)]\n"
+                "if art is None:\n"
+                "    missing.append('specs/art-direction')\n"
+                "print(json.dumps(missing))\n"
+            )
+            check_result = mcp_client.call_tool_sync(
+                tool_use_id=f"precheck-{uuid.uuid4().hex[:8]}",
+                name="run_python",
+                arguments={"code": check_code, "deck_id": deck_id, "purpose": "spec file existence check"},
+            )
+            missing_files: list[str] = []
+            for item in check_result.get("content", []):
+                if isinstance(item, dict) and "text" in item:
+                    try:
+                        out = json.loads(item["text"])
+                        if isinstance(out, dict) and "output" in out:
+                            missing_files = json.loads(out["output"])
+                        elif isinstance(out, list):
+                            missing_files = out
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+
+            if missing_files:
+                # Map missing files to their workflow (phase order)
+                workflow_map = {
+                    "specs/brief.md": "create-new-1-briefing",
+                    "specs/outline.md": "create-new-1-outline",
+                    "specs/art-direction": "create-new-1-art-direction",
+                    "deck.json": "create-new-1-art-direction",
+                }
+                workflows_needed = dict.fromkeys(
+                    workflow_map[f] for f in missing_files if f in workflow_map
+                )
+                steps = " → ".join(f"`{w}`" for w in workflows_needed)
+                instruction = (
+                    f"Cannot compose: missing {missing_files}. "
+                    f"Complete these workflows in order: {steps}. "
+                    "Do NOT call compose_slides again until ALL spec files exist."
+                )
+                yield json.dumps({"status": "error", "missing_files": missing_files, "instruction": instruction})
+                return
+
         generated = []
         errors = []
         summaries = {}

--- a/mcp-local/upload_tools.py
+++ b/mcp-local/upload_tools.py
@@ -39,6 +39,15 @@ _ALLOWED_URL_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp", "ima
 _SESSION_TTL_DAYS = 7
 
 
+def _convert_webp_to_png(data: bytes) -> bytes:
+    """Convert webp image bytes to PNG for PPTX compatibility."""
+    img = PILImage.open(io.BytesIO(data))
+    img = img.convert("RGBA")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def _deck_root() -> Path:
     return Path(os.environ.get("SDPM_DECK_ROOT", "")) or Path.home() / "Documents" / "SDPM-Presentations"
 
@@ -324,7 +333,13 @@ def _import_from_upload(upload_id: str, deck_id: str, filename: str) -> str:
         dest_name = f"{short_id}_{file_name}"
         if file_type.startswith("image/"):
             images_dir.mkdir(exist_ok=True)
-            shutil.copy2(src_path, images_dir / dest_name)
+            # Convert webp to PNG for PPTX compatibility
+            if src_path.suffix.lower() == ".webp":
+                png_data = _convert_webp_to_png(src_path.read_bytes())
+                dest_name = f"{short_id}_{Path(file_name).stem}.png"
+                (images_dir / dest_name).write_bytes(png_data)
+            else:
+                shutil.copy2(src_path, images_dir / dest_name)
             result["files"].append(f"images/{dest_name}")
             result["image_mapping"][file_name] = f"images/{dest_name}"
         else:
@@ -365,6 +380,11 @@ def _import_from_url(url: str, deck_id: str, filename: str) -> str:
     dest_name = f"{short_id}_{filename}"
     images_dir = deck_dir / "images"
     images_dir.mkdir(exist_ok=True)
+    # Convert webp to PNG for PPTX compatibility
+    if ct == "image/webp" or filename.lower().endswith(".webp"):
+        data = _convert_webp_to_png(data)
+        filename = Path(filename).stem + ".png"
+        dest_name = f"{short_id}_{filename}"
     (images_dir / dest_name).write_bytes(data)
     return json.dumps({
         "source": url,

--- a/mcp-server/tools/attachment.py
+++ b/mcp-server/tools/attachment.py
@@ -14,6 +14,17 @@ _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
 _ALLOWED_URL_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"}
 
 
+def _convert_webp_to_png(data: bytes) -> bytes:
+    """Convert webp image bytes to PNG for PPTX compatibility."""
+    import io
+    from PIL import Image
+    img = Image.open(io.BytesIO(data))
+    img = img.convert("RGBA")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def import_attachment(
     source: str,
     deck_id: str,
@@ -96,6 +107,10 @@ def _import_from_upload(
         data = storage.download_file_from_pptx_bucket(s3_key)
 
         if file_type.startswith("image/"):
+            # Convert webp to PNG for PPTX compatibility
+            if file_name.lower().endswith(".webp"):
+                data = _convert_webp_to_png(data)
+                file_name = file_name.rsplit(".", 1)[0] + ".png"
             dest_name = f"{short_id}_{file_name}"
             dest_key = f"decks/{deck_id}/images/{dest_name}"
             ct = mimetypes.guess_type(file_name)[0] or file_type
@@ -143,6 +158,12 @@ def _import_from_url(url: str, deck_id: str, storage: Storage, filename: str) ->
         filename = basename
 
     dest_name = f"{short_id}_{filename}"
+    # Convert webp to PNG for PPTX compatibility
+    if ct == "image/webp" or filename.lower().endswith(".webp"):
+        data = _convert_webp_to_png(data)
+        filename = filename.rsplit(".", 1)[0] + ".png" if "." in filename else filename + ".png"
+        dest_name = f"{short_id}_{filename}"
+        ct = "image/png"
     dest_key = f"decks/{deck_id}/images/{dest_name}"
     storage.upload_file(key=dest_key, data=data, content_type=ct)
 


### PR DESCRIPTION
## Summary

compose_slides ツール実行前のバリデーションと、画像インポート時の webp→PNG 変換を追加。

## Changes

### 1. Spec file existence check (composer.py)

compose_slides 関数冒頭で必須ファイル（brief.md, outline.md, art-direction.html|md, deck.json）の存在を検証。欠落時は Composer Agent を起動せず、不足ファイルと対応ワークフローの指示をまとめて返却し早期終了する。

- 無駄な Composer 起動によるコスト・時間の浪費を防止
- SPEC Agent が適切なサブフェーズから Phase 1 を再開できる

### 2. WebP → PNG conversion on import (upload_tools.py, attachment.py)

import_attachment（upload 経由・URL 経由）で webp 画像を PNG に変換してから保存。

- python-pptx / OOXML は webp を content type としてサポートしていない
- インポート時に1回変換することでビルド時の追加処理が不要
- Local (Layer 2) / Cloud (Layer 3) の両方に対応

## Testing

- [ ] compose_slides: specs 欠落時にエラー JSON が返り Composer が起動しないことを確認
- [ ] compose_slides: 全 specs 存在時に従来通り動作することを確認
- [ ] import (local): webp ファイルアップロード → PNG として保存されることを確認
- [ ] import (cloud): webp URL インポート → PNG として S3 に保存されることを確認
- [ ] 変換後の PNG が PPTX ビルドで正常に埋め込まれることを確認
