### PR TITLE
fix: add AWS Marketplace permissions to AgentCore runtime role

### DIFF
--- a/infra/lib/runtime-stack.ts
+++ b/infra/lib/runtime-stack.ts
@@ -164,6 +164,17 @@ export class RuntimeStack extends cdk.Stack {
       })
     );
 
+    // --- AWS Marketplace permissions (required for Bedrock model subscriptions) ---
+    runtimeRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "aws-marketplace:ViewSubscriptions",
+          "aws-marketplace:Subscribe",
+        ],
+        resources: ["*"],
+      })
+    );
+
     // --- KB permissions (Amazon Titan Embed + S3 Vectors + Amazon Bedrock Retrieve) ---
     if (props.vectorBucketName) {
       runtimeRole.addToPolicy(


### PR DESCRIPTION
## Summary

AgentCore runtime role に AWS Marketplace の権限を追加します。

## Problem

AWSアカウントで初めて Bedrock 上のモデルを利用する場合、Marketplace のサブスクリプション関連の権限が不足しているためモデルアクセスがエラーになるケースがありました。

## Changes

- AgentCore の IAM ロールに Marketplace 関連の権限を追加

## Testing

- 新規アカウントでデプロイし、モデルアクセスが正常に動作することを確認済み