### PR TITLE
✨ feat(web-ui): default to separated agents mode

### DIFF
--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/web-ui/src/hooks/usePreferences.ts
+++ b/web-ui/src/hooks/usePreferences.ts
@@ -20,7 +20,7 @@ interface Prefs {
   createModelId?: string
 }
 
-const DEFAULTS: Prefs = { sendWithEnter: false, viewMode: "full", fetchWebImages: false, parallelAgents: false, agentMode: "spec" }
+const DEFAULTS: Prefs = { sendWithEnter: false, viewMode: "full", fetchWebImages: false, parallelAgents: true, agentMode: "spec" }
 
 /**
  * Read preferences from localStorage, falling back to defaults.


### PR DESCRIPTION
## Default to separated agents mode

### Change
- `parallelAgents` default flipped from `false` to `true`
- New users get multi-composer agent slide generation by default
- Existing users with saved preferences are unaffected (localStorage persists their choice)

### Scope
- Cloud / Local 共通 (`usePreferences.ts` DEFAULTS)
- Version bump: 0.3.3 → 0.3.4
