### PR TITLE
🐛 fix(web-fetch-encoding): use apparent_encoding for charset-less res…

### DIFF
--- a/agent/tools/web_tools.py
+++ b/agent/tools/web_tools.py
@@ -71,6 +71,11 @@ def web_fetch(
         return _handle_pdf(url, response.content, page_start=page_start)
 
     # --- HTML (default) ---
+    # Fix encoding: requests defaults to Latin-1 when charset is not in Content-Type header,
+    # causing mojibake for UTF-8 sites. Use apparent_encoding (charset-normalizer) as fallback.
+    if response.encoding is None or response.encoding.lower().replace("-", "") == "iso88591":
+        response.encoding = response.apparent_encoding
+
     h = html2text.HTML2Text()
     h.ignore_links = False
     h.ignore_images = not include_images


### PR DESCRIPTION
## Fix: web_fetch encoding detection for charset-less responses

### Problem

`web_fetch` produces mojibake (文字化け) when fetching UTF-8 pages whose server returns `Content-Type: text/html` without `charset=utf-8`.

Python's `requests` library defaults to Latin-1 (per RFC 2616) when charset is absent, causing UTF-8 multi-byte sequences to be misinterpreted.

### Root Cause

```
Server response:  Content-Type: text/html  (no charset)
requests default: ISO-8859-1
Result:           UTF-8 bytes decoded as Latin-1 → mojibake
```

### Fix

Before accessing `response.text`, check if encoding is None or the RFC default (ISO-8859-1). If so, override with `response.apparent_encoding` (charset-normalizer statistical detection).

No new dependencies — `charset-normalizer` is already a transitive dependency of `requests`.

### Verification

```
encoding (before): ISO-8859-1
encoding (after):  utf-8
```

Tested with https://yamato-transport-recruit.com/about/top_message/ (Japanese site, no charset in header).
