### PR TITLE
feat(mcp-local): lockless measure via iso.pptx — remove .save.lock

### DIFF
--- a/mcp-local/sandbox_tools.py
+++ b/mcp-local/sandbox_tools.py
@@ -176,229 +176,227 @@ Audience: Developers
             errs = result.setdefault("errors", {})
             errs["lintDiagnostics"] = lint_diagnostics
 
-    # Post-processing: build PPTX + SVG (compose/measure) + preview
-    _lock_fp = None
+    # Post-processing: build PPTX + iso measure/compose/preview (lockless)
     if save:
-        if sys.platform != "win32":
-            try:
-                import fcntl
-                lock_path = deck_dir / ".save.lock"
-                lock_path.touch(exist_ok=True)
-                _lock_fp = open(lock_path, "r+b")
-                fcntl.flock(_lock_fp.fileno(), fcntl.LOCK_EX)
-            except Exception:
-                if _lock_fp:
-                    _lock_fp.close()
-                    _lock_fp = None
+        import shutil
 
-    if save:
+        from sdpm.api import generate, parse_outline_slugs
+        from sdpm.assets import invalidate_manifest_cache
+        from sdpm.preview import get_work_dir
+
+        invalidate_manifest_cache()
+        _build_warnings: list[str] = []
+        _build_lint: list[dict] = []
+
+        # 1) Full-deck output.pptx — no lock needed (python-pptx write is ~0.2s)
         try:
-            from sdpm.api import generate
-            from sdpm.assets import invalidate_manifest_cache
-            invalidate_manifest_cache()
             pptx_out = str(deck_dir / "output.pptx")
             build_result = generate(json_path=deck_input, output_path=pptx_out)
             result["pptx"] = build_result.get("output_path", pptx_out)
-            # Store for later filtering by measure_slides
             _build_warnings = build_result.get("warnings", [])
             _build_lint = build_result.get("errors", {}).get("lintDiagnostics", [])
         except Exception as e:
             result["pptx_error"] = str(e)
-            _build_warnings = []
-            _build_lint = []
 
-        import shutil
-        svg_path: Path | None = None
-        _svg_tmpdir: str | None = None
-        pptx_slugs: list[str] = []
-        try:
-            from sdpm.preview import get_work_dir
-            lo = shutil.which("soffice")
-            if not lo:
-                _lo_candidates = [
-                    Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
-                    Path(r"C:\Program Files\LibreOffice\program\soffice.exe"),
-                ]
-                for _c in _lo_candidates:
-                    if _c.exists():
-                        lo = str(_c)
-                        break
-            pptx_out = result.get("pptx", "")
-            if lo and pptx_out:
-                _svg_tmpdir = tempfile.mkdtemp(dir=get_work_dir(deck_dir))
-                env = dict(os.environ)
-                cmd = [lo, "--headless", "--convert-to", "svg", "--outdir", _svg_tmpdir]
-                if sys.platform == "win32":
-                    cmd.append(f"-env:UserInstallation=file:///{_svg_tmpdir.replace(os.sep, '/')}")
-                else:
-                    env["HOME"] = _svg_tmpdir
-                cmd.append(pptx_out)
-                subprocess.run(cmd, capture_output=True, timeout=120, env=env, stdin=subprocess.DEVNULL)
-                svg_files = list(Path(_svg_tmpdir).glob("*.svg"))
-                if svg_files:
-                    svg_path = svg_files[0]
-        except Exception as e:
-            result["compose_error"] = str(e)
+        # 2) iso.pptx path: compose + measure + preview for measure_slides only
+        if measure_slides:
+            outline_slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
+            measure_set = set(measure_slides)
+            pptx_slugs = [
+                s for s in outline_slugs
+                if s in measure_set and (deck_dir / "slides" / f"{s}.json").exists()
+            ]
 
-        # Compose: SVG → optimized JSON
-        if svg_path:
+            work_root = get_work_dir(deck_dir)
+            iso_dir = Path(tempfile.mkdtemp(prefix="measure-", dir=work_root))
             try:
-                from compose import extract_optimized_defs, split_slide_components, count_slides
-                from sdpm.api import parse_outline_slugs
-                import time as _t
-                import re as _re
-                n = count_slides(svg_path)
-                compose_dir = deck_dir / "compose"
-                compose_dir.mkdir(exist_ok=True)
-                epoch = int(_t.time())
-
-                prev_by_slug: dict[str, Path] = {}
-                for f in compose_dir.iterdir():
-                    m = _re.match(r"^(.+)_(\d+)\.json$", f.name)
-                    if m and not f.name.startswith("defs_"):
-                        slug, ep = m.group(1), int(m.group(2))
-                        cur = prev_by_slug.get(slug)
-                        if not cur or int(_re.search(r"_(\d+)\.json$", cur.name).group(1)) < ep:
-                            prev_by_slug[slug] = f
-
-                def _mk(c: dict) -> str:
-                    b = c.get("bbox")
-                    return f"{c['class']}|{b['x']},{b['y']},{b['w']},{b['h']}" if b else f"{c['class']}|none"
-
-                def _fp(c: dict) -> str:
-                    return f"{c['class']}|{c.get('text', '')}"
-
-                (compose_dir / f"defs_{epoch}.json").write_text(
-                    json.dumps(extract_optimized_defs(svg_path), ensure_ascii=False),
-                    encoding="utf-8",
+                # Build iso.pptx containing only the target slugs
+                iso_pptx = iso_dir / "iso.pptx"
+                generate(
+                    json_path=deck_input,
+                    output_path=str(iso_pptx),
+                    only_slugs=set(measure_slides),
                 )
 
-                slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
-                pptx_slugs = [s for s in slugs if (deck_dir / "slides" / f"{s}.json").exists()]
-                if not prev_by_slug:
-                    target_slugs: set[str] = set(pptx_slugs)
-                else:
-                    target_slugs = set(measure_slides or [])
+                # Export SVG from iso.pptx
+                svg_path: Path | None = None
+                lo = shutil.which("soffice")
+                if not lo:
+                    _lo_candidates = [
+                        Path("/Applications/LibreOffice.app/Contents/MacOS/soffice"),
+                        Path(r"C:\Program Files\LibreOffice\program\soffice.exe"),
+                    ]
+                    for _c in _lo_candidates:
+                        if _c.exists():
+                            lo = str(_c)
+                            break
 
-                composed = 0
-                for sn in range(1, n):
-                    idx = sn - 1
-                    if idx >= len(pptx_slugs):
-                        break
-                    slug = pptx_slugs[idx]
-                    if slug not in target_slugs:
-                        continue
+                if lo:
+                    env = dict(os.environ)
+                    svg_outdir = str(iso_dir / "svg")
+                    Path(svg_outdir).mkdir()
+                    cmd = [lo, "--headless", "--convert-to", "svg", "--outdir", svg_outdir]
+                    if sys.platform == "win32":
+                        cmd.append(f"-env:UserInstallation=file:///{svg_outdir.replace(os.sep, '/')}")
+                    else:
+                        env["HOME"] = svg_outdir
+                    cmd.append(str(iso_pptx))
+                    subprocess.run(cmd, capture_output=True, timeout=120, env=env, stdin=subprocess.DEVNULL)
+                    svg_files = list(Path(svg_outdir).glob("*.svg"))
+                    if svg_files:
+                        svg_path = svg_files[0]
+
+                # --- Compose: SVG → optimized JSON ---
+                if svg_path:
                     try:
-                        comp_data = split_slide_components(svg_path, sn)
-                        print(f"[compose] svg slide {sn} → slug {slug}", file=sys.stderr)
-                        prev_file = prev_by_slug.get(slug)
-                        if prev_file and prev_file.exists():
-                            try:
-                                prev_comps = json.loads(prev_file.read_text(encoding="utf-8")).get("components", [])
-                                prev_map = {_mk(c): _fp(c) for c in prev_comps}
-                                for c in comp_data["components"]:
-                                    k = _mk(c)
-                                    c["changed"] = k not in prev_map or prev_map[k] != _fp(c)
-                            except Exception:
-                                for c in comp_data["components"]:
-                                    c["changed"] = True
-                        else:
-                            for c in comp_data["components"]:
-                                c["changed"] = True
-                        (compose_dir / f"{slug}_{epoch}.json").write_text(
-                            json.dumps(comp_data, ensure_ascii=False), encoding="utf-8"
+                        from compose import extract_optimized_defs, split_slide_components, count_slides
+                        import time as _t
+                        import re as _re
+
+                        n = count_slides(svg_path)
+                        compose_dir = deck_dir / "compose"
+                        compose_dir.mkdir(exist_ok=True)
+                        epoch = int(_t.time())
+
+                        prev_by_slug: dict[str, Path] = {}
+                        for f in compose_dir.iterdir():
+                            m = _re.match(r"^(.+)_(\d+)\.json$", f.name)
+                            if m and not f.name.startswith("defs_"):
+                                slug_name, ep = m.group(1), int(m.group(2))
+                                cur = prev_by_slug.get(slug_name)
+                                if not cur or int(_re.search(r"_(\d+)\.json$", cur.name).group(1)) < ep:
+                                    prev_by_slug[slug_name] = f
+
+                        def _mk(c: dict) -> str:
+                            b = c.get("bbox")
+                            return f"{c['class']}|{b['x']},{b['y']},{b['w']},{b['h']}" if b else f"{c['class']}|none"
+
+                        def _fp(c: dict) -> str:
+                            return f"{c['class']}|{c.get('text', '')}"
+
+                        (compose_dir / f"defs_{epoch}.json").write_text(
+                            json.dumps(extract_optimized_defs(svg_path), ensure_ascii=False),
+                            encoding="utf-8",
                         )
-                        composed += 1
-                    except Exception:
-                        pass
 
-                for f in compose_dir.iterdir():
-                    m = _re.match(r"^defs_(\d+)\.json$", f.name)
-                    if m and int(m.group(1)) < epoch:
-                        try:
-                            f.unlink()
-                        except Exception:
-                            pass
+                        target_slugs = set(measure_slides)
+                        composed = 0
+                        for sn in range(1, n):
+                            idx = sn - 1
+                            if idx >= len(pptx_slugs):
+                                break
+                            slug = pptx_slugs[idx]
+                            if slug not in target_slugs:
+                                continue
+                            try:
+                                comp_data = split_slide_components(svg_path, sn)
+                                print(f"[compose] svg slide {sn} → slug {slug}", file=sys.stderr)
+                                prev_file = prev_by_slug.get(slug)
+                                if prev_file and prev_file.exists():
+                                    try:
+                                        prev_comps = json.loads(prev_file.read_text(encoding="utf-8")).get("components", [])
+                                        prev_map = {_mk(c): _fp(c) for c in prev_comps}
+                                        for c in comp_data["components"]:
+                                            k = _mk(c)
+                                            c["changed"] = k not in prev_map or prev_map[k] != _fp(c)
+                                    except Exception:
+                                        for c in comp_data["components"]:
+                                            c["changed"] = True
+                                else:
+                                    for c in comp_data["components"]:
+                                        c["changed"] = True
+                                (compose_dir / f"{slug}_{epoch}.json").write_text(
+                                    json.dumps(comp_data, ensure_ascii=False), encoding="utf-8"
+                                )
+                                composed += 1
+                            except Exception:
+                                pass
 
-                result["compose"] = f"{composed} slides composed"
-                if n <= 2 and len(slugs) > 1:
-                    result["compose_error"] = (
-                        f"LibreOffice exported only {n - 1} slide(s) to SVG but outline has "
-                        f"{len(slugs)} slides. Upgrade LibreOffice to 25.8.6+ (macOS multi-slide SVG fix)."
-                    )
-            except Exception as e:
-                result["compose_error"] = str(e)
+                        for f in compose_dir.iterdir():
+                            m = _re.match(r"^defs_(\d+)\.json$", f.name)
+                            if m and int(m.group(1)) < epoch:
+                                try:
+                                    f.unlink()
+                                except Exception:
+                                    pass
 
-        # Measure
-        if measure_slides and svg_path and pptx_slugs:
-            try:
-                from sdpm.preview.measure import measure_from_svg, format_measure_report
-                slug_to_page = {s: i + 1 for i, s in enumerate(pptx_slugs)}
-                page_to_slug = {v: k for k, v in slug_to_page.items()}
-                slide_indices = [slug_to_page[s] for s in measure_slides if s in slug_to_page]
-                if slide_indices:
-                    results = measure_from_svg(svg_path, slide_indices)
-                    result["measure"] = format_measure_report(results, page_to_slug=page_to_slug)
-            except Exception as e:
-                result["measure"] = f"Measure error: {e}"
-        elif measure_slides and not svg_path:
-            try:
-                from sdpm.api import measure as _sdpm_measure
-                result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
-            except Exception as e:
-                result["measure"] = f"Measure error: {e}"
+                        result["compose"] = f"{composed} slides composed"
+                        if n <= 2 and len(outline_slugs) > 1:
+                            result["compose_error"] = (
+                                f"LibreOffice exported only {n - 1} slide(s) to SVG but outline has "
+                                f"{len(outline_slugs)} slides. Upgrade LibreOffice to 25.8.6+ (macOS multi-slide SVG fix)."
+                            )
+                    except Exception as e:
+                        result["compose_error"] = str(e)
 
-        if _svg_tmpdir:
-            shutil.rmtree(_svg_tmpdir, ignore_errors=True)
+                # --- Measure ---
+                if svg_path and pptx_slugs:
+                    try:
+                        from sdpm.preview.measure import measure_from_svg, format_measure_report
+                        slug_to_page = {s: i + 1 for i, s in enumerate(pptx_slugs)}
+                        page_to_slug = {v: k for k, v in slug_to_page.items()}
+                        slide_indices = [slug_to_page[s] for s in measure_slides if s in slug_to_page]
+                        if slide_indices:
+                            results = measure_from_svg(svg_path, slide_indices)
+                            result["measure"] = format_measure_report(results, page_to_slug=page_to_slug)
+                    except Exception as e:
+                        result["measure"] = f"Measure error: {e}"
+                elif not svg_path:
+                    try:
+                        from sdpm.api import measure as _sdpm_measure
+                        result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
+                    except Exception as e:
+                        result["measure"] = f"Measure error: {e}"
 
-        # Preview: PDF → PNG
-        try:
-            from sdpm.api import preview as _preview
-            preview_result = _preview(json_path=deck_input, output_path=str(deck_dir / "output.pptx"))
-            if isinstance(preview_result, dict) and preview_result.get("files"):
-                import shutil as _sh
-                preview_dir = deck_dir / "preview"
-                if preview_dir.exists():
-                    _sh.rmtree(preview_dir)
-                preview_dir.mkdir(exist_ok=True)
-                for png_path in preview_result["files"]:
-                    src = Path(png_path)
-                    if src.exists():
-                        _sh.copy2(src, preview_dir / src.name)
-                _sh.rmtree(preview_result["preview_dir"], ignore_errors=True)
+                # --- Preview: PDF → PNG (slug-named) ---
+                if iso_pptx.exists():
+                    try:
+                        from sdpm.preview import export_pdf
+                        preview_dir = deck_dir / "preview"
+                        preview_dir.mkdir(exist_ok=True)
 
-                # Return filtered preview paths + warnings for measure_slides slugs
-                import re as _re2
-                if measure_slides and pptx_slugs:
-                    slug_to_page_num = {s: i + 1 for i, s in enumerate(pptx_slugs)}
-                    target_pages = {slug_to_page_num[s] for s in measure_slides if s in slug_to_page_num}
-                else:
-                    target_pages = None  # return all
+                        pdf_path = iso_dir / "slides.pdf"
+                        if export_pdf(iso_pptx, pdf_path, work_dir=iso_dir):
+                            png_outdir = iso_dir / "pngs"
+                            png_outdir.mkdir()
+                            cmd_png = ["pdftoppm", "-png", "-scale-to", "1280", str(pdf_path), str(png_outdir / "page")]
+                            subprocess.run(cmd_png, capture_output=True, text=True, stdin=subprocess.DEVNULL)
 
-                # Filter preview files
-                all_previews = sorted(preview_dir.iterdir())
-                filtered_previews = []
-                for f in all_previews:
-                    if not f.name.endswith(".png"):
-                        continue
-                    m = _re2.match(r"^page(\d+)[-.]", f.name)
-                    if m:
-                        if target_pages is None or int(m.group(1)) in target_pages:
-                            filtered_previews.append(str(f))
-                result["preview_files"] = filtered_previews
+                            filtered_previews = []
+                            for idx_p, slug in enumerate(pptx_slugs):
+                                src_png = png_outdir / f"page-{idx_p + 1:06d}.png"
+                                if not src_png.exists():
+                                    src_png = png_outdir / f"page-{idx_p + 1:02d}.png"
+                                if not src_png.exists():
+                                    src_png = png_outdir / f"page-{idx_p + 1:03d}.png"
+                                if src_png.exists():
+                                    dst = preview_dir / f"{slug}.png"
+                                    shutil.copy2(src_png, dst)
+                                    filtered_previews.append(str(dst))
+                            result["preview_files"] = filtered_previews
+                    except Exception as e:
+                        result["preview_error"] = str(e)
 
-                # Filter warnings
-                if target_pages is not None:
+                # Filter warnings/lint to measured slugs
+                if _build_warnings or _build_lint:
+                    slug_to_page_full = {}
+                    all_slugs = [s for s in outline_slugs if (deck_dir / "slides" / f"{s}.json").exists()]
+                    for i, s in enumerate(all_slugs):
+                        slug_to_page_full[s] = i + 1
+                    target_pages = {slug_to_page_full[s] for s in measure_slides if s in slug_to_page_full}
                     page_pats = {f"page{p:02d}" for p in target_pages}
                     result["warnings"] = [w for w in _build_warnings if any(p in w for p in page_pats)]
                     result["lint_diagnostics"] = [d for d in _build_lint if any(p in str(d) for p in page_pats)]
-                else:
-                    if _build_warnings:
-                        result["warnings"] = _build_warnings
-                    if _build_lint:
-                        result["lint_diagnostics"] = _build_lint
-        except Exception as e:
-            result["preview_error"] = str(e)
+
+            finally:
+                shutil.rmtree(iso_dir, ignore_errors=True)
+
+        else:
+            # save=True without measure_slides: output.pptx only, skip compose/measure/preview
+            if _build_warnings:
+                result["warnings"] = _build_warnings
+            if _build_lint:
+                result["lint_diagnostics"] = _build_lint
 
     elif measure_slides:
         try:
@@ -406,14 +404,6 @@ Audience: Developers
             result["measure"] = _sdpm_measure(json_path=deck_input, slides=list(measure_slides))
         except Exception as e:
             result["measure"] = f"Measure error: {e}"
-
-    if _lock_fp is not None:
-        try:
-            import fcntl as _fc
-            _fc.flock(_lock_fp.fileno(), _fc.LOCK_UN)
-            _lock_fp.close()
-        except Exception:
-            pass
 
     return json.dumps(result, ensure_ascii=False)
 

--- a/skill/sdpm/api.py
+++ b/skill/sdpm/api.py
@@ -335,11 +335,16 @@ class BuildConfig:
     lint_diagnostics: list = field(default_factory=list)
 
 
-def _assemble_slides_from_dir(deck_dir: Path) -> tuple[dict, list[dict]]:
+def _assemble_slides_from_dir(
+    deck_dir: Path,
+    only_slugs: set[str] | None = None,
+) -> tuple[dict, list[dict]]:
     """Assemble presentation dict from deck.json + outline.md + slides/*.json.
 
     Args:
         deck_dir: Directory containing deck.json, specs/outline.md, slides/*.
+        only_slugs: When set, include only the specified slugs (preserving
+            outline order). None means include all.
 
     Returns:
         (deck_meta, slides) where deck_meta has template/fonts/defaultTextColor
@@ -353,6 +358,8 @@ def _assemble_slides_from_dir(deck_dir: Path) -> tuple[dict, list[dict]]:
     deck_meta = read_json(deck_json)
 
     slugs = parse_outline_slugs(deck_dir / "specs" / "outline.md")
+    if only_slugs is not None:
+        slugs = [s for s in slugs if s in only_slugs]
 
     slides: list[dict] = []
     for slug in slugs:
@@ -390,11 +397,18 @@ def parse_outline_slugs(outline_path: Path) -> list[str]:
     return slugs
 
 
-def _resolve_config(json_path: str | Path) -> BuildConfig:
+def _resolve_config(
+    json_path: str | Path,
+    only_slugs: set[str] | None = None,
+) -> BuildConfig:
     """Resolve template, fonts, icons, overrides from JSON or directory.
 
     Accepts either a presentation.json file path (legacy) or a directory
     containing deck.json + specs/outline.md + slides/*.json (new format).
+
+    Args:
+        json_path: Path to presentation.json or deck directory.
+        only_slugs: When set, include only the specified slugs in the build.
 
     Raises FileNotFoundError, ValueError on missing template/icons.
     """
@@ -407,7 +421,7 @@ def _resolve_config(json_path: str | Path) -> BuildConfig:
 
     # Directory input: deck.json + slides/*.json
     if input_path.is_dir():
-        deck_meta, slides = _assemble_slides_from_dir(input_path)
+        deck_meta, slides = _assemble_slides_from_dir(input_path, only_slugs=only_slugs)
         data = {**deck_meta, "slides": slides}
         base_dir = input_path
     else:
@@ -463,6 +477,10 @@ def _resolve_config(json_path: str | Path) -> BuildConfig:
             id_map[s["id"]] = s
     resolved_slides = [resolve_override(s, id_map) for s in slides]
 
+    # Filter by only_slugs for legacy JSON path (directory path already filtered)
+    if only_slugs is not None and not input_path.is_dir():
+        resolved_slides = [s for s in resolved_slides if s.get("id") in only_slugs]
+
     return BuildConfig(
         template_path=template_file,
         custom_template=custom,
@@ -495,6 +513,7 @@ def _build(config: BuildConfig, output_path: Path) -> Path:
 def generate(
     json_path: str | Path,
     output_path: str | Path | None = None,
+    only_slugs: set[str] | None = None,
 ) -> dict[str, Any]:
     """Generate PPTX from JSON.
 
@@ -503,13 +522,14 @@ def generate(
     Args:
         json_path: Path to the slides JSON file.
         output_path: Output .pptx path. Auto-generated if None.
+        only_slugs: When set, build only the specified slugs (for iso.pptx).
 
     Returns:
         Dict with output_path, slide_count, slides summary, warnings.
     """
     from sdpm.preview import check_layout_imbalance_data
 
-    config = _resolve_config(json_path)
+    config = _resolve_config(json_path, only_slugs=only_slugs)
 
     # Output path
     input_path = Path(json_path)

--- a/tests/test_only_slugs.py
+++ b/tests/test_only_slugs.py
@@ -1,0 +1,102 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for only_slugs filtering in generate() and _assemble_slides_from_dir.
+
+Validates Task 8 (asset/template resolution with only_slugs) and
+Task 9 (multiple slug batch) from the lockless-measure spec.
+"""
+
+import json
+from pathlib import Path
+
+from sdpm.api import generate, _assemble_slides_from_dir
+
+
+def _make_multi_slide_deck(tmp_path: Path, slugs: list[str]) -> Path:
+    """Write a deck directory with multiple slides."""
+    deck = tmp_path / "deck"
+    (deck / "slides").mkdir(parents=True)
+    (deck / "specs").mkdir()
+    (deck / "deck.json").write_text(json.dumps({
+        "template": "blank-dark.pptx",
+        "fonts": {"fullwidth": "Meiryo", "halfwidth": "Arial"},
+        "defaultTextColor": "#FFFFFF",
+    }))
+    outline_lines = [f"- [{s}] Slide {s}\n" for s in slugs]
+    (deck / "specs" / "outline.md").write_text("".join(outline_lines))
+    for s in slugs:
+        (deck / "slides" / f"{s}.json").write_text(json.dumps({
+            "layout": "Blank",
+            "elements": [
+                {"type": "textbox", "text": f"Content of {s}",
+                 "x": 100, "y": 100, "width": 800, "height": 80, "fontSize": 28},
+            ],
+        }, ensure_ascii=False))
+    return deck
+
+
+class TestAssembleSlidesOnlySlugs:
+    """Unit tests for _assemble_slides_from_dir with only_slugs."""
+
+    def test_none_returns_all_slides(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details", "closing"])
+        _, slides = _assemble_slides_from_dir(deck, only_slugs=None)
+        assert len(slides) == 4
+        assert [s["id"] for s in slides] == ["title", "intro", "details", "closing"]
+
+    def test_single_slug_filter(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details", "closing"])
+        _, slides = _assemble_slides_from_dir(deck, only_slugs={"intro"})
+        assert len(slides) == 1
+        assert slides[0]["id"] == "intro"
+
+    def test_multiple_slugs_preserves_outline_order(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details", "closing"])
+        _, slides = _assemble_slides_from_dir(deck, only_slugs={"closing", "title"})
+        assert len(slides) == 2
+        assert [s["id"] for s in slides] == ["title", "closing"]
+
+    def test_nonexistent_slug_is_ignored(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro"])
+        _, slides = _assemble_slides_from_dir(deck, only_slugs={"title", "nonexistent"})
+        assert len(slides) == 1
+        assert slides[0]["id"] == "title"
+
+    def test_empty_set_returns_no_slides(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro"])
+        _, slides = _assemble_slides_from_dir(deck, only_slugs=set())
+        assert len(slides) == 0
+
+
+class TestGenerateOnlySlugs:
+    """Integration tests: generate() with only_slugs produces correct PPTX."""
+
+    def test_generate_single_slug(self, tmp_path):
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details"])
+        out_pptx = tmp_path / "out.pptx"
+        result = generate(deck, output_path=out_pptx, only_slugs={"intro"})
+        assert result["slide_count"] == 1
+        assert Path(result["output_path"]).exists()
+
+    def test_generate_multiple_slugs(self, tmp_path):
+        """Task 9: multiple slug batch (Consistency review scenario)."""
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details", "closing"])
+        out_pptx = tmp_path / "out.pptx"
+        result = generate(deck, output_path=out_pptx, only_slugs={"title", "details", "closing"})
+        assert result["slide_count"] == 3
+
+    def test_generate_none_builds_all(self, tmp_path):
+        """Backward compatibility: only_slugs=None builds everything."""
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details"])
+        out_pptx = tmp_path / "out.pptx"
+        result = generate(deck, output_path=out_pptx, only_slugs=None)
+        assert result["slide_count"] == 3
+
+    def test_generate_iso_produces_valid_pptx(self, tmp_path):
+        """Task 8: iso.pptx resolves template/assets correctly with only_slugs."""
+        deck = _make_multi_slide_deck(tmp_path, ["title", "intro", "details"])
+        iso_pptx = tmp_path / "iso.pptx"
+        result = generate(deck, output_path=iso_pptx, only_slugs={"details"})
+        assert Path(result["output_path"]).exists()
+        assert Path(result["output_path"]).stat().st_size > 0
+        assert result["slide_count"] == 1

--- a/web-ui/src/app/api/decks/[id]/route.ts
+++ b/web-ui/src/app/api/decks/[id]/route.ts
@@ -52,13 +52,15 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
     ? outlineText.split("\n").map(l => /^-\s*\[([a-z0-9-]+)\]/.exec(l)?.[1]).filter((s): s is string => !!s)
     : []
 
-  // Index preview PNGs
+  // Index preview PNGs — supports both slug-named ({slug}.png) and legacy page-numbered (page{N}-*.png)
+  const previewBySlug = new Map<string, string>()
   const previewByPage = new Map<number, string>()
   const previewDir = path.join(dp, "preview")
   if (fs.existsSync(previewDir)) {
     for (const f of fs.readdirSync(previewDir)) {
       if (!f.endsWith(".png")) continue
-      const m = f.match(/^page(\d+)[-.]/); if (m) previewByPage.set(parseInt(m[1]), f)
+      const pageMatch = f.match(/^page(\d+)[-.]/); if (pageMatch) { previewByPage.set(parseInt(pageMatch[1]), f); continue }
+      const slugMatch = f.match(/^([a-z0-9-]+)\.png$/); if (slugMatch) previewBySlug.set(slugMatch[1], f)
     }
   }
 
@@ -73,7 +75,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
       if (!fs.existsSync(path.join(slidesDir, `${slug}.json`))) continue
       pageNum++
       const composeFile = composeBySlug.get(slug)
-      const previewFile = previewByPage.get(pageNum)
+      const previewFile = previewBySlug.get(slug) || previewByPage.get(pageNum)
       slides.push({
         slug,
         previewUrl: previewFile ? `/api/preview/${deckId}/preview/${previewFile}` : null,


### PR DESCRIPTION
## Summary

- **Remove `.save.lock` / `fcntl` file locking** from `run_python(save=True)` — the deck-wide exclusive lock that serialized all concurrent composers (6-9s LibreOffice hold time) is no longer needed
- **Add `only_slugs` parameter** to Engine's `generate()` / `_resolve_config` / `_assemble_slides_from_dir` — builds a PPTX containing only the specified slides
- **Introduce iso.pptx isolation** in MCP Local: when `measure_slides` is specified, a unique tempdir iso.pptx is built for just those slugs, then SVG export → compose + measure + preview all operate on that isolated file (structurally lock-free — no other process can access the tempdir path)
- **Slug-named preview PNGs** (`{slug}.png` instead of `page{N}-*.png`) — stable across reorders, no full-directory wipe on parallel saves
- **Web UI route.ts** updated to prefer slug-named previews with page-numbered fallback

## Motivation

PR #192 added a `compose_slide` tool to work around the `.save.lock` bottleneck for CC Phase 2 parallel composers. This PR achieves the same goal (and more) without adding a new tool — by restructuring the existing `run_python` internals so that:

1. `output.pptx` writes are lock-free (python-pptx only, ~0.2s, last-writer-wins is safe)
2. measure/compose/preview use a per-call iso.pptx in a unique tempdir (no contention possible)

All existing clients (Kiro CLI, Claude Desktop, ACP composer) benefit without any API or prompt changes.

## Test plan

- [x] 9 new unit/integration tests for `only_slugs` filtering (`tests/test_only_slugs.py`)
- [x] Full test suite passes (232 tests, ruff clean, TypeScript clean)
- [ ] Manual: run `run_python(save=True, measure_slides=["slug"])` with LibreOffice installed — verify iso.pptx compose/measure/preview output
- [ ] Manual: parallel composers on same deck — verify no data corruption without lock
- [ ] Closes #192 (same goal achieved via parameter extension, no new tool needed)