### PR TITLE
🐛 fix(lint): skip _comment elements in lint

### DIFF
--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/skill/sdpm/schema/lint.py
+++ b/skill/sdpm/schema/lint.py
@@ -64,6 +64,8 @@ def _diag(slide: int, element: int, rule: str, message: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def _lint_element(si: int, ei: int, elem: dict) -> list[dict]:
+    if "_comment" in elem:
+        return []
     etype = elem.get("type")
     if etype is None:
         return [_diag(si, ei, "missing-type", "element has no 'type' field")]


### PR DESCRIPTION
## Fix: lint skip _comment elements

### Problem
Elements with `_comment` key (used as inline comments in slide JSON) were flagged as `missing-type` lint errors since they have no `type` field.

### Fix
Skip lint validation for any element containing a `_comment` key, consistent with how `diff` already filters them out.

### Version
0.3.4 → 0.3.5
