### PR TITLE
🔧 config: bump version to v0.3.2

### DIFF
--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
## Summary

Bump version to v0.3.2.

## What's included (since v0.3.1)

- Template resolution fix: `analyze_template` / `init_presentation` use `get_templates_dirs()` for consistent multi-directory resolution
- MCP Local server architecture refactor: independent mcp instances, `tools.py` as interface layer, `sandbox_tools.py` extraction
- `apply_style` moved to Engine API (`sdpm.api`)
- Deck format: `init()` generates `deck.json` + `slides/` + `specs/`
- `slide-json-spec.md` rewritten for new deck structure
