### PR TITLE
docs: add one-click deploy buttons to deploy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ Choose your environment and follow the setup guide:
 |---|---|
 | Agent skill (Claude Code, Codex CLI, Cursor, Kiro, Copilot) | [Getting Started — Layer 1](docs/en/getting-started.md#layer-1-kiro-cli-skill) |
 | Local MCP client (Claude Desktop, Claude Cowork) | [Getting Started — Layer 2](docs/en/getting-started.md#layer-2-local-mcp-server) |
-| Remote MCP / Web UI (AWS deployment) | [Recommended Deploy Guide](docs/en/deploy-cloudshell.md) |
+| Remote MCP / Web UI (AWS deployment) | [Deploy Guide](docs/en/deploy-cloudshell.md) |
 
-AWS deployment runs from CloudShell or any local shell — no CDK/Docker install required.
+### One-Click Deploy to AWS
+
+| Region | Launch |
+|--------|--------|
+| Tokyo (ap-northeast-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://ap-northeast-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| N. Virginia (us-east-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-east-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| Oregon (us-west-2) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+
+See the [Deploy Guide](docs/en/deploy-cloudshell.md) for parameter details and alternative deployment methods.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Choose your environment and follow the setup guide:
 | Local MCP client (Claude Desktop, Claude Cowork) | [Getting Started — Layer 2](docs/en/getting-started.md#layer-2-local-mcp-server) |
 | Remote MCP / Web UI (AWS deployment) | [Deploy Guide](docs/en/deploy-cloudshell.md) |
 
-### One-Click Deploy to AWS
+### 🚀 One-Click Deploy — Just an AWS Account to Get Started
 
 | Region | Launch |
 |--------|--------|

--- a/README_ja.md
+++ b/README_ja.md
@@ -44,9 +44,17 @@
 |---|---|
 | エージェントスキル（Claude Code, Codex CLI, Cursor, Kiro, Copilot） | [はじめに — Layer 1](docs/ja/getting-started.md#layer-1-kiro-cli-スキル) |
 | ローカル MCP クライアント（Claude Desktop, Claude Cowork） | [はじめに — Layer 2](docs/ja/getting-started.md#layer-2-ローカル-mcp-サーバー) |
-| リモート MCP / Web UI（AWS デプロイ） | [推奨デプロイ手順](docs/ja/deploy-cloudshell.md) |
+| リモート MCP / Web UI（AWS デプロイ） | [デプロイ手順](docs/ja/deploy-cloudshell.md) |
 
-AWS デプロイは CloudShell や任意のローカルシェルから実行でき、CDK/Docker のローカルインストールは不要です。
+### ワンクリックデプロイ
+
+| リージョン | デプロイ |
+|-----------|---------|
+| 東京 (ap-northeast-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://ap-northeast-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| バージニア北部 (us-east-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-east-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| オレゴン (us-west-2) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+
+パラメータの詳細や別のデプロイ方法については [デプロイ手順](docs/ja/deploy-cloudshell.md) を参照してください。
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -46,7 +46,7 @@
 | ローカル MCP クライアント（Claude Desktop, Claude Cowork） | [はじめに — Layer 2](docs/ja/getting-started.md#layer-2-ローカル-mcp-サーバー) |
 | リモート MCP / Web UI（AWS デプロイ） | [デプロイ手順](docs/ja/deploy-cloudshell.md) |
 
-### ワンクリックデプロイ
+### 🚀 AWS アカウントだけですぐに開始！ ワンクリックデプロイ
 
 | リージョン | デプロイ |
 |-----------|---------|

--- a/docs/en/deploy-cloudshell.md
+++ b/docs/en/deploy-cloudshell.md
@@ -1,12 +1,62 @@
 [EN](../en/deploy-cloudshell.md) | [JA](../ja/deploy-cloudshell.md)
 
-# spec-driven-presentation-maker Recommended Deploy Guide
+# spec-driven-presentation-maker Deploy Guide
 
 ## About spec-driven-presentation-maker
 
 spec-driven-presentation-maker is an open-source toolkit that adds presentation generation capabilities to AI agents. Simply connect it as an MCP (Model Context Protocol) tool to your existing AI system, and you can generate slides through conversation. Choose the layer that fits your needs — from a local CLI to a full-stack web app.
 
-This document describes the **recommended way to deploy spec-driven-presentation-maker (SDPM) to AWS**. Because CodeBuild runs the build and deployment, you don't need a local CDK or Docker install, and the same steps work in either of these environments:
+---
+
+## One-Click Deploy (Recommended)
+
+Deploy SDPM to your AWS account with a single click. No local tools or CLI setup required — just sign in to the AWS Console, click the button, fill in the parameters, and wait for completion.
+
+### Prerequisites
+
+- Signed in to the [AWS Management Console](https://console.aws.amazon.com/)
+- **AdministratorAccess** or equivalent permissions in the target account
+
+### Step 1: Click the Launch Stack button
+
+Choose the region closest to you:
+
+| Region | Launch |
+|--------|--------|
+| Tokyo (ap-northeast-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://ap-northeast-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| N. Virginia (us-east-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-east-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| Oregon (us-west-2) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+
+### Step 2: Fill in parameters
+
+The CloudFormation console will display a parameter form. Fill in the following:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| **NotificationEmailAddress** | Email address to receive deployment start/completion notifications | *(required)* |
+| **DeploymentLayer** | `layer3` = MCP Server only, `layer4` = Full stack (Agent + Web UI) | `layer4` |
+| **ModelId** | Bedrock model ID for the Agent (e.g. `global.anthropic.claude-sonnet-4-6`) | `global.anthropic.claude-sonnet-4-6` |
+| **EnableInvocationLogging** | Enable Bedrock Model Invocation Logging (`true` / `false`) | `false` |
+| **AllowedIpV4AddressRanges** | Comma-separated IPv4 CIDR ranges for WAF IP restriction (leave empty for no restriction) | *(empty)* |
+| **AllowedIpV6AddressRanges** | Comma-separated IPv6 CIDR ranges for WAF IP restriction (leave empty for no restriction) | *(empty)* |
+
+> **💡 Tip:** We recommend specifying `AllowedIpV4AddressRanges` to restrict access. You can check your current public IP at [https://checkip.amazonaws.com/](https://checkip.amazonaws.com/). If you don't restrict IPs, the app is publicly accessible but login (Cognito) is still required.
+
+### Step 3: Deploy
+
+1. Check **"I acknowledge that AWS CloudFormation might create IAM resources with custom names."**
+2. Click **Create stack**
+3. Wait for the stack to complete (approximately 30–40 minutes). You'll receive an email notification when done.
+
+> **🌐 Want to try it in your browser right away?** Layer 4 deploys a chat-based Web UI. After deployment, [create a Cognito user](#creating-a-cognito-user-layer-4) and you can start generating slides from your browser immediately.
+
+---
+
+## Deploy using CloudShell
+
+Use this method if you need to **customize deployment options** beyond the one-click parameters (e.g., external IdP, config.yaml overrides, or specific deploy.sh flags).
+
+Because CodeBuild runs the build and deployment, you don't need a local CDK or Docker install, and the same steps work in either of these environments:
 
 - **AWS CloudShell** (fully browser-based)
 - Local **Linux / macOS / WSL** (requires `bash` and the `aws` CLI)
@@ -15,15 +65,13 @@ This document describes the **recommended way to deploy spec-driven-presentation
 
 > **📌 Note:** Deployment settings can be persisted in `infra/config.yaml`, making re-deploys more consistent. Direct local CDK deployment (`npx cdk deploy`) is reserved for development and debugging workflows.
 
-## Prerequisites
+### Prerequisites
 
 - Signed in to the AWS Management Console
 - **AdministratorAccess** or equivalent permissions in the target account (for first deployment)
 - One of the following working environments
     - AWS CloudShell (opened in the target deployment region)
     - Local Linux / macOS / WSL with `bash`, `git`, the `aws` CLI, and valid AWS credentials
-
-## Deploy
 
 ### Quick Start
 
@@ -36,8 +84,6 @@ cd sample-spec-driven-presentation-maker
 chmod +x scripts/deploy.sh
 ./scripts/deploy.sh --region us-east-1
 ```
-
-> **🌐 Want to try it in your browser right away?** Layer 4 deploys a chat-based Web UI. After deployment, [create a Cognito user](#creating-a-cognito-user-layer-4) and you can start generating slides from your browser immediately.
 
 > **💡 Tip:** CloudShell's home directory (1 GB) persists across sessions. For subsequent deployments, run `cd ~/sample-spec-driven-presentation-maker && git pull && ./scripts/deploy.sh --region us-east-1` to update and redeploy.
 

--- a/docs/en/deploy-cloudshell.md
+++ b/docs/en/deploy-cloudshell.md
@@ -48,7 +48,9 @@ The CloudFormation console will display a parameter form. Fill in the following:
 2. Click **Create stack**
 3. Wait for the stack to complete (approximately 30–40 minutes). You'll receive an email notification when done.
 
-> **🌐 Want to try it in your browser right away?** Layer 4 deploys a chat-based Web UI. After deployment, [create a Cognito user](#creating-a-cognito-user-layer-4) and you can start generating slides from your browser immediately.
+### Step 4: Sign in
+
+When deployment completes, a temporary password is sent to the **NotificationEmailAddress** you specified. Open the Web UI URL (included in the notification email or found in CloudFormation Outputs `SdpmWebUi` → `SiteUrl`), sign in with that email and temporary password, and set a new password on first login. That's it — you can start generating slides immediately.
 
 ---
 
@@ -86,6 +88,8 @@ chmod +x scripts/deploy.sh
 ```
 
 > **💡 Tip:** CloudShell's home directory (1 GB) persists across sessions. For subsequent deployments, run `cd ~/sample-spec-driven-presentation-maker && git pull && ./scripts/deploy.sh --region us-east-1` to update and redeploy.
+
+> **📝 Note:** Unlike One-Click Deploy, this method does not automatically create a Cognito user. After deployment, [create a Cognito user manually](#creating-a-cognito-user-layer-4) to sign in to the Web UI.
 
 ### Alternative Configurations
 

--- a/docs/ja/deploy-cloudshell.md
+++ b/docs/ja/deploy-cloudshell.md
@@ -77,7 +77,7 @@ CodeBuild がビルドとデプロイを実行するため、ローカル環境�
 
 ### クイックスタート
 
-CloudShell の場合は AWS コンソールから CloudShell を開き、ローカルの場合は任意のシェルで以下をコピペ実行します。**Layer 4（Agent + Web UI、デフォルト）** が `us-east-1` にデプロイされます。
+CloudShell の場合は AWS コンソールから CloudShell を開き、ローカルの場合は任意のシェルで以下のコマンドを実行します。**Layer 4（Agent + Web UI、デフォルト）** が `us-east-1` にデプロイされます。
 
 ```bash
 cd ~

--- a/docs/ja/deploy-cloudshell.md
+++ b/docs/ja/deploy-cloudshell.md
@@ -1,12 +1,62 @@
 [EN](../en/deploy-cloudshell.md) | [JA](../ja/deploy-cloudshell.md)
 
-# spec-driven-presentation-maker 推奨デプロイ手順
+# spec-driven-presentation-maker デプロイ手順
 
 ## spec-driven-presentation-maker について
 
 spec-driven-presentation-maker は、AI エージェントにプレゼンテーション生成能力を追加するオープンソースツールキットです。MCP（Model Context Protocol）ツールとして既存の AI システムに接続するだけで、対話によるスライド生成が可能になります。ローカル CLI からフルスタック Web アプリまで、ニーズに合ったレイヤーを選んで段階的に採用できます。
 
-本ドキュメントでは、spec-driven-presentation-maker（以下 SDPM）を AWS にデプロイする際の **推奨手順** を説明します。この手順では CodeBuild がビルドとデプロイを実行するため、ローカル環境に CDK や Docker をインストールする必要はありません。また、以下のいずれの環境でも同じ手順でデプロイできます。
+---
+
+## ワンクリックデプロイ（推奨）
+
+ワンクリックで SDPM を AWS アカウントにデプロイできます。ローカル環境や CLI のセットアップは一切不要です。AWS コンソールにログインし、ボタンをクリックして、パラメータを入力するだけで完了します。
+
+### 前提条件
+
+- [AWS マネジメントコンソール](https://console.aws.amazon.com/) にログイン済み
+- デプロイ先アカウントで **AdministratorAccess** 相当の権限があること
+
+### ステップ 1: Launch Stack ボタンをクリック
+
+最寄りのリージョンを選択してください：
+
+| リージョン | デプロイ |
+|-----------|---------|
+| 東京 (ap-northeast-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://ap-northeast-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| バージニア北部 (us-east-1) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-east-1.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+| オレゴン (us-west-2) | [![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=SdpmDeploymentStack&templateURL=https://aws-ml-jp.s3.ap-northeast-1.amazonaws.com/asset-deployments/SdpmDeploymentStack.yaml) |
+
+### ステップ 2: パラメータを入力
+
+CloudFormation コンソールにパラメータ入力画面が表示されます。以下を設定してください：
+
+| パラメータ | 説明 | デフォルト |
+|-----------|------|-----------|
+| **NotificationEmailAddress** | デプロイの開始・完了を通知するメールアドレス | *（必須）* |
+| **DeploymentLayer** | `layer3` = MCP Server のみ、`layer4` = フルスタック（Agent + Web UI） | `layer4` |
+| **ModelId** | Agent が使用する Bedrock モデル ID（例: `global.anthropic.claude-sonnet-4-6`） | `global.anthropic.claude-sonnet-4-6` |
+| **EnableInvocationLogging** | Bedrock Model Invocation Logging の有効/無効（`true` / `false`） | `false` |
+| **AllowedIpV4AddressRanges** | WAF IP 制限用の IPv4 CIDR 範囲（カンマ区切り、空欄で制限なし） | *（空欄）* |
+| **AllowedIpV6AddressRanges** | WAF IP 制限用の IPv6 CIDR 範囲（カンマ区切り、空欄で制限なし） | *（空欄）* |
+
+> **💡 ヒント:** `AllowedIpV4AddressRanges` を指定してアクセスを制限することを推奨します。現在のパブリック IP は [https://checkip.amazonaws.com/](https://checkip.amazonaws.com/) で確認できます。IP 制限を設定しない場合でも、ログインには Cognito 認証が必要です。
+
+### ステップ 3: デプロイ実行
+
+1. **「AWS CloudFormation によって IAM リソースがカスタム名で作成される場合があることを承認します。」** にチェック
+2. **スタックの作成** をクリック
+3. スタックの完了を待ちます（約 30〜40 分）。完了するとメールで通知されます。
+
+> **🌐 ブラウザだけですぐに試したい方はこちら！** Layer 4 をデプロイすると、チャット形式の Web UI が立ち上がります。デプロイ後に [Cognito ユーザーを作成](#cognito-ユーザーの作成layer-4)すれば、ブラウザからすぐにスライド生成を体験できます。
+
+---
+
+## CloudShell を使ったデプロイ
+
+ワンクリックデプロイのパラメータ以上に**カスタマイズしたい場合**（外部 IdP 連携、config.yaml による設定、deploy.sh の各種フラグ活用など）は、こちらの方法を使います。
+
+CodeBuild がビルドとデプロイを実行するため、ローカル環境に CDK や Docker をインストールする必要はありません。以下のいずれの環境でも同じ手順でデプロイできます。
 
 - **AWS CloudShell**（ブラウザだけで完結）
 - ローカル **Linux / macOS / WSL**（`bash` と `aws` CLI があれば OK）
@@ -15,15 +65,13 @@ spec-driven-presentation-maker は、AI エージェントにプレゼンテー�
 
 > **📌 補足:** デプロイ設定は `infra/config.yaml` に保持できるため、再デプロイ時の一貫性を保ちやすくなります。ローカル CDK による直接デプロイ（`npx cdk deploy`）は開発・デバッグ用途に位置付けています。
 
-## 前提条件
+### 前提条件
 
 - AWS マネジメントコンソールにログイン済み
 - デプロイ先アカウントで **AdministratorAccess** 相当の権限があること（初回デプロイ時）
 - 以下いずれかの作業環境
     - AWS CloudShell（デプロイ先リージョンで開く）
     - ローカル Linux / macOS / WSL（`bash`、`git`、`aws` CLI、適切な AWS 認証情報）
-
-## デプロイ
 
 ### クイックスタート
 
@@ -36,8 +84,6 @@ cd sample-spec-driven-presentation-maker
 chmod +x scripts/deploy.sh
 ./scripts/deploy.sh --region us-east-1
 ```
-
-> **🌐 ブラウザだけですぐに試したい方はこちら！** Layer 4 をデプロイすると、チャット形式の Web UI が立ち上がります。デプロイ後に [Cognito ユーザーを作成](#cognito-ユーザーの作成layer-4)すれば、ブラウザからすぐにスライド生成を体験できます。
 
 > **💡 ヒント:** CloudShell のホームディレクトリ（1 GB）はセッション間で永続化されます。2 回目以降は `cd ~/sample-spec-driven-presentation-maker && git pull && ./scripts/deploy.sh --region us-east-1` で最新化＋再デプロイできます。
 

--- a/docs/ja/deploy-cloudshell.md
+++ b/docs/ja/deploy-cloudshell.md
@@ -48,7 +48,9 @@ CloudFormation コンソールにパラメータ入力画面が表示されま�
 2. **スタックの作成** をクリック
 3. スタックの完了を待ちます（約 30〜40 分）。完了するとメールで通知されます。
 
-> **🌐 ブラウザだけですぐに試したい方はこちら！** Layer 4 をデプロイすると、チャット形式の Web UI が立ち上がります。デプロイ後に [Cognito ユーザーを作成](#cognito-ユーザーの作成layer-4)すれば、ブラウザからすぐにスライド生成を体験できます。
+### ステップ 4: ログイン
+
+デプロイ完了後、指定した **NotificationEmailAddress** 宛に仮パスワードが送信されます。通知メールに記載の Web UI URL（または CloudFormation Outputs の `SdpmWebUi` → `SiteUrl`）を開き、メールアドレスと仮パスワードでログインし、初回ログイン時にパスワードを変更すれば完了です。すぐにスライド生成を体験できます。
 
 ---
 
@@ -86,6 +88,8 @@ chmod +x scripts/deploy.sh
 ```
 
 > **💡 ヒント:** CloudShell のホームディレクトリ（1 GB）はセッション間で永続化されます。2 回目以降は `cd ~/sample-spec-driven-presentation-maker && git pull && ./scripts/deploy.sh --region us-east-1` で最新化＋再デプロイできます。
+
+> **📝 補足:** ワンクリックデプロイとは異なり、この方法では Cognito ユーザーが自動作成されません。デプロイ後に [Cognito ユーザーを手動で作成](#cognito-ユーザーの作成layer-4) して Web UI にログインしてください。
 
 ### 別の構成でデプロイする
 


### PR DESCRIPTION
## Summary

Add One-Click Deploy section to the deploy guide (EN/JA) with Launch Stack buttons for 3 regions.

## Changes

- Added **One-Click Deploy (Recommended)** section at the top of both EN and JA deploy docs
- Launch Stack buttons for: ap-northeast-1, us-east-1, us-west-2
- Parameter table explaining each CloudFormation parameter
- Step-by-step guide (login → click → fill params → wait)
- Existing CloudShell-based deploy instructions preserved as **Deploy using CloudShell** for users who need advanced customization (external IdP, config.yaml, WAF flags, etc.)

## Testing

- Verified Launch Stack URLs match the pattern used by [sample-one-click-generative-ai-solutions](https://github.com/aws-samples/sample-one-click-generative-ai-solutions)
- Markdown renders correctly with badge images