### PR TITLE
feat: add per-user notes for builtin templates

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -501,6 +501,18 @@ def list_templates() -> Dict[str, Any]:
         for item in resp.get("Responses", {}).get(table.name, []):
             ddb_cache[item["name"]] = item
 
+    # Per-user notes overlay builtin metadata without modifying shared cache rows.
+    builtin_notes: Dict[str, str] = {}
+    if s3_templates:
+        resp = table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("BUILTIN_NOTE#"),
+        )
+        builtin_notes = {
+            item["SK"].removeprefix("BUILTIN_NOTE#"): item.get("description", "")
+            for item in resp.get("Items", [])
+        }
+
     # Build builtin list with lazy analysis
     to_analyze: List[str] = []
     for name, etag in s3_templates.items():
@@ -513,7 +525,7 @@ def list_templates() -> Dict[str, Any]:
             templates.append({
                 "name": name,
                 "source": "builtin",
-                "description": cached.get("description", ""),
+                "description": builtin_notes.get(name, cached.get("description", "")),
                 "theme_colors": analysis.get("theme_colors", {}),
                 "fonts": cached.get("fonts", {}),
                 "layout_count": len(analysis.get("layouts", [])),
@@ -523,7 +535,7 @@ def list_templates() -> Dict[str, Any]:
             templates.append({
                 "name": name,
                 "source": "builtin",
-                "description": "",
+                "description": builtin_notes.get(name, ""),
                 "theme_colors": {},
                 "fonts": {},
                 "layout_count": 0,
@@ -608,6 +620,40 @@ def download_template(name: str) -> Any:
         return {"downloadUrl": url}
     except Exception:
         return {"error": "Template not found"}, 404
+
+
+@app.patch("/templates/builtin/<name>")
+def patch_builtin_template_note(name: str) -> Dict[str, Any]:
+    """Create, update, or clear the current user's note for a builtin template.
+
+    Body: {"description": str}. Blank descriptions clear the user overlay.
+    """
+    user_id = get_user_id(app.current_event)
+    body = app.current_event.json_body or {}
+    description_raw = body.get("description")
+    if not isinstance(description_raw, str):
+        return {"error": "Description must be a string"}, 400
+    if not name or not re.fullmatch(r"[a-zA-Z0-9_\-\s.()]+", name):
+        return {"error": "Invalid template name"}, 400
+
+    # Notes can only target builtin templates that currently exist in S3.
+    try:
+        s3_client.head_object(Bucket=RESOURCE_BUCKET, Key=f"templates/{name}.pptx")
+    except Exception:
+        return {"error": "Template not found"}, 404
+
+    key = {"PK": f"USER#{user_id}", "SK": f"BUILTIN_NOTE#{name}"}
+    description = description_raw.strip()
+    if not description:
+        table.delete_item(Key=key)
+    else:
+        table.put_item(Item={
+            **key,
+            "name": name,
+            "description": description,
+            "updatedAt": now_iso(),
+        })
+    return {"updated": name, "description": description}
 
 
 @app.post("/templates/user/upload-url")

--- a/docs/en/custom-template.md
+++ b/docs/en/custom-template.md
@@ -160,8 +160,7 @@ uv run python scripts/upload_template.py \
   --file my-template.pptx \
   --name "Corporate 2026" \
   --bucket <ResourceBucketName> \
-  --table <TableName> \
-  --default
+  --table <TableName>
 ```
 
 | Parameter | Required | Description |
@@ -170,9 +169,10 @@ uv run python scripts/upload_template.py \
 | `--name` | ✅ | Display name for the template |
 | `--bucket` | ✅ | S3 bucket name (CDK output `ResourceBucketName`) |
 | `--table` | ✅ | Amazon DynamoDB table name (CDK output `TableName`) |
-| `--default` | | Set as the default template |
 
 The script handles S3 upload, template analysis, and Amazon DynamoDB metadata registration automatically.
+
+In the cloud Web UI, each user can add a private note to builtin and user templates from the Templates page. The agent considers these notes—including intended use cases, preferences, and default-use requests—when proposing or selecting a template.
 
 ---
 

--- a/docs/ja/custom-template.md
+++ b/docs/ja/custom-template.md
@@ -158,8 +158,7 @@ uv run python scripts/upload_template.py \
   --file my-template.pptx \
   --name "Corporate 2026" \
   --bucket <ResourceBucketName> \
-  --table <TableName> \
-  --default
+  --table <TableName>
 ```
 
 | パラメータ | 必須 | 説明 |
@@ -168,9 +167,10 @@ uv run python scripts/upload_template.py \
 | `--name` | ✅ | テンプレートの表示名 |
 | `--bucket` | ✅ | S3 バケット名（CDK 出力の `ResourceBucketName`） |
 | `--table` | ✅ | Amazon DynamoDB テーブル名（CDK 出力の `TableName`） |
-| `--default` | | デフォルトテンプレートに設定 |
 
 スクリプトは S3 へのアップロード、テンプレート解析、Amazon DynamoDB へのメタデータ登録を自動で行います。
+
+クラウド Web UI では、テンプレート画面からビルトインおよびユーザーテンプレートにユーザー専用のメモを追加できます。エージェントは、用途、好み、デフォルト利用の希望などのメモをテンプレートの提案・選択時に考慮します。
 
 ---
 

--- a/mcp-server/storage/__init__.py
+++ b/mcp-server/storage/__init__.py
@@ -204,6 +204,17 @@ class Storage(ABC):
     # --- User Templates ---
 
     @abstractmethod
+    def get_builtin_template_notes(self, user_id: str) -> dict[str, str]:
+        """Get per-user notes for builtin templates.
+
+        Args:
+            user_id: User identifier.
+
+        Returns:
+            Mapping of builtin template name to user-provided description.
+        """
+
+    @abstractmethod
     def list_user_templates(self, user_id: str) -> list[dict]:
         """List user-uploaded templates metadata from DDB.
 

--- a/mcp-server/storage/aws.py
+++ b/mcp-server/storage/aws.py
@@ -279,6 +279,20 @@ class AwsStorage(Storage):
 
     # --- User Templates ---
 
+    def get_builtin_template_notes(self, user_id: str) -> dict[str, str]:
+        """Get per-user notes for builtin templates from DDB."""
+        resp = self._table.query(
+            KeyConditionExpression="PK = :pk AND begins_with(SK, :prefix)",
+            ExpressionAttributeValues={
+                ":pk": f"USER#{user_id}",
+                ":prefix": "BUILTIN_NOTE#",
+            },
+        )
+        return {
+            item["SK"].removeprefix("BUILTIN_NOTE#"): item.get("description", "")
+            for item in resp.get("Items", [])
+        }
+
     def list_user_templates(self, user_id: str) -> list[dict]:
         """List user templates from DDB."""
         resp = self._table.query(

--- a/mcp-server/tools/template.py
+++ b/mcp-server/tools/template.py
@@ -23,6 +23,7 @@ def list_templates(storage: Storage, user_id: str = "") -> dict[str, Any]:
         Dict with list of templates (name, source, description, fonts, layout_count).
     """
     templates = []
+    builtin_notes = storage.get_builtin_template_notes(user_id) if user_id else {}
 
     # Builtin templates
     for t in storage.list_templates():
@@ -33,7 +34,7 @@ def list_templates(storage: Storage, user_id: str = "") -> dict[str, Any]:
         templates.append({
             "name": t.get("name", ""),
             "source": "builtin",
-            "description": t.get("description", ""),
+            "description": builtin_notes.get(t.get("name", ""), t.get("description", "")),
             "fonts": t.get("fonts", {}),
             "layout_count": len(analysis.get("layouts", [])),
         })

--- a/scripts/upload_template.py
+++ b/scripts/upload_template.py
@@ -17,7 +17,6 @@ Usage:
         --name "Corporate 2026" \
         --bucket my-sdpm-bucket \
         --table my-sdpm-table \
-        [--default] \
         [--region us-east-1]
 """
 
@@ -36,7 +35,6 @@ def main() -> None:
     parser.add_argument("--name", required=True, help="Display name for the template")
     parser.add_argument("--bucket", required=True, help="S3 bucket name")
     parser.add_argument("--table", required=True, help="DynamoDB table name")
-    parser.add_argument("--default", action="store_true", help="Set as default template")
     parser.add_argument("--region", default="us-east-1", help="AWS region")
     args = parser.parse_args()
 
@@ -73,15 +71,11 @@ def main() -> None:
         "s3Key": s3_key,
         "analysisJson": analysis_json,
         "fonts": fonts,
-        "isDefault": args.default,
         "createdAt": now,
         "updatedAt": now,
     }
     table.put_item(Item=item)
     print(f"Template registered: {template_id} ({args.name})")
-
-    if args.default:
-        print("Set as default template")
 
 
 if __name__ == "__main__":

--- a/skill/references/workflows/create-new-1-art-direction.md
+++ b/skill/references/workflows/create-new-1-art-direction.md
@@ -47,6 +47,7 @@ Internalize the design tokens and visual language now — Phase 2 will not re-re
 ### 1. Select and analyze template
 
 List available templates and ask the user to select one.
+Template descriptions may contain user notes such as intended use cases, preferences, or a request to use one by default. Read these notes and take them into account when proposing or selecting a template.
 
 ```bash
 uv run python3 scripts/pptx_builder.py list-templates

--- a/tests/test_mcp_template_tools.py
+++ b/tests/test_mcp_template_tools.py
@@ -1,0 +1,93 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for MCP template listing behavior."""
+
+from tools.template import list_templates
+
+
+class TemplateStorage:
+    """Minimal storage double for list_templates tests."""
+
+    def __init__(self, notes: dict[str, str] | None = None) -> None:
+        self.notes = notes or {}
+        self.notes_user_id = ""
+
+    def get_builtin_template_notes(self, user_id: str) -> dict[str, str]:
+        self.notes_user_id = user_id
+        return self.notes
+
+    def list_templates(self) -> list[dict]:
+        return [
+            {
+                "name": "blank-dark",
+                "description": "Shared description",
+                "fonts": {},
+                "analysisJson": "{}",
+            },
+            {
+                "name": "blank-light",
+                "description": "Light shared description",
+                "fonts": {},
+                "analysisJson": "{}",
+            },
+        ]
+
+    def list_user_templates(self, user_id: str) -> list[dict]:
+        return []
+
+
+def test_list_templates_overlays_builtin_description_with_user_note() -> None:
+    storage = TemplateStorage({"blank-dark": "Use for internal reviews"})
+
+    result = list_templates(storage, user_id="user-123")
+
+    descriptions = {item["name"]: item["description"] for item in result["templates"]}
+    assert descriptions == {
+        "blank-dark": "Use for internal reviews",
+        "blank-light": "Light shared description",
+    }
+    assert storage.notes_user_id == "user-123"
+
+
+def test_list_templates_without_user_keeps_shared_descriptions() -> None:
+    storage = TemplateStorage({"blank-dark": "Should not be read"})
+
+    result = list_templates(storage)
+
+    descriptions = {item["name"]: item["description"] for item in result["templates"]}
+    assert descriptions["blank-dark"] == "Shared description"
+    assert storage.notes_user_id == ""
+
+
+class QueryTable:
+    """DynamoDB table double that records query parameters."""
+
+    def __init__(self) -> None:
+        self.query_kwargs: dict = {}
+
+    def query(self, **kwargs: object) -> dict:
+        self.query_kwargs = kwargs
+        return {
+            "Items": [
+                {
+                    "PK": "USER#user-123",
+                    "SK": "BUILTIN_NOTE#blank-dark",
+                    "description": "Use for internal reviews",
+                },
+            ],
+        }
+
+
+def test_aws_storage_get_builtin_template_notes_maps_ddb_items() -> None:
+    from storage.aws import AwsStorage
+
+    table = QueryTable()
+    storage = AwsStorage(table, object(), "pptx-bucket", "resource-bucket")
+
+    notes = storage.get_builtin_template_notes("user-123")
+
+    assert notes == {"blank-dark": "Use for internal reviews"}
+    assert table.query_kwargs["ExpressionAttributeValues"] == {
+        ":pk": "USER#user-123",
+        ":prefix": "BUILTIN_NOTE#",
+    }

--- a/web-ui/src/app/(authenticated)/templates/page.tsx
+++ b/web-ui/src/app/(authenticated)/templates/page.tsx
@@ -20,10 +20,13 @@ import {
   uploadTemplate,
   deleteTemplate,
   updateTemplateDescription,
+  updateBuiltinTemplateNote,
   renameTemplate,
   type TemplateEntry,
 } from "@/services/deckService"
 import { Download, Trash2, Upload, FileText, Type, LayoutGrid, X } from "lucide-react"
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_MODE === "local"
 
 export default function TemplatesPage() {
   const t = useTranslations("templatesPage")
@@ -60,6 +63,13 @@ export default function TemplatesPage() {
     const result = await updateTemplateDescription(name, description, idToken)
     if (result.error) { showToast(result.error, "error"); return }
     setTemplates(prev => prev.map(t => t.name === name ? { ...t, description } : t))
+  }
+
+  const handleUpdateBuiltinNote = async (name: string, description: string) => {
+    if (!idToken) return
+    const result = await updateBuiltinTemplateNote(name, description, idToken)
+    if (result.error) { showToast(result.error, "error"); return }
+    setTemplates(prev => prev.map(t => t.name === name && t.source === "builtin" ? { ...t, description } : t))
   }
 
   const handleRename = async (oldName: string, newName: string): Promise<string | null> => {
@@ -148,6 +158,7 @@ export default function TemplatesPage() {
                       key={t.name}
                       template={t}
                       onDownload={handleDownload}
+                      onEditDescription={IS_LOCAL ? undefined : handleUpdateBuiltinNote}
                     />
                   ))}
                 </div>
@@ -290,7 +301,7 @@ function TemplateCard({ template, onDownload, onDelete, onEditDescription, onRen
                 <span className="text-[11px] text-brand-teal/70 font-medium shrink-0">{t("custom")}</span>
               )}
             </div>
-            {/* Description — click to edit for user templates */}
+            {/* Description — editable when an update handler is available. */}
             {editing ? (
               <textarea
                 autoFocus

--- a/web-ui/src/components/deck/TemplatePickerSection.test.tsx
+++ b/web-ui/src/components/deck/TemplatePickerSection.test.tsx
@@ -64,6 +64,19 @@ describe("TemplatePickerSection", () => {
     expect(screen.getByText("Template")).toBeTruthy()
   })
 
+  it("shows descriptions on cards without requiring hover", async () => {
+    renderWithIntl(
+      <TemplatePickerSection idToken="tok" currentTemplate={null} onTemplateSelect={() => {}} />
+    )
+    await screen.findByText("my-brand")
+    // Descriptions (including per-user builtin notes) are rendered as visible text
+    expect(screen.getByText("Builtin A")).toBeTruthy()
+    expect(screen.getByText("Company brand")).toBeTruthy()
+    // Templates without a description render no empty paragraph
+    const corporateCard = screen.getByRole("button", { name: "Use the corporate template" })
+    expect(corporateCard.querySelector("p")).toBeNull()
+  })
+
   it("orders user templates before builtin when nothing is confirmed", async () => {
     renderWithIntl(
       <TemplatePickerSection idToken="tok" currentTemplate={null} onTemplateSelect={() => {}} />

--- a/web-ui/src/components/deck/TemplatePickerSection.tsx
+++ b/web-ui/src/components/deck/TemplatePickerSection.tsx
@@ -149,13 +149,19 @@ function TemplatePickCard({ template, isCurrent, pulsing, onClick }: {
         )}
       </div>
       {/* Name row */}
-      <div className="px-2.5 py-2 flex items-center gap-1.5">
+      <div className={`px-2.5 pt-2 flex items-center gap-1.5 ${template.description ? "pb-0.5" : "pb-2"}`}>
         {isCurrent && <Check className="h-3 w-3 text-brand-teal shrink-0" aria-hidden="true" />}
         <span className={`text-xs font-medium truncate ${isCurrent ? "text-brand-teal" : ""}`}>{template.name}</span>
         {template.source === "user" && (
           <span className="text-[11px] text-brand-teal/70 font-medium shrink-0">{t("custom")}</span>
         )}
       </div>
+      {/* Description — user notes influence template choice, so keep them visible */}
+      {template.description && (
+        <p className="px-2.5 pb-2 text-xs text-foreground-muted line-clamp-2 leading-snug">
+          {template.description}
+        </p>
+      )}
       {/* Hover overlay — previews the click's meaning (insert into chat) */}
       <span className="absolute inset-0 flex items-center justify-center gap-1 rounded-xl bg-black/60 text-xs font-medium text-foreground opacity-0 group-hover:opacity-100 transition-opacity duration-150">
         <Plus className="h-3.5 w-3.5" />

--- a/web-ui/src/services/deckService.ts
+++ b/web-ui/src/services/deckService.ts
@@ -647,6 +647,17 @@ export async function updateTemplateDescription(name: string, description: strin
   return res.json()
 }
 
+/** Update the current user's note for a builtin template. */
+export async function updateBuiltinTemplateNote(name: string, description: string, idToken: string): Promise<{ updated?: string; error?: string }> {
+  const base = await getApiBaseUrl()
+  const res = await fetch(`${base}templates/builtin/${encodeURIComponent(name)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${idToken}` },
+    body: JSON.stringify({ description }),
+  })
+  return res.json()
+}
+
 /** Rename a user template. */
 export async function renameTemplate(name: string, newName: string, idToken: string): Promise<{ renamed?: { from: string; to: string }; error?: string }> {
   const base = await getApiBaseUrl()


### PR DESCRIPTION
## Summary
- store private per-user notes for builtin templates using DynamoDB overlay items
- merge notes into the Web API and remote MCP `list_templates` responses
- enable builtin-template note editing in the cloud Web UI
- guide the agent to consider template notes during template selection
- remove the unused `isDefault` field and `--default` upload option

## Data model

```text
PK = USER#{user_id}
SK = BUILTIN_NOTE#{template_name}
```

Builtin metadata remains shared and unchanged. Clearing a note deletes its overlay item.

## Validation
- `make lint`
- `make test` — 295 passed, 1 skipped
- `uv run pytest tests/test_mcp_template_tools.py -q` — 3 passed
- `cd web-ui && npx tsc --noEmit`

Closes #166