### PR TITLE
fix(composer): define module logger — NameError on group MCP stop failure

### DIFF
--- a/agent/modes/separated/composer.py
+++ b/agent/modes/separated/composer.py
@@ -3,6 +3,7 @@
 """Composer agent: compose_slides tool with parallel execution, prefetch, and post-build."""
 
 import json
+import logging
 import os
 import queue
 import time
@@ -17,6 +18,8 @@ from composition import resolve_parts
 from cost_logger import log_usage
 from modes import MODES  # imported lazily in compose_slides if needed
 from resilience import call_tool_with_retry
+
+logger = logging.getLogger("sdpm.agent")
 
 
 # Soft-stop signal: the webui cancel button sends InvokeAgentRuntimeCommand


### PR DESCRIPTION
## Summary
- `agent/modes/separated/composer.py` calls `logger.warning()` in the `run_group` finally block (per-group MCP stop failure path) but never defined `logger` — the warning itself raised `NameError`.
- Adds the standard `logging.getLogger("sdpm.agent")` module logger (same convention as factory.py / session.py / streaming.py).

## Background
Found while investigating roadmap 3-4 (compose checkpoint resume). 3-4 itself was closed as won't-do: the deck workspace already persists `slides/*.json` on write, so the workspace itself is the checkpoint; group failures are covered by the #193 structured-error retry flow. Rationale recorded in the roadmap spec notes (local ledger).

## Test
- `make lint` / `make test` — 251 passed, 1 skipped