### PR TITLE
🎯 perf(acp): deduplicate SVG export in run_python post-processing

### DIFF
--- a/mcp-local/server_acp.py
+++ b/mcp-local/server_acp.py
@@ -517,17 +517,7 @@ Audience: Developers
         slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
         return {slug: i + 1 for i, slug in enumerate(slugs)}
 
-    # Post-processing: measure
-    if measure_slides:
-        try:
-            # Call sdpm.api.measure directly with slug list — it resolves slug→page
-            # and reports using slug names via format_measure_report(page_to_slug=...)
-            from sdpm.api import measure as _sdpm_measure
-            result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
-        except Exception as e:
-            result["measure"] = f"Measure error: {e}"
-
-    # Post-processing: build PPTX + preview + SVG compose (when save=True)
+    # Post-processing: build PPTX + SVG (compose/measure) + preview (PDF→PNG)
     _lock_fp = None
     if save:
         # File lock per deck — prevents concurrent saves from corrupting PPTX
@@ -547,7 +537,6 @@ Audience: Developers
 
     if save:
         try:
-            # Force output.pptx inside deck dir (sdpm.api default goes to parent for directory input)
             pptx_out = str(deck_dir / "output.pptx")
             build_result = _generate_pptx(
                 slides_json_path=deck_input, output_path=pptx_out, skill_dir=_SKILL_DIR
@@ -556,6 +545,156 @@ Audience: Developers
         except Exception as e:
             result["pptx_error"] = str(e)
 
+        # SVG output (single invocation) — used by both compose and measure
+        svg_path: Path | None = None
+        pptx_slugs: list[str] = []
+        try:
+            import shutil as _sh
+            from sdpm.preview import get_work_dir
+            lo = _sh.which("soffice")
+            if not lo:
+                _lo_candidates = [
+                    Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+                    Path(r"C:\Program Files\LibreOffice\program\soffice.exe"),
+                ]
+                for _c in _lo_candidates:
+                    if _c.exists():
+                        lo = str(_c)
+                        break
+            pptx_out = result.get("pptx", "")
+            if lo and pptx_out:
+                _svg_tmpdir = tempfile.mkdtemp(dir=get_work_dir(deck_dir))
+                env = dict(os.environ)
+                cmd = [lo, "--headless", "--convert-to", "svg", "--outdir", _svg_tmpdir]
+                if sys.platform == "win32":
+                    cmd.append(f"-env:UserInstallation=file:///{_svg_tmpdir.replace(os.sep, '/')}")
+                else:
+                    env["HOME"] = _svg_tmpdir
+                cmd.append(pptx_out)
+                subprocess.run(cmd, capture_output=True, timeout=120, env=env, stdin=subprocess.DEVNULL)
+                svg_files = list(Path(_svg_tmpdir).glob("*.svg"))
+                if svg_files:
+                    svg_path = svg_files[0]
+        except Exception as e:
+            result["compose_error"] = str(e)
+
+        # Compose: SVG → optimized JSON for WebUI live preview
+        if svg_path:
+            try:
+                from compose import extract_optimized_defs, split_slide_components, count_slides
+                from sdpm.api import parse_outline_slugs
+                import time as _t
+                import re as _re
+                n = count_slides(svg_path)
+                compose_dir = deck_dir / "compose"
+                compose_dir.mkdir(exist_ok=True)
+                epoch = int(_t.time())
+
+                # Index previous compose by slug → latest epoch path
+                prev_by_slug: dict[str, Path] = {}
+                for f in compose_dir.iterdir():
+                    m = _re.match(r"^(.+)_(\d+)\.json$", f.name)
+                    if m and not f.name.startswith("defs_"):
+                        slug, ep = m.group(1), int(m.group(2))
+                        cur = prev_by_slug.get(slug)
+                        if not cur or int(_re.search(r"_(\d+)\.json$", cur.name).group(1)) < ep:
+                            prev_by_slug[slug] = f
+
+                def _mk(c: dict) -> str:
+                    b = c.get("bbox")
+                    return f"{c['class']}|{b['x']},{b['y']},{b['w']},{b['h']}" if b else f"{c['class']}|none"
+
+                def _fp(c: dict) -> str:
+                    return f"{c['class']}|{c.get('text', '')}"
+
+                (compose_dir / f"defs_{epoch}.json").write_text(
+                    json.dumps(extract_optimized_defs(svg_path), ensure_ascii=False),
+                    encoding="utf-8",
+                )
+
+                slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
+                pptx_slugs = [s for s in slugs if (deck_dir / "slides" / f"{s}.json").exists()]
+                if not prev_by_slug:
+                    target_slugs: set[str] = set(pptx_slugs)
+                else:
+                    target_slugs = set(measure_slides or [])
+
+                composed = 0
+                for sn in range(1, n):  # skip DummySlide at index 0
+                    idx = sn - 1
+                    if idx >= len(pptx_slugs):
+                        break
+                    slug = pptx_slugs[idx]
+                    if slug not in target_slugs:
+                        continue
+                    try:
+                        comp_data = split_slide_components(svg_path, sn)
+                        print(f"[compose] svg slide {sn} → slug {slug}", file=__import__('sys').stderr)
+                        prev_file = prev_by_slug.get(slug)
+                        if prev_file and prev_file.exists():
+                            try:
+                                prev_comps = json.loads(prev_file.read_text(encoding="utf-8")).get("components", [])
+                                prev_map = {_mk(c): _fp(c) for c in prev_comps}
+                                for c in comp_data["components"]:
+                                    k = _mk(c)
+                                    c["changed"] = k not in prev_map or prev_map[k] != _fp(c)
+                            except Exception:
+                                for c in comp_data["components"]:
+                                    c["changed"] = True
+                        else:
+                            for c in comp_data["components"]:
+                                c["changed"] = True
+                        (compose_dir / f"{slug}_{epoch}.json").write_text(
+                            json.dumps(comp_data, ensure_ascii=False), encoding="utf-8"
+                        )
+                        composed += 1
+                    except Exception:
+                        pass
+
+                # Cleanup old defs
+                for f in compose_dir.iterdir():
+                    m = _re.match(r"^defs_(\d+)\.json$", f.name)
+                    if m and int(m.group(1)) < epoch:
+                        try:
+                            f.unlink()
+                        except Exception:
+                            pass
+
+                result["compose"] = f"{composed} slides composed"
+                if n <= 2 and len(slugs) > 1:
+                    result["compose_error"] = (
+                        f"LibreOffice exported only {n - 1} slide(s) to SVG but outline has "
+                        f"{len(slugs)} slides. Upgrade LibreOffice to 25.8.6+ (macOS multi-slide SVG fix)."
+                    )
+            except Exception as e:
+                result["compose_error"] = str(e)
+
+        # Measure: reuse SVG from above (no extra LibreOffice call)
+        if measure_slides and svg_path and pptx_slugs:
+            try:
+                from sdpm.preview.measure import measure_from_svg, format_measure_report
+                slug_to_page = {s: i + 1 for i, s in enumerate(pptx_slugs)}
+                page_to_slug = {v: k for k, v in slug_to_page.items()}
+                slide_indices = [slug_to_page[s] for s in measure_slides if s in slug_to_page]
+                if slide_indices:
+                    results = measure_from_svg(svg_path, slide_indices)
+                    result["measure"] = format_measure_report(results, page_to_slug=page_to_slug)
+            except Exception as e:
+                result["measure"] = f"Measure error: {e}"
+        elif measure_slides and not svg_path:
+            # SVG unavailable (no LibreOffice) — fall back to api.measure
+            try:
+                from sdpm.api import measure as _sdpm_measure
+                result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
+            except Exception as e:
+                result["measure"] = f"Measure error: {e}"
+
+        # Cleanup SVG temp dir
+        if svg_path:
+            import shutil as _shutil2
+            _shutil2.rmtree(svg_path.parent, ignore_errors=True)
+
+        # Preview: PDF → PNG (separate LibreOffice call, different format)
         try:
             import shutil as _shutil
             preview_result = _preview(slides_json_path=deck_input, pages="", output_path=str(deck_dir / "output.pptx"))
@@ -569,148 +708,17 @@ Audience: Developers
                     if src.exists():
                         _shutil.copy2(src, preview_dir / src.name)
                 result["preview"] = f"{len(preview_result['files'])} PNGs"
-                # Clean up temp preview dir
                 _shutil.rmtree(preview_result["preview_dir"], ignore_errors=True)
         except Exception as e:
             result["preview_error"] = str(e)
 
-        # SVG compose for WebUI animation (requires LibreOffice 25.8.6+)
+    elif measure_slides:
+        # measure only (save=False) — standalone SVG via api.measure
         try:
-            import shutil as _sh
-            lo = _sh.which("soffice")
-            if not lo:
-                _lo_candidates = [
-                    Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
-                    Path(r"C:\Program Files\LibreOffice\program\soffice.exe"),
-                ]
-                for _c in _lo_candidates:
-                    if _c.exists():
-                        lo = str(_c)
-                        break
-            pptx_out = result.get("pptx", "")
-            if lo and pptx_out:
-                from sdpm.preview import get_work_dir
-                with tempfile.TemporaryDirectory(dir=get_work_dir(deck_dir)) as tmpdir:
-                    env = dict(os.environ)
-                    cmd = [lo, "--headless", "--convert-to", "svg", "--outdir", tmpdir]
-                    if sys.platform == "win32":
-                        cmd.append(f"-env:UserInstallation=file:///{tmpdir.replace(os.sep, '/')}")
-                    else:
-                        env["HOME"] = tmpdir
-                    cmd.append(pptx_out)
-                    subprocess.run(cmd, capture_output=True, timeout=120, env=env, stdin=subprocess.DEVNULL)
-                    svg_files = list(Path(tmpdir).glob("*.svg"))
-                    if svg_files:
-                        from compose import extract_optimized_defs, split_slide_components, count_slides
-                        from sdpm.api import parse_outline_slugs
-                        import time as _t
-                        import re as _re
-                        svg_path = svg_files[0]
-                        n = count_slides(svg_path)
-                        compose_dir = deck_dir / "compose"
-                        compose_dir.mkdir(exist_ok=True)
-                        epoch = int(_t.time())
-
-                        # Index previous compose by slug → latest epoch path
-                        prev_by_slug: dict[str, Path] = {}
-                        if compose_dir.exists():
-                            for f in compose_dir.iterdir():
-                                m = _re.match(r"^(.+)_(\d+)\.json$", f.name)
-                                if m and not f.name.startswith("defs_"):
-                                    slug, ep = m.group(1), int(m.group(2))
-                                    cur = prev_by_slug.get(slug)
-                                    if not cur or int(_re.search(r"_(\d+)\.json$", cur.name).group(1)) < ep:
-                                        prev_by_slug[slug] = f
-
-                        def _mk(c: dict) -> str:
-                            b = c.get("bbox")
-                            return f"{c['class']}|{b['x']},{b['y']},{b['w']},{b['h']}" if b else f"{c['class']}|none"
-
-                        def _fp(c: dict) -> str:
-                            return f"{c['class']}|{c.get('text', '')}"
-
-                        # Write defs_{epoch}.json
-                        (compose_dir / f"defs_{epoch}.json").write_text(
-                            json.dumps(extract_optimized_defs(svg_path), ensure_ascii=False),
-                            encoding="utf-8",
-                        )
-
-                        # Determine which slugs to regenerate:
-                        # - measure_slides (edited this turn) always
-                        # - any slug without existing compose (first build / new slides)
-                        # - first build (no prior compose at all) → regen ALL
-                        # Matches mcp-server (subagent branch) behavior. Deliberately no
-                        # mtime-based detection — parallel composers share deck, so mtime
-                        # would over-fire. Each composer's save=True should target its
-                        # own slug via measure_slides.
-                        slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
-                        # PPTX contains only slugs whose slides/*.json exists
-                        # (builder skips missing). Build a PPTX-order list so
-                        # SVG slide index → slug mapping is correct.
-                        pptx_slugs = [s for s in slugs if (deck_dir / "slides" / f"{s}.json").exists()]
-                        # Strict targeting:
-                        # - measure_slides → compose those
-                        # - On FIRST build (no prior compose at all) → compose all
-                        #   so the initial snapshot has compose for every slide
-                        # - Otherwise: only measure_slides. No implicit "all missing"
-                        #   inclusion — prevents batching when a composer saves
-                        #   after writing multiple slides without per-slide save.
-                        if not prev_by_slug:
-                            target_slugs: set[str] = set(pptx_slugs)
-                        else:
-                            target_slugs = set(measure_slides or [])
-
-                        composed = 0
-                        for sn in range(1, n):  # skip DummySlide at index 0
-                            idx = sn - 1
-                            if idx >= len(pptx_slugs):
-                                break
-                            slug = pptx_slugs[idx]
-                            if slug not in target_slugs:
-                                continue
-                            try:
-                                comp_data = split_slide_components(svg_path, sn)
-                                # Sanity log: slide sn extracted for slug
-                                print(f"[compose] svg slide {sn} → slug {slug} (pptx_slugs={pptx_slugs})", file=__import__('sys').stderr)
-                                # Diff against previous compose for this slug
-                                prev_file = prev_by_slug.get(slug)
-                                if prev_file and prev_file.exists():
-                                    try:
-                                        prev_comps = json.loads(prev_file.read_text(encoding="utf-8")).get("components", [])
-                                        prev_map = {_mk(c): _fp(c) for c in prev_comps}
-                                        for c in comp_data["components"]:
-                                            k = _mk(c)
-                                            c["changed"] = k not in prev_map or prev_map[k] != _fp(c)
-                                    except Exception:
-                                        for c in comp_data["components"]:
-                                            c["changed"] = True
-                                else:
-                                    for c in comp_data["components"]:
-                                        c["changed"] = True
-                                (compose_dir / f"{slug}_{epoch}.json").write_text(
-                                    json.dumps(comp_data, ensure_ascii=False), encoding="utf-8"
-                                )
-                                composed += 1
-                            except Exception:
-                                pass
-
-                        # Cleanup old defs (keep only newest)
-                        for f in compose_dir.iterdir():
-                            m = _re.match(r"^defs_(\d+)\.json$", f.name)
-                            if m and int(m.group(1)) < epoch:
-                                try:
-                                    f.unlink()
-                                except Exception:
-                                    pass
-
-                        result["compose"] = f"{composed} slides composed"
-                        if n <= 2 and len(slugs) > 1:
-                            result["compose_error"] = (
-                                f"LibreOffice exported only {n - 1} slide(s) to SVG but outline has "
-                                f"{len(slugs)} slides. Upgrade LibreOffice to 25.8.6+ (macOS multi-slide SVG fix)."
-                            )
+            from sdpm.api import measure as _sdpm_measure
+            result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
         except Exception as e:
-            result["compose_error"] = str(e)
+            result["measure"] = f"Measure error: {e}"
 
     if _lock_fp is not None:
         try:

--- a/mcp-local/server_acp.py
+++ b/mcp-local/server_acp.py
@@ -511,12 +511,6 @@ Audience: Developers
             errs = result.setdefault("errors", {})
             errs["lintDiagnostics"] = lint_diagnostics
 
-    # Build slug → page number mapping from outline.md (for slug-based measure_slides)
-    def _slug_to_page() -> dict[str, int]:
-        from sdpm.api import parse_outline_slugs
-        slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
-        return {slug: i + 1 for i, slug in enumerate(slugs)}
-
     # Post-processing: build PPTX + SVG (compose/measure) + preview (PDF→PNG)
     _lock_fp = None
     if save:
@@ -547,6 +541,7 @@ Audience: Developers
 
         # SVG output (single invocation) — used by both compose and measure
         svg_path: Path | None = None
+        _svg_tmpdir: str | None = None
         pptx_slugs: list[str] = []
         try:
             import shutil as _sh
@@ -690,9 +685,9 @@ Audience: Developers
                 result["measure"] = f"Measure error: {e}"
 
         # Cleanup SVG temp dir
-        if svg_path:
+        if _svg_tmpdir:
             import shutil as _shutil2
-            _shutil2.rmtree(svg_path.parent, ignore_errors=True)
+            _shutil2.rmtree(_svg_tmpdir, ignore_errors=True)
 
         # Preview: PDF → PNG (separate LibreOffice call, different format)
         try:

--- a/mcp-local/server_acp.py
+++ b/mcp-local/server_acp.py
@@ -540,13 +540,13 @@ Audience: Developers
             result["pptx_error"] = str(e)
 
         # SVG output (single invocation) — used by both compose and measure
+        import shutil
         svg_path: Path | None = None
         _svg_tmpdir: str | None = None
         pptx_slugs: list[str] = []
         try:
-            import shutil as _sh
             from sdpm.preview import get_work_dir
-            lo = _sh.which("soffice")
+            lo = shutil.which("soffice")
             if not lo:
                 _lo_candidates = [
                     Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
@@ -624,7 +624,7 @@ Audience: Developers
                         continue
                     try:
                         comp_data = split_slide_components(svg_path, sn)
-                        print(f"[compose] svg slide {sn} → slug {slug}", file=__import__('sys').stderr)
+                        print(f"[compose] svg slide {sn} → slug {slug}", file=sys.stderr)
                         prev_file = prev_by_slug.get(slug)
                         if prev_file and prev_file.exists():
                             try:
@@ -686,24 +686,22 @@ Audience: Developers
 
         # Cleanup SVG temp dir
         if _svg_tmpdir:
-            import shutil as _shutil2
-            _shutil2.rmtree(_svg_tmpdir, ignore_errors=True)
+            shutil.rmtree(_svg_tmpdir, ignore_errors=True)
 
         # Preview: PDF → PNG (separate LibreOffice call, different format)
         try:
-            import shutil as _shutil
             preview_result = _preview(slides_json_path=deck_input, pages="", output_path=str(deck_dir / "output.pptx"))
             if isinstance(preview_result, dict) and preview_result.get("files"):
                 preview_dir = deck_dir / "preview"
                 if preview_dir.exists():
-                    _shutil.rmtree(preview_dir)
+                    shutil.rmtree(preview_dir)
                 preview_dir.mkdir(exist_ok=True)
                 for png_path in preview_result["files"]:
                     src = Path(png_path)
                     if src.exists():
-                        _shutil.copy2(src, preview_dir / src.name)
+                        shutil.copy2(src, preview_dir / src.name)
                 result["preview"] = f"{len(preview_result['files'])} PNGs"
-                _shutil.rmtree(preview_result["preview_dir"], ignore_errors=True)
+                shutil.rmtree(preview_result["preview_dir"], ignore_errors=True)
         except Exception as e:
             result["preview_error"] = str(e)
 

--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/web-ui/src/app/api/agent/definitions/route.ts
+++ b/web-ui/src/app/api/agent/definitions/route.ts
@@ -24,6 +24,7 @@ interface AgentSelection {
   vibe: string
   composer: string
   single: string
+  model?: string
 }
 
 const DEFAULTS: AgentSelection = {
@@ -65,10 +66,16 @@ function syncToAgentsDir(sel: AgentSelection): void {
   fs.mkdirSync(dest, { recursive: true })
   for (const [role, fixedName] of Object.entries(ROLE_TO_FIXED)) {
     const fileName = sel[role as keyof AgentSelection] || DEFAULTS[role as keyof AgentSelection]
-    if (!isSafeFileName(fileName)) continue
+    if (!fileName || !isSafeFileName(fileName)) continue
     const srcFile = path.join(ACP_AGENTS_DIR, fileName) // nosemgrep: path-join-resolve-traversal
     if (fs.existsSync(srcFile)) {
-      fs.copyFileSync(srcFile, path.join(dest, fixedName))
+      const agent = JSON.parse(fs.readFileSync(srcFile, "utf-8"))
+      if (sel.model) {
+        agent.model = sel.model
+      } else {
+        delete agent.model
+      }
+      fs.writeFileSync(path.join(dest, fixedName), JSON.stringify(agent, null, 2) + "\n")
     }
   }
 }
@@ -100,8 +107,9 @@ export async function GET() {
 /** PUT: update selection and sync to agents/ */
 export async function PUT(req: Request) {
   const body = await req.json()
-  // Validate all values are safe filenames
-  for (const v of Object.values(body)) {
+  // Validate role values are safe filenames (model is a free-form model ID)
+  for (const [k, v] of Object.entries(body)) {
+    if (k === "model") continue
     if (typeof v === "string" && !isSafeFileName(v)) {
       return Response.json({ error: "Invalid filename" }, { status: 400 })
     }

--- a/web-ui/src/components/Settings.tsx
+++ b/web-ui/src/components/Settings.tsx
@@ -32,15 +32,21 @@ export function Settings({ open, onOpenChange }: SettingsProps) {
 
   // ── Local: agent definition selection ──
   interface AgentDef { fileName: string; name: string; description: string }
-  interface AgentSelection { spec: string; vibe: string; composer: string; single: string }
+  interface AgentSelection { spec: string; vibe: string; composer: string; single: string; model?: string }
   const [agentDefs, setAgentDefs] = useState<AgentDef[]>([])
   const [agentSelection, setAgentSelection] = useState<AgentSelection>({ spec: "", vibe: "", composer: "", single: "" })
+  const [localModels, setLocalModels] = useState<{ modelId: string; displayName: string; description?: string }[]>([])
 
   useEffect(() => {
     if (!IS_LOCAL || !open) return
     fetch("/api/agent/definitions").then((r) => r.json()).then((d) => {
       setAgentDefs(d.agents || [])
       setAgentSelection(d.selection || {})
+    }).catch(() => {})
+    fetch("/api/agent/models").then((r) => r.json()).then((d) => {
+      setLocalModels((d.available || []).map((m: { modelId: string; name: string; description?: string }) => ({
+        modelId: m.modelId, displayName: m.name, description: m.description,
+      })))
     }).catch(() => {})
   }, [open])
 
@@ -63,6 +69,26 @@ export function Settings({ open, onOpenChange }: SettingsProps) {
       toast.error(`Failed to update ${role} agent`)
     })
   }, [agentSelection, agentDefs])
+
+  const onLocalModelChange = useCallback((modelId: string | undefined) => {
+    const prev = { ...agentSelection }
+    const next = { ...agentSelection, model: modelId }
+    setAgentSelection(next)
+    fetch("/api/agent/definitions", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: modelId || null }),
+    }).then((r) => {
+      if (!r.ok) throw new Error()
+      const m = localModels.find((a) => a.modelId === modelId)
+      toast.success(m ? `Model: ${m.displayName}` : "Model: default", {
+        description: "Takes effect on next chat.",
+      })
+    }).catch(() => {
+      setAgentSelection(prev)
+      toast.error("Failed to update model")
+    })
+  }, [agentSelection, localModels])
 
   // Silently drop stale selections (admin may have removed the model from config).
   useEffect(() => {
@@ -140,6 +166,24 @@ export function Settings({ open, onOpenChange }: SettingsProps) {
                     </div>
                   )
                 })}
+                {localModels.length > 0 && (
+                  <div>
+                    <label
+                      htmlFor="agent-model"
+                      className="mb-1.5 block text-xs font-medium text-foreground"
+                    >
+                      Model
+                    </label>
+                    <ModelPicker
+                      models={localModels}
+                      value={agentSelection.model || undefined}
+                      onChange={onLocalModelChange}
+                      inheritLabel="Default"
+                      triggerId="agent-model"
+                      ariaLabel="Select agent model"
+                    />
+                  </div>
+                )}
               </div>
             </section>
           )}

--- a/web-ui/src/components/chat/ChatPanelShell.tsx
+++ b/web-ui/src/components/chat/ChatPanelShell.tsx
@@ -26,8 +26,7 @@
 import { useRef, useEffect, useState, useCallback } from "react"
 import { ChatPanel, ChatPanelHandle } from "@/components/chat/ChatPanel"
 import { MessageSquare, PanelRightClose, SquarePen, Layers } from "lucide-react"
-import { LocalOnly, IS_LOCAL } from "@/lib/mode"
-import { ModelSelector } from "./ModelSelector"
+import { IS_LOCAL } from "@/lib/mode"
 
 export type ChatTabKey = "new" | "deck"
 
@@ -273,7 +272,6 @@ export function ChatPanelShell({
                 <MessageSquare className="h-2.5 w-2.5 text-brand-teal" />
               </div>
               <span className="text-sm font-semibold tracking-[-0.01em]">Chat</span>
-              <LocalOnly><ModelSelector /></LocalOnly>
             </div>
             <div className="flex items-center gap-0.5">
               <button

--- a/web-ui/src/components/chat/StyleChatShell.tsx
+++ b/web-ui/src/components/chat/StyleChatShell.tsx
@@ -12,8 +12,6 @@
 import { useRef, useEffect, useState, useCallback } from "react"
 import { StyleChatPanel } from "./StyleChatPanel"
 import { MessageSquare, PanelRightClose } from "lucide-react"
-import { LocalOnly } from "@/lib/mode"
-import { ModelSelector } from "./ModelSelector"
 
 const CHAT_WIDTH_KEY = "sdpm-chat-width"
 const DEFAULT_WIDTH = 440
@@ -124,7 +122,6 @@ export function StyleChatShell({ open, onClose, styleId, styleName, onStyleWritt
                 <span className="text-sm font-semibold tracking-[-0.01em] truncate max-w-[200px]">
                   {styleName || "Style Chat"}
                 </span>
-                <LocalOnly><ModelSelector /></LocalOnly>
               </div>
               <button
                 onClick={onClose}

--- a/web-ui/src/components/deck/AnimatedSlidePreview.tsx
+++ b/web-ui/src/components/deck/AnimatedSlidePreview.tsx
@@ -107,10 +107,7 @@ export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation,
       if (!compUrlBase) return
       if (compUrlBase === lastComposeUrlRef.current) return
       if (animatingRef.current) return  // defer until animation completes
-      // Skip only on the first URL seen after mount (initial load for existing
-      // deck). Subsequent URL changes (user edits) always animate.
-      const isFirstUrl = !lastComposeUrlRef.current
-      const skipThisUpdate = skipRef.current && isFirstUrl
+      const skipThisUpdate = skipRef.current
       lastComposeUrlRef.current = compUrlBase
       setError(false)
 

--- a/web-ui/src/components/deck/AnimatedSlidePreview.tsx
+++ b/web-ui/src/components/deck/AnimatedSlidePreview.tsx
@@ -138,6 +138,10 @@ export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation,
           if (!container || cancelled) return
 
           cleanup()
+          setError(false)
+          // Immediately hide fallback (React re-render is async)
+          const fb = container.parentElement?.querySelector("[data-fallback]") as HTMLElement | null
+          if (fb) fb.style.display = "none"
 
           const animTargets = new Set<number>()
           if (!skipThisUpdate) {
@@ -294,7 +298,7 @@ export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation,
   return (
     <div data-slide-id={slug} className="aspect-[16/9] relative overflow-hidden rounded-lg bg-black">
       <div ref={containerRef} className="absolute inset-0" data-slide-id={slug} />
-      {error && fallback && <div className="absolute inset-0">{fallback}</div>}
+      {error && fallback && <div data-fallback className="absolute inset-0">{fallback}</div>}
     </div>
   )
 }

--- a/web-ui/src/components/deck/AnimatedSlidePreview.tsx
+++ b/web-ui/src/components/deck/AnimatedSlidePreview.tsx
@@ -54,6 +54,7 @@ interface AnimatedSlidePreviewProps {
   composeUrl: string
   slug?: string
   skipAnimation?: boolean
+  knownUrl?: string | null
   onAnimate?: () => void
   onComplete?: () => void
   fallback?: React.ReactNode
@@ -68,7 +69,7 @@ function assignAgent(comp: ComposeComponent) {
   return AGENTS[4]
 }
 
-export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation, onAnimate, onComplete, fallback }: AnimatedSlidePreviewProps) {
+export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation, knownUrl, onAnimate, onComplete, fallback }: AnimatedSlidePreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
   const intervalsRef = useRef<number[]>([])
@@ -92,6 +93,7 @@ export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation,
   const composeUrlRef = useRef(composeUrl)
   const defsUrlRef = useRef(defsUrl)
   const skipRef = useRef(skipAnimation)
+  const knownUrlRef = useRef(knownUrl?.split("?")[0] || null)
   composeUrlRef.current = composeUrl
   defsUrlRef.current = defsUrl
   skipRef.current = skipAnimation
@@ -107,7 +109,7 @@ export function AnimatedSlidePreview({ defsUrl, composeUrl, slug, skipAnimation,
       if (!compUrlBase) return
       if (compUrlBase === lastComposeUrlRef.current) return
       if (animatingRef.current) return  // defer until animation completes
-      const skipThisUpdate = skipRef.current
+      const skipThisUpdate = skipRef.current || compUrlBase === knownUrlRef.current
       lastComposeUrlRef.current = compUrlBase
       setError(false)
 

--- a/web-ui/src/components/deck/SlideCarousel.tsx
+++ b/web-ui/src/components/deck/SlideCarousel.tsx
@@ -74,6 +74,7 @@ export function SlideCarousel({ slides, defsUrl, deckId, deckName, pptxUrl, isLo
   const scrollTargetRef = useRef<string | null | undefined>(undefined)
   const [hadSlidesOnMount] = useState(slides.length > 0)
   const [firstComposeSeen, setFirstComposeSeen] = useState(false)
+  const [knownComposeUrls, setKnownComposeUrls] = useState<Map<string, string>>(new Map())
 
   useEffect(() => {
     let anyChanged = false
@@ -93,6 +94,7 @@ export function SlideCarousel({ slides, defsUrl, deckId, deckName, pptxUrl, isLo
       setFirstComposeSeen(true)
     }
     if (anyChanged) scrollTargetRef.current = null // arm scroll for next onAnimate
+    setKnownComposeUrls(new Map(prevComposeKeys.current))
   }, [slides])
 
   const handleAnimate = useCallback((slug: string) => {
@@ -352,7 +354,7 @@ export function SlideCarousel({ slides, defsUrl, deckId, deckName, pptxUrl, isLo
                 composeUrl={slide.composeUrl}
                 slug={slide.slug}
                 skipAnimation={!settled}
-                knownUrl={prevComposeKeys.current.get(slide.slug) || null}
+                knownUrl={knownComposeUrls.get(slide.slug) || null}
                 onAnimate={() => handleAnimate(slide.slug)}
                 fallback={
                   <SlideThumbnail

--- a/web-ui/src/components/deck/SlideCarousel.tsx
+++ b/web-ui/src/components/deck/SlideCarousel.tsx
@@ -352,6 +352,7 @@ export function SlideCarousel({ slides, defsUrl, deckId, deckName, pptxUrl, isLo
                 composeUrl={slide.composeUrl}
                 slug={slide.slug}
                 skipAnimation={!settled}
+                knownUrl={prevComposeKeys.current.get(slide.slug) || null}
                 onAnimate={() => handleAnimate(slide.slug)}
                 fallback={
                   <SlideThumbnail

--- a/web-ui/src/components/deck/SlideCarousel.tsx
+++ b/web-ui/src/components/deck/SlideCarousel.tsx
@@ -351,7 +351,7 @@ export function SlideCarousel({ slides, defsUrl, deckId, deckName, pptxUrl, isLo
                 defsUrl={defsUrl}
                 composeUrl={slide.composeUrl}
                 slug={slide.slug}
-                skipAnimation={!settled || (hadSlidesOnMount && !firstComposeSeen)}
+                skipAnimation={!settled}
                 onAnimate={() => handleAnimate(slide.slug)}
                 fallback={
                   <SlideThumbnail


### PR DESCRIPTION
## perf/deduplicate-svg-export

### Summary

ACP の `run_python` ポストプロセスで LibreOffice SVG 出力を1回に統合し、compose アニメーションの初回表示バグを修正。

### Changes

**Performance**
- LibreOffice SVG 出力を compose と measure で共有（2回→1回）
- 処理順序を最適化: build → SVG → compose → measure → preview(PDF→PNG)
- compose がライブプレビューなので preview より先に実行

**Bug fixes**
- 初回 compose アニメーションがスキップされる問題を修正（`isFirstUrl` ガード削除、`settled` 3秒ルールのみに簡素化）
- grid→full 切替時に既知の compose が再アニメーションされる問題を修正（`knownUrl` prop 追加）
- compose アニメーション中に PNG fallback が重複表示される問題を軽減

**Feature**
- Settings の Agents セクションにモデル選択を追加（全エージェントに同一モデルを注入）
- チャットパネルのインライン ModelSelector を削除（Settings に一本化）

**Cleanup**
- デッドコード `_slug_to_page()` 削除
- SVG temp dir のクリーンアップ漏れ修正
- Engine version 0.3.1

### Testing

- `uv run pytest tests/ -x -q` — 176 passed, 1 skipped
- `npx tsc --noEmit` — clean
- `uv run ruff check` — clean
