### PR TITLE
Fix/cli styles resolve

### DIFF
--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -263,7 +263,12 @@ def cmd_examples(args):
                 if not args.no_browse:
                     open_styles_gallery(styles_dirs)
             else:
-                print("# Copy a style to your project: cp references/examples/styles/{name}.html specs/art-direction.html", file=sys.stderr)
+                from sdpm.api import _find_style_in_dirs
+                src = _find_style_in_dirs(sub, styles_dirs)
+                if src is None:
+                    print(f"# Style not found: {sub}", file=sys.stderr)
+                else:
+                    print(f"# cp {src} specs/art-direction.html")
             continue
 
         # pptx files (components, patterns)

--- a/skill/scripts/pptx_builder.py
+++ b/skill/scripts/pptx_builder.py
@@ -218,7 +218,7 @@ def cmd_list_templates(args):
         print("No templates found.", file=sys.stderr)
         return
     for stem in sorted(seen):
-        print(f"  {stem}")
+        print(f"  {stem}  {seen[stem]}")
 
 
 def cmd_search_patterns(args):


### PR DESCRIPTION
## Fix: CLI style/template path resolution

### Problem
- `examples styles/{name}` printed a hardcoded bundled path, failing to resolve styles in `~/.config/sdpm/styles/`
- `list-templates` showed only stem names without paths, causing agents to search the wrong directories for user-local templates

### Changes
- `examples styles/{name}`: Use `_find_style_in_dirs` to resolve across all styles_dirs (env → user-local → bundled) and print the resolved path
- `list-templates`: Show full resolved path alongside template name

### Impact
- CLI only — MCP Local/Remote use independent code paths (Engine API) and are unaffected
