### PR TITLE
Fix template API to use uv run python instead of bare python3

### DIFF
--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/web-ui/src/app/api/templates/route.ts
+++ b/web-ui/src/app/api/templates/route.ts
@@ -9,6 +9,9 @@ import { getUserConfigDir, getState, updateState } from "@/lib/local/sdpmPaths"
 /** Bundled templates directory. */
 const BUNDLED_TEMPLATES_DIR = path.resolve(process.cwd(), "..", "skill", "templates")
 
+/** mcp-local directory (uv-managed venv with sdpm deps). */
+const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
+
 /** User-local templates directory. */
 function getUserTemplatesDir(): string {
   return path.join(getUserConfigDir(), "templates")
@@ -29,9 +32,10 @@ export async function GET() {
   function analyzeAndCache(templatePath: string, name: string): Record<string, unknown> {
     try {
       const script = `import sys; sys.path.insert(0, sys.argv[1]); import json; from sdpm.analyzer import analyze_template; r=analyze_template(__import__('pathlib').Path(sys.argv[2])); print(json.dumps({'theme_colors':r.get('theme_colors',{}),'fonts':r.get('fonts',{}),'layout_count':len(r.get('layouts',[]))}))`
-      const result = execFileSync("python3", ["-c", script, skillDir, templatePath], {
+      const result = execFileSync("uv", ["run", "--directory", MCP_LOCAL_DIR, "python", "-c", script, skillDir, templatePath], {
         encoding: "utf-8",
         timeout: 10000,
+        cwd: MCP_LOCAL_DIR,
       })
       const parsed = JSON.parse(result.trim())
       metadata[name] = { ...metadata[name], ...parsed }

--- a/web-ui/src/app/api/templates/user/route.ts
+++ b/web-ui/src/app/api/templates/user/route.ts
@@ -6,6 +6,9 @@ import path from "path"
 import { execFileSync } from "child_process"
 import { getUserConfigDir, getState, updateState } from "@/lib/local/sdpmPaths"
 
+/** mcp-local directory (uv-managed venv with sdpm deps). */
+const MCP_LOCAL_DIR = path.resolve(process.cwd(), "..", "mcp-local")
+
 function getUserTemplatesDir(): string {
   return path.join(getUserConfigDir(), "templates")
 }
@@ -47,9 +50,10 @@ export async function POST(req: Request) {
   try {
     const skillDir = path.resolve(process.cwd(), "..", "skill")
     const script = `import sys; sys.path.insert(0, sys.argv[1]); import json; from sdpm.api import analyze_and_store_template; from pathlib import Path; r=analyze_and_store_template(Path(sys.argv[2]), description=sys.argv[3]); print(json.dumps(r, ensure_ascii=False))`
-    const result = execFileSync("python3", ["-c", script, skillDir, outputPath, description], {
+    const result = execFileSync("uv", ["run", "--directory", MCP_LOCAL_DIR, "python", "-c", script, skillDir, outputPath, description], {
       encoding: "utf-8",
       timeout: 15000,
+      cwd: MCP_LOCAL_DIR,
     })
     meta = JSON.parse(result.trim())
   } catch { /* fallback: minimal metadata */ }


### PR DESCRIPTION
## Summary
web-ui のテンプレート解析 API 2 箇所が bare `python3` を直接呼んでおり、mcp-local venv の `sdpm` 依存を解決できず、install-kit からの Python 撤去後（uv managed Python へ集約）の環境、特に Windows で動作しない。`upload/route.ts` と同じ `uv run --directory <mcp-local> python` 方式に統一する。

## Changes
- `web-ui/src/app/api/templates/route.ts` — `analyzeAndCache` の実行を `uv run` 方式に変更、`MCP_LOCAL_DIR` 定義追加
- `web-ui/src/app/api/templates/user/route.ts` — アップロード解析の実行を `uv run` 方式に変更、`MCP_LOCAL_DIR` 定義追加
- フォールバック（try/catch でメタデータ無し継続）は維持
- bump `0.3.7` → `0.3.8` (PATCH)

リポジトリ全体を走査し、ユーザ実行時の bare `python3` は本2箇所で網羅。`infra/lib/data-stack.ts` の `python3` はデプロイ時 Docker バンドルのローカルフォールバックで文脈が異なるためスコープ外。

## Testing
- `tsc --noEmit` 通過
- 対象2ファイルの eslint 通過
- [ ] システム Python 無し環境での実機動作確認（reviewer/手元で確認推奨）