### PR TITLE
feat: add GPT-5.6 Terra via bedrock-mantle Responses API

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -13,7 +13,7 @@ RUN uv pip install --no-cache -r requirements.txt
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-COPY basic_agent.py cost_logger.py factory.py composition.py mcp_clients.py mantle_client.py model_profiles.py resilience.py session.py streaming.py ./
+COPY basic_agent.py cost_logger.py errors.py factory.py composition.py mcp_clients.py mantle_client.py model_profiles.py resilience.py session.py streaming.py ./
 COPY prompts/ prompts/
 COPY modes/ modes/
 COPY tools/ tools/

--- a/agent/mantle_client.py
+++ b/agent/mantle_client.py
@@ -40,12 +40,28 @@ class _SigV4Transport(httpx.AsyncBaseTransport):
 
 
 def mantle_model(model_id: str, region: str = "us-east-1"):
-    """Create a Strands OpenAIModel pointing at bedrock-mantle with SigV4 auth.
+    """Create a Strands model pointing at bedrock-mantle with AWS-native auth.
+
+    Models that only support the Responses API (see
+    ``model_profiles.MANTLE_RESPONSES_MODELS``, e.g. GPT-5.6 Terra/Luna) use
+    Strands' native ``OpenAIResponsesModel`` with ``bedrock_mantle_config``
+    (bearer token minted per request). All other models use the legacy
+    Chat Completions path with a SigV4-signed httpx transport.
 
     Usage:
         from mantle_client import mantle_model
         model = mantle_model("openai.gpt-5.4", region="us-east-1")
     """
+    from model_profiles import MANTLE_RESPONSES_MODELS
+
+    if model_id in MANTLE_RESPONSES_MODELS:
+        from strands.models.openai_responses import OpenAIResponsesModel
+
+        return OpenAIResponsesModel(
+            bedrock_mantle_config={"region": region},
+            model_id=model_id,
+        )
+
     from strands.models.openai import OpenAIModel
 
     class _MantleOpenAIModel(OpenAIModel):

--- a/agent/mantle_client.py
+++ b/agent/mantle_client.py
@@ -43,7 +43,7 @@ def mantle_model(model_id: str, region: str = "us-east-1"):
     """Create a Strands model pointing at bedrock-mantle with AWS-native auth.
 
     Models that only support the Responses API (see
-    ``model_profiles.MANTLE_RESPONSES_MODELS``, e.g. GPT-5.6 Terra/Luna) use
+    ``model_profiles.MANTLE_RESPONSES_MODELS``, e.g. GPT-5.6 Terra) use
     Strands' native ``OpenAIResponsesModel`` with ``bedrock_mantle_config``
     (bearer token minted per request). All other models use the legacy
     Chat Completions path with a SigV4-signed httpx transport.

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -92,6 +92,10 @@ KIMI_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capa
 # OpenAI GPT — bedrock-mantle only (Responses API endpoint).
 GPT_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="none")
 
+# OpenAI GPT fast tier (e.g. GPT-5.6 Luna) — same invocation params, but not
+# capable enough for compose (Haiku-class positioning).
+GPT_FAST = ModelProfile(temperature=0.7, cache_strategy="none", compose_capable=False)
+
 
 # Fallback profile when a model id is not explicitly registered.
 _DEFAULT = CLAUDE_STANDARD
@@ -99,6 +103,8 @@ _DEFAULT = CLAUDE_STANDARD
 # Models served via bedrock-mantle (OpenAI-compatible endpoint, not Converse API).
 # model_id → list of supported regions (first entry is the fallback).
 MANTLE_MODELS: dict[str, list[str]] = {
+    "openai.gpt-5.6-terra": ["us-east-1", "us-east-2", "us-west-2"],
+    "openai.gpt-5.6-luna": ["us-east-1", "us-east-2", "us-west-2"],
     "openai.gpt-5.5": ["us-east-1", "us-east-2"],
     "openai.gpt-5.4": ["us-east-1", "us-east-2", "us-west-2"],
 }
@@ -136,6 +142,8 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     # Amazon Nova
     "us.amazon.nova-2-lite-v1:0": NOVA_2_DEFAULT,
     # OpenAI GPT (bedrock-mantle)
+    "openai.gpt-5.6-terra": GPT_DEFAULT,
+    "openai.gpt-5.6-luna": GPT_FAST,
     "openai.gpt-5.5": GPT_DEFAULT,
     "openai.gpt-5.4": GPT_DEFAULT,
 }

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -154,7 +154,7 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "us.amazon.nova-2-lite-v1:0": NOVA_2_DEFAULT,
     # OpenAI GPT (bedrock-mantle)
     "openai.gpt-5.6-terra": GPT_DEFAULT,
-    "openai.gpt-5.6-luna": GPT_DEFAULT,  # compose enabled for feasibility testing
+    "openai.gpt-5.6-luna": GPT_FAST,  # feasibility-tested 2026-07-14: insufficient for compose
     "openai.gpt-5.5": GPT_DEFAULT,
     "openai.gpt-5.4": GPT_DEFAULT,
 }

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -104,7 +104,10 @@ _DEFAULT = CLAUDE_STANDARD
 # model_id → list of supported regions (first entry is the fallback).
 MANTLE_MODELS: dict[str, list[str]] = {
     "openai.gpt-5.6-terra": ["us-east-1", "us-east-2", "us-west-2"],
-    "openai.gpt-5.6-luna": ["us-east-1", "us-east-2", "us-west-2"],
+    # Luna: us-east-2 first — us-east-1 mantle streaming stalls mid-response
+    # (verified 2026-07-14: us-east-1 stream emits 2 events then hangs;
+    # us-east-2 / us-west-2 complete in <1s). Revisit after AWS fixes it.
+    "openai.gpt-5.6-luna": ["us-east-2", "us-west-2", "us-east-1"],
     "openai.gpt-5.5": ["us-east-1", "us-east-2"],
     "openai.gpt-5.4": ["us-east-1", "us-east-2", "us-west-2"],
 }

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -92,10 +92,6 @@ KIMI_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capa
 # OpenAI GPT — bedrock-mantle only (Responses API endpoint).
 GPT_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="none")
 
-# OpenAI GPT fast tier (e.g. GPT-5.6 Luna) — same invocation params, but not
-# capable enough for compose (Haiku-class positioning).
-GPT_FAST = ModelProfile(temperature=0.7, cache_strategy="none", compose_capable=False)
-
 
 # Fallback profile when a model id is not explicitly registered.
 _DEFAULT = CLAUDE_STANDARD
@@ -104,10 +100,6 @@ _DEFAULT = CLAUDE_STANDARD
 # model_id → list of supported regions (first entry is the fallback).
 MANTLE_MODELS: dict[str, list[str]] = {
     "openai.gpt-5.6-terra": ["us-east-1", "us-east-2", "us-west-2"],
-    # Luna: us-east-2 first — us-east-1 mantle streaming stalls mid-response
-    # (verified 2026-07-14: us-east-1 stream emits 2 events then hangs;
-    # us-east-2 / us-west-2 complete in <1s). Revisit after AWS fixes it.
-    "openai.gpt-5.6-luna": ["us-east-2", "us-west-2", "us-east-1"],
     "openai.gpt-5.5": ["us-east-1", "us-east-2"],
     "openai.gpt-5.4": ["us-east-1", "us-east-2", "us-west-2"],
 }
@@ -117,7 +109,6 @@ MANTLE_MODELS: dict[str, list[str]] = {
 # /chat/completions returns 400 Bad Request.
 MANTLE_RESPONSES_MODELS: set[str] = {
     "openai.gpt-5.6-terra",
-    "openai.gpt-5.6-luna",
 }
 
 
@@ -154,7 +145,6 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "us.amazon.nova-2-lite-v1:0": NOVA_2_DEFAULT,
     # OpenAI GPT (bedrock-mantle)
     "openai.gpt-5.6-terra": GPT_DEFAULT,
-    "openai.gpt-5.6-luna": GPT_FAST,  # feasibility-tested 2026-07-14: insufficient for compose
     "openai.gpt-5.5": GPT_DEFAULT,
     "openai.gpt-5.4": GPT_DEFAULT,
 }

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -143,7 +143,7 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "us.amazon.nova-2-lite-v1:0": NOVA_2_DEFAULT,
     # OpenAI GPT (bedrock-mantle)
     "openai.gpt-5.6-terra": GPT_DEFAULT,
-    "openai.gpt-5.6-luna": GPT_FAST,
+    "openai.gpt-5.6-luna": GPT_DEFAULT,  # compose enabled for feasibility testing
     "openai.gpt-5.5": GPT_DEFAULT,
     "openai.gpt-5.4": GPT_DEFAULT,
 }

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -109,6 +109,14 @@ MANTLE_MODELS: dict[str, list[str]] = {
     "openai.gpt-5.4": ["us-east-1", "us-east-2", "us-west-2"],
 }
 
+# Mantle models that only support the Responses API (no Chat Completions).
+# GPT-5.6 model cards: Responses ✅ / Chat Completions ❌ — calling
+# /chat/completions returns 400 Bad Request.
+MANTLE_RESPONSES_MODELS: set[str] = {
+    "openai.gpt-5.6-terra",
+    "openai.gpt-5.6-luna",
+}
+
 
 def resolve_mantle_region(model_id: str, deploy_region: str | None = None) -> str:
     """Resolve the best mantle region for a model.

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies for Strands Agent. AI model access requires appropriate
 # IAM permissions and Bedrock model access grants.
-strands-agents[otel,openai]>=1.30.0
+strands-agents[otel,openai]>=1.47.0
 mcp>=1.23.1
 bedrock-agentcore[strands-agents]>=1.0.6
 aws-opentelemetry-distro>=0.10.0

--- a/infra/config.example.yaml
+++ b/infra/config.example.yaml
@@ -43,7 +43,6 @@ model:
     - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
     - "us.amazon.nova-2-lite-v1:0"
     - "openai.gpt-5.6-terra"                         # bedrock-mantle (us-east-1, us-east-2, us-west-2)
-    - "openai.gpt-5.6-luna"                          # bedrock-mantle (us-east-1, us-east-2, us-west-2), chat only
     - "openai.gpt-5.5"                               # bedrock-mantle (us-east-1, us-east-2)
     - "openai.gpt-5.4"                               # bedrock-mantle (us-east-1, us-east-2, us-west-2)
 

--- a/infra/config.example.yaml
+++ b/infra/config.example.yaml
@@ -42,6 +42,8 @@ model:
     - "global.anthropic.claude-opus-4-6-v1"
     - "global.anthropic.claude-haiku-4-5-20251001-v1:0"
     - "us.amazon.nova-2-lite-v1:0"
+    - "openai.gpt-5.6-terra"                         # bedrock-mantle (us-east-1, us-east-2, us-west-2)
+    - "openai.gpt-5.6-luna"                          # bedrock-mantle (us-east-1, us-east-2, us-west-2), chat only
     - "openai.gpt-5.5"                               # bedrock-mantle (us-east-1, us-east-2)
     - "openai.gpt-5.4"                               # bedrock-mantle (us-east-1, us-east-2, us-west-2)
 

--- a/infra/lib/agent-stack.ts
+++ b/infra/lib/agent-stack.ts
@@ -65,10 +65,12 @@ export class AgentStack extends cdk.Stack {
         resources: ["*"],
       })
     );
-    // bedrock-mantle (OpenAI-compatible endpoint) for models like GPT-5.4/5.5
+    // bedrock-mantle (OpenAI-compatible endpoint) for models like GPT-5.4/5.5/5.6.
+    // CreateInference: legacy SigV4 path (Chat Completions).
+    // CallWithBearerToken: Responses API path (bearer token, e.g. GPT-5.6 Terra/Luna).
     role.addToPolicy(
       new iam.PolicyStatement({
-        actions: ["bedrock-mantle:CreateInference"],
+        actions: ["bedrock-mantle:CreateInference", "bedrock-mantle:CallWithBearerToken"],
         resources: ["*"],
       })
     );

--- a/infra/lib/agent-stack.ts
+++ b/infra/lib/agent-stack.ts
@@ -67,7 +67,7 @@ export class AgentStack extends cdk.Stack {
     );
     // bedrock-mantle (OpenAI-compatible endpoint) for models like GPT-5.4/5.5/5.6.
     // CreateInference: legacy SigV4 path (Chat Completions).
-    // CallWithBearerToken: Responses API path (bearer token, e.g. GPT-5.6 Terra/Luna).
+    // CallWithBearerToken: Responses API path (bearer token, e.g. GPT-5.6 Terra).
     role.addToPolicy(
       new iam.PolicyStatement({
         actions: ["bedrock-mantle:CreateInference", "bedrock-mantle:CallWithBearerToken"],

--- a/infra/lib/model-metadata.ts
+++ b/infra/lib/model-metadata.ts
@@ -57,6 +57,7 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
   "openai.gpt-5.6-luna": {
     displayName: "GPT-5.6 Luna",
     description: "Fast and affordable, OpenAI's lowest cost tier",
+    composable: false,
   },
   "openai.gpt-5.5": {
     displayName: "GPT-5.5",

--- a/infra/lib/model-metadata.ts
+++ b/infra/lib/model-metadata.ts
@@ -50,6 +50,15 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
     composable: false,
   },
   // --- OpenAI GPT ---
+  "openai.gpt-5.6-terra": {
+    displayName: "GPT-5.6 Terra",
+    description: "Balanced performance competitive with GPT-5.5 at half the cost",
+  },
+  "openai.gpt-5.6-luna": {
+    displayName: "GPT-5.6 Luna",
+    description: "Fast and affordable, OpenAI's lowest cost tier",
+    composable: false,
+  },
   "openai.gpt-5.5": {
     displayName: "GPT-5.5",
     description: "OpenAI's most capable model, advanced coding and agentic tasks",

--- a/infra/lib/model-metadata.ts
+++ b/infra/lib/model-metadata.ts
@@ -57,7 +57,6 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
   "openai.gpt-5.6-luna": {
     displayName: "GPT-5.6 Luna",
     description: "Fast and affordable, OpenAI's lowest cost tier",
-    composable: false,
   },
   "openai.gpt-5.5": {
     displayName: "GPT-5.5",

--- a/infra/lib/model-metadata.ts
+++ b/infra/lib/model-metadata.ts
@@ -54,11 +54,6 @@ export const MODEL_METADATA: Record<string, ModelMetadata> = {
     displayName: "GPT-5.6 Terra",
     description: "Balanced performance competitive with GPT-5.5 at half the cost",
   },
-  "openai.gpt-5.6-luna": {
-    displayName: "GPT-5.6 Luna",
-    description: "Fast and affordable, OpenAI's lowest cost tier",
-    composable: false,
-  },
   "openai.gpt-5.5": {
     displayName: "GPT-5.5",
     description: "OpenAI's most capable model, advanced coding and agentic tasks",


### PR DESCRIPTION
## Summary
- Add OpenAI **GPT-5.6 Terra** (`openai.gpt-5.6-terra`, GA 2026-07-13) as a selectable model for chat and create
- New **Responses API path** for bedrock-mantle models: GPT-5.6 supports Responses only (no Chat Completions), routed via strands `OpenAIResponsesModel` + `bedrock_mantle_config` (bearer-token auth); `MANTLE_RESPONSES_MODELS` registry selects the path per model
- Grant `bedrock-mantle:CallWithBearerToken` to the agent role (bearer-token path requires it; the legacy SigV4 path only needed `CreateInference`)
- Bump `strands-agents` floor to **1.47.0** (native `bedrock_mantle_config` support)
- Fix: add missing `errors.py` to agent Dockerfile COPY (runtime failed to start with HTTP 424 / ModuleNotFoundError — pre-existing bug surfaced by this image rebuild)

## Not included (tested & rejected)
GPT-5.6 **Luna** was added, feasibility-tested, and removed: output quality insufficient even for chat. History also contains a diagnosis of a us-east-1 mantle Luna streaming stall (stream emits 2 events then hangs; us-east-2/us-west-2 complete in <1s) — kept in commit messages for reference.

## Testing
- `make all` (lint + 292 unit tests) and `tsc --noEmit` pass
- Local smoke tests via mantle us-east-1: Terra single-turn 1.8s, multi-turn tool round-trip 3.2s
- Deployed to a dev account (SdpmAgent + SdpmWebUi via CodeBuild): Terra verified working in Web UI chat and create