### PR TITLE
Feature/image aspect ratio fit

### DIFF
--- a/skill/references/workflows/slide-json-spec.md
+++ b/skill/references/workflows/slide-json-spec.md
@@ -300,6 +300,10 @@ Height includes the language label (22px). Code body height is `height - 22`.
 
 - `src`: `assets:SOURCE/NAME`, `icons:NAME` (backward compatible), `qr:URL`, file path, relative path
 - `height`: omit to maintain aspect ratio
+- `fit`: `"contain"` (default) | `"cover"` | `"stretch"` — controls sizing when both width and height are specified
+  - `contain`: maintain aspect ratio, fit within the box (may leave gaps)
+  - `cover`: maintain aspect ratio, fill the box (excess is cropped via PowerPoint trim)
+  - `stretch`: ignore aspect ratio, fill the box exactly
 - `labelSize`: default 11
 - `iconColor`: (optional) change SVG icon color. Single-color SVGs only (multi-color icons are ignored)
 

--- a/skill/sdpm/builder/elements/image.py
+++ b/skill/sdpm/builder/elements/image.py
@@ -106,11 +106,41 @@ class ImageMixin:
         # Calculate dimensions
         x = self._px_to_emu(x_pct)
         y = self._px_to_emu(y_pct)
+        fit = elem.get("fit", _DEFAULTS["fit"])
+        cover_crop = None
         
         if width_pct:
             width = self._px_to_emu(width_pct)
             if height_pct:
                 height = self._px_to_emu(height_pct)
+                # Apply fit logic when both dimensions specified
+                if is_svg:
+                    img_w, img_h = get_svg_dimensions(img_path)
+                else:
+                    from PIL import Image
+                    try:
+                        with Image.open(img_path) as img:
+                            img_w, img_h = img.size
+                    except Exception:
+                        img_w, img_h = 1, 1
+                if img_w > 0 and img_h > 0 and fit != "stretch":
+                    img_ratio = img_w / img_h
+                    box_ratio = width / height
+                    if fit == "contain":
+                        if img_ratio > box_ratio:
+                            height = int(width / img_ratio)
+                        else:
+                            width = int(height * img_ratio)
+                    elif fit == "cover":
+                        if img_ratio > box_ratio:
+                            crop_pct = (1 - box_ratio / img_ratio) / 2
+                            cover_crop = {"l": crop_pct, "r": crop_pct, "t": 0, "b": 0}
+                        else:
+                            crop_pct = (1 - img_ratio / box_ratio) / 2
+                            cover_crop = {"l": 0, "r": 0, "t": crop_pct, "b": crop_pct}
+                        # Keep width/height as the box size
+                        width = self._px_to_emu(width_pct)
+                        height = self._px_to_emu(height_pct)
             else:
                 # Maintain original aspect ratio
                 if is_svg:
@@ -137,6 +167,27 @@ class ImageMixin:
                 pic = slide.shapes.add_picture(str(img_path), x, y)
                 width = pic.width
                 height = pic.height
+        
+        # Apply cover crop via srcRect
+        if cover_crop and pic is not None:
+            from lxml import etree
+            from pptx.oxml.ns import qn
+            pic_el = pic._element if hasattr(pic, '_element') else pic
+            blip_fill = pic_el.find(qn('p:blipFill'))
+            if blip_fill is None:
+                blip_fill = pic_el.find(qn('pic:blipFill'))
+            if blip_fill is not None:
+                for sr in blip_fill.findall(qn('a:srcRect')):
+                    blip_fill.remove(sr)
+                src_rect = etree.Element(qn('a:srcRect'))
+                for attr, key in [('l', 'l'), ('t', 't'), ('r', 'r'), ('b', 'b')]:
+                    if cover_crop[key]:
+                        src_rect.set(attr, str(int(cover_crop[key] * 100000)))
+                blip = blip_fill.find(qn('a:blip'))
+                if blip is not None:
+                    blip.addnext(src_rect)
+                else:
+                    blip_fill.insert(0, src_rect)
         
         # Apply rotation
         if rotation != 0:

--- a/skill/sdpm/builder/elements/image.py
+++ b/skill/sdpm/builder/elements/image.py
@@ -123,9 +123,20 @@ class ImageMixin:
                             img_w, img_h = img.size
                     except Exception:
                         img_w, img_h = 1, 1
-                if img_w > 0 and img_h > 0 and fit != "stretch":
+                if img_w > 0 and img_h > 0:
                     img_ratio = img_w / img_h
                     box_ratio = width / height
+                    # Warn if aspect ratios differ significantly
+                    if abs(img_ratio - box_ratio) / max(img_ratio, box_ratio) > 0.05:
+                        sw_h = int(width_pct / img_ratio)  # width-based height
+                        sh_w = int(height_pct * img_ratio)  # height-based width
+                        print(f"Warning: aspect ratio mismatch (fit={fit}): {src}\n"
+                              f"  box {width_pct}×{height_pct} → suggest "
+                              f"width={width_pct}, height={sw_h} or "
+                              f"width={sh_w}, height={height_pct}\n"
+                              f"  (or use fit=\"cover\" to fill with crop, "
+                              f"fit=\"stretch\" to allow distortion)",
+                              file=sys.stderr)
                     if fit == "contain":
                         if img_ratio > box_ratio:
                             height = int(width / img_ratio)

--- a/skill/sdpm/builder/elements/image.py
+++ b/skill/sdpm/builder/elements/image.py
@@ -131,17 +131,15 @@ class ImageMixin:
                         sw_h = int(width_pct / img_ratio)  # width-based height
                         sh_w = int(height_pct * img_ratio)  # height-based width
                         if fit == "cover":
-                            hint = "(cropping applied; or adjust box to suggested size)"
+                            consequence = "image is being cropped"
                         elif fit == "stretch":
-                            hint = "(distortion applied; or adjust box to suggested size)"
+                            consequence = "image is being distorted"
                         else:
-                            hint = ("(or use fit=\"cover\" to fill with crop, "
-                                    "fit=\"stretch\" to allow distortion)")
-                        print(f"Warning: aspect ratio mismatch (fit={fit}): {src}\n"
+                            consequence = "image has padding within the box"
+                        print(f"Warning: {consequence} (fit={fit}): {src}\n"
                               f"  box {width_pct}×{height_pct} → suggest "
                               f"width={width_pct}, height={sw_h} or "
-                              f"width={sh_w}, height={height_pct}\n"
-                              f"  {hint}",
+                              f"width={sh_w}, height={height_pct}",
                               file=sys.stderr)
                     if fit == "contain":
                         if img_ratio > box_ratio:

--- a/skill/sdpm/builder/elements/image.py
+++ b/skill/sdpm/builder/elements/image.py
@@ -137,7 +137,7 @@ class ImageMixin:
                         else:
                             consequence = "image has padding within the box"
                         print(f"Warning: {consequence} (fit={fit}): {src}\n"
-                              f"  box {width_pct}×{height_pct} → suggest "
+                              f"  box {width_pct}×{height_pct} → to preserve aspect ratio: "
                               f"width={width_pct}, height={sw_h} or "
                               f"width={sh_w}, height={height_pct}",
                               file=sys.stderr)

--- a/skill/sdpm/builder/elements/image.py
+++ b/skill/sdpm/builder/elements/image.py
@@ -130,12 +130,18 @@ class ImageMixin:
                     if abs(img_ratio - box_ratio) / max(img_ratio, box_ratio) > 0.05:
                         sw_h = int(width_pct / img_ratio)  # width-based height
                         sh_w = int(height_pct * img_ratio)  # height-based width
+                        if fit == "cover":
+                            hint = "(cropping applied; or adjust box to suggested size)"
+                        elif fit == "stretch":
+                            hint = "(distortion applied; or adjust box to suggested size)"
+                        else:
+                            hint = ("(or use fit=\"cover\" to fill with crop, "
+                                    "fit=\"stretch\" to allow distortion)")
                         print(f"Warning: aspect ratio mismatch (fit={fit}): {src}\n"
                               f"  box {width_pct}×{height_pct} → suggest "
                               f"width={width_pct}, height={sw_h} or "
                               f"width={sh_w}, height={height_pct}\n"
-                              f"  (or use fit=\"cover\" to fill with crop, "
-                              f"fit=\"stretch\" to allow distortion)",
+                              f"  {hint}",
                               file=sys.stderr)
                     if fit == "contain":
                         if img_ratio > box_ratio:

--- a/skill/sdpm/schema/defaults.py
+++ b/skill/sdpm/schema/defaults.py
@@ -58,6 +58,7 @@ ELEMENT_DEFAULTS = {
         "rotation": 0,
         "flipH": False,
         "flipV": False,
+        "fit": "contain",
     },
     "table": {
         "rotation": 0,


### PR DESCRIPTION
## Add `fit` property for image aspect ratio control

### Summary

画像挿入時に `width` と `height` を両方指定した場合、アスペクト比が崩れる問題を修正。
`fit` プロパティを追加し、デフォルトでアスペクト比を維持するようにした。

### Changes

- `fit` プロパティ追加: `contain` (default) / `cover` / `stretch`
  - **contain**: 枠内に収まる最大サイズ（余白あり）
  - **cover**: 枠を埋め、はみ出しを PowerPoint トリミング (srcRect) でクロップ
  - **stretch**: 従来動作（引き伸ばし）
- アスペクト比が5%以上異なる場合にビルド時警告を出力
  - 推奨サイズ（アスペクト比維持）を提示
  - fit モードに応じた結果説明（cropped / distorted / padding）

### Breaking Change

`width` + `height` 両方指定時のデフォルト動作が stretch → contain に変更。
従来の引き伸ばし動作が必要な場合は `"fit": "stretch"` を明示。

### Testing

- 既存テスト 153件 全パス
- `py_compile` 通過
