### PR TITLE
♻️ refactor(relax-outline-lint): allow free-text in outline, warn ins…

### DIFF
--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -662,7 +662,7 @@ def run_python(purpose: str, code: str, deck_id: str | None = None, save: bool =
     if deck_id:
         _check_deck_access(deck_id, action="edit_slide" if save else "read")
 
-    output, outline_rejected, lint_diagnostics = sandbox_mod.execute_in_sandbox(
+    output, outline_warnings, lint_diagnostics = sandbox_mod.execute_in_sandbox(
         code=code,
         storage=_storage,
         region=_region,
@@ -673,9 +673,8 @@ def run_python(purpose: str, code: str, deck_id: str | None = None, save: bool =
 
     result: dict = {"output": output}
 
-    if outline_rejected:
-        errs = result.setdefault("errors", {})
-        errs["outline"] = (
+    if outline_warnings:
+        result.setdefault("warnings", {})["outline"] = (
             "outline.md format violation. "
             "Read workflow `create-new-1-outline` for the correct format."
         )

--- a/mcp-server/tools/sandbox.py
+++ b/mcp-server/tools/sandbox.py
@@ -55,7 +55,7 @@ def execute_in_sandbox(
         files: Additional S3 keys to download into sandbox by basename.
 
     Returns:
-        Tuple of (code execution output, outline_rejected flag).
+        Tuple of (code execution output, outline_warnings list).
 
     Raises:
         ValueError: If save=True without deck_id, or duplicate filenames in files.
@@ -105,15 +105,15 @@ def execute_in_sandbox(
         output = _collect_stream(response)
 
         # Save modified workspace files back to S3
-        outline_rejected = False
+        outline_warnings: list[dict] = []
         lint_diagnostics: list[dict] = []
         if save and deck_id:
-            outline_rejected, lint_diagnostics = _save_deck_workspace(
+            outline_warnings, lint_diagnostics = _save_deck_workspace(
                 client, session_id, storage, deck_id,
             )
             logger.info("Deck workspace saved for deck %s", deck_id)
 
-        return output, outline_rejected, lint_diagnostics
+        return output, outline_warnings, lint_diagnostics
 
     finally:
         client.stop_code_interpreter_session(
@@ -225,16 +225,15 @@ def _save_deck_workspace(
 
     file_map: dict[str, str] = json.loads(raw)
 
-    # Lint outline.md before saving — reject on failure
-    outline_rejected = False
+    # Lint outline.md before saving — warn on failure
+    outline_warnings: list[dict] = []
     outline_key = "specs/outline.md"
     if outline_key in file_map and file_map[outline_key].strip():
         from sdpm.schema.lint_outline import lint_outline
 
-        if lint_outline(file_map[outline_key]):
-            del file_map[outline_key]
-            outline_rejected = True
-            logger.warning("outline.md lint failed for deck %s — not saved", deck_id)
+        outline_warnings = lint_outline(file_map[outline_key])
+        if outline_warnings:
+            logger.warning("outline.md lint warnings for deck %s: %s", deck_id, outline_warnings)
 
     # Lint and sanitize slide JSON before saving
     lint_diagnostics: list[dict] = []
@@ -264,7 +263,7 @@ def _save_deck_workspace(
             content_type=_content_type(rel_path),
         )
 
-    return outline_rejected, lint_diagnostics
+    return outline_warnings, lint_diagnostics
 
 
 def _write_files(client: Any, session_id: str, content: list[dict[str, str]]) -> None:

--- a/skill/sdpm/schema/lint_outline.py
+++ b/skill/sdpm/schema/lint_outline.py
@@ -8,7 +8,6 @@ import re
 
 _SLUG_RE = re.compile(r"^[a-z0-9-]+$")
 _LINE_RE = re.compile(r"^-\s+\[([^\]]+)\]\s+.+")
-_SUB_ITEM_RE = re.compile(r"^-\s+\w[\w_]*:\s")
 
 
 def lint_outline(text: str) -> list[dict]:
@@ -23,12 +22,8 @@ def lint_outline(text: str) -> list[dict]:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
-        # Sub-items (indented `- key: value`) are valid in detailed outlines
-        if line[0] in (" ", "\t") and _SUB_ITEM_RE.match(stripped):
-            continue
         m = _LINE_RE.match(stripped)
         if not m:
-            diagnostics.append({"line": i, "rule": "format"})
             continue
         slug = m.group(1)
         if not _SLUG_RE.match(slug):
@@ -37,5 +32,8 @@ def lint_outline(text: str) -> list[dict]:
             diagnostics.append({"line": i, "rule": "slug-duplicate"})
         else:
             seen_slugs.add(slug)
+
+    if not seen_slugs and not diagnostics:
+        diagnostics.append({"line": 0, "rule": "no-slides"})
 
     return diagnostics

--- a/tests/test_lint_outline.py
+++ b/tests/test_lint_outline.py
@@ -13,11 +13,20 @@ class TestBasicOutline:
         )
         assert lint_outline(text) == []
 
-    def test_invalid_format(self):
-        text = "not a valid line\n"
+    def test_no_slides(self):
+        text = "Just some free text without any slide entries\n"
         diags = lint_outline(text)
         assert len(diags) == 1
-        assert diags[0]["rule"] == "format"
+        assert diags[0]["rule"] == "no-slides"
+
+    def test_free_text_with_slides(self):
+        text = (
+            "Some intro text\n"
+            "- [title] First slide\n"
+            "Random notes here\n"
+            "- [closing] Last slide\n"
+        )
+        assert lint_outline(text) == []
 
     def test_duplicate_slug(self):
         text = (
@@ -72,10 +81,3 @@ class TestDetailedOutline:
             "\t- what_to_say: Key point\n"
         )
         assert lint_outline(text) == []
-
-    def test_non_indented_sub_item_rejected(self):
-        """A sub-item format at column 0 is not valid — must be indented."""
-        text = "- what_to_say: This is not a slug line\n"
-        diags = lint_outline(text)
-        assert len(diags) == 1
-        assert diags[0]["rule"] == "format"


### PR DESCRIPTION
…tead of reject

- Remove 'format' rule: non-slide lines are now silently skipped
- Add 'no-slides' rule: error only when no [slug] entries exist
- MCP Remote: save outline even on lint failure (warn, don't reject)
- Unify behavior with MCP Local (warnings only)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
