### PR TITLE
fix: PPTX import follow-up — diff ImportError, theme_hints crash, template fallback

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -37,6 +37,7 @@ from shared.schema import (
     DECK_SK_PREFIX, FAV_SK_PREFIX,
     extract_deck_id, extract_fav_id,
     GSI_PUBLIC_DECKS, public_gsi1pk,
+    theme_hints_ddb_item,
 )
 
 # Environment variables
@@ -1591,15 +1592,12 @@ def process_upload(upload_id: str) -> Dict[str, Any]:
                     # PPTX deck-structure metadata — stored for the edit guide
                     # and returned by process_upload / get_upload_status.
                     if result.deck_structure:
-                        from decimal import Decimal
-                        bg_lum = result.theme_hints.get("backgroundLuminance")
+                        # theme_hints may be None when theme extraction failed
+                        # (ingest logs a warning and continues) — the helper
+                        # guards so a successful conversion is not reported
+                        # as failed.
                         update_expr_parts.append("themeHints = :th")
-                        expr_values[":th"] = {
-                            # DynamoDB rejects native floats; round-trip via str(Decimal).
-                            "backgroundLuminance": Decimal(str(bg_lum)) if bg_lum is not None else None,
-                            "accentColors": result.theme_hints.get("accentColors", []),
-                            "fonts": result.theme_hints.get("fonts", {}),
-                        }
+                        expr_values[":th"] = theme_hints_ddb_item(result.theme_hints)
                         update_expr_parts.append("slideCount = :sc")
                         expr_values[":sc"] = result.slide_count
                         update_expr_parts.append("suggestedName = :sn")

--- a/mcp-server/tools/generate.py
+++ b/mcp-server/tools/generate.py
@@ -209,9 +209,16 @@ def _prepare_workspace(
             template_path.write_bytes(
                 storage.download_file_from_pptx_bucket(deck_template_key),
             )
-            tmpl_name = ""  # signal: resolved
-        except Exception:
-            tmpl_name = ""  # fall through to sdpm-template lookup below
+        except Exception as e:
+            # Do NOT fall back to a stock template: imported decks reference
+            # layout names from the original PPTX, so building with a stock
+            # template would fail later with an obscure layout mismatch.
+            raise ValueError(
+                f"Deck template not found: {deck_template_key}. "
+                "This deck was imported from a PPTX and requires its own "
+                "template.pptx. Re-import the PPTX to restore it."
+            ) from e
+        tmpl_name = ""  # signal: resolved
     if tmpl_name:
         normalized = tmpl_name.removesuffix(".pptx")
         for t in storage.list_templates():

--- a/shared/schema.py
+++ b/shared/schema.py
@@ -145,4 +145,34 @@ def extract_fav_id(sk: str) -> str:
     return sk.replace(FAV_SK_PREFIX, "")
 
 
+# ---------------------------------------------------------------------------
+# Item builders
+# ---------------------------------------------------------------------------
+
+
+def theme_hints_ddb_item(theme_hints: dict | None) -> dict:
+    """Build the DynamoDB ``themeHints`` attribute from a ConversionResult.
+
+    Tolerates ``theme_hints=None`` (shared.ingest continues with a warning
+    when theme extraction fails) so a successful conversion is never
+    reported as failed. DynamoDB rejects native floats, so
+    ``backgroundLuminance`` is round-tripped via ``str(Decimal)``.
+
+    Args:
+        theme_hints: ``ConversionResult.theme_hints`` — may be None.
+
+    Returns:
+        Dict with backgroundLuminance (Decimal | None), accentColors, fonts.
+    """
+    from decimal import Decimal
+
+    hints = theme_hints or {}
+    bg_lum = hints.get("backgroundLuminance")
+    return {
+        "backgroundLuminance": Decimal(str(bg_lum)) if bg_lum is not None else None,
+        "accentColors": hints.get("accentColors", []),
+        "fonts": hints.get("fonts", {}),
+    }
+
+
 

--- a/skill/sdpm/__init__.py
+++ b/skill/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.3.8"
+__version__ = "0.4.0"

--- a/skill/sdpm/diff/__init__.py
+++ b/skill/sdpm/diff/__init__.py
@@ -201,14 +201,14 @@ def load_slides_json_or_pptx(path):
     if is_source:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_pptx = Path(tmpdir) / "tmp.pptx"
-            from sdpm.api import _find_template_in_dirs, _get_templates_dirs
+            from sdpm.api import _find_template_in_dirs, get_templates_dirs
             from sdpm.builder import PPTXBuilder, resolve_override
             tpl_name = data.get("template")
             if not tpl_name:
                 raise ValueError("No \"template\" specified in JSON. Cannot build for diff.")
             template = Path(path).parent / tpl_name
             if not template.exists():
-                named = _find_template_in_dirs(tpl_name, _get_templates_dirs())
+                named = _find_template_in_dirs(tpl_name, get_templates_dirs())
                 if named is not None:
                     template = named
                 else:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -98,5 +98,75 @@ class TestDiffDeckDirBaseline:
         assert "ADDED" in result["report"]
 
 
+class TestDiffSourceJsonBaseline:
+    """Regression tests for the source-JSON baseline path.
+
+    ``load_slides_json_or_pptx`` builds a PPTX from a source slides JSON
+    (template + builder elements) before diffing. This path once crashed
+    with ``ImportError: cannot import name '_get_templates_dirs'`` because
+    the import didn't match the actual ``sdpm.api.get_templates_dirs`` name
+    (PR #215 follow-up, R1) — no test exercised it.
+    """
+
+    @pytest.fixture()
+    def source_json(self, tmp_path: Path) -> Path:
+        path = tmp_path / "source.json"
+        path.write_text(json.dumps({
+            "template": "blank-dark.pptx",
+            "fonts": {"fullwidth": "Meiryo", "halfwidth": "Arial"},
+            "defaultTextColor": "#FFFFFF",
+            "slides": [
+                {
+                    "layout": "Blank",
+                    "elements": [
+                        {"type": "textbox", "text": "Source Title", "x": 100, "y": 100,
+                         "width": 800, "height": 80, "fontSize": 32},
+                    ],
+                },
+            ],
+        }))
+        return path
+
+    def test_source_json_baseline_loads(self, source_json: Path) -> None:
+        """Named-template resolution (get_templates_dirs) must not crash."""
+        from sdpm.diff import load_slides_json_or_pptx
+
+        baseline = load_slides_json_or_pptx(str(source_json))
+        assert baseline["slides"], "source JSON baseline produced no slides"
+
+    def test_source_json_baseline_diff_detects_edit(
+        self, source_json: Path, tmp_path: Path,
+    ) -> None:
+        """End-to-end: pptx_builder.py diff <source.json> <edited.pptx>."""
+        from sdpm.api import _find_template_in_dirs, get_templates_dirs
+        from sdpm.builder import PPTXBuilder
+
+        template = _find_template_in_dirs("blank-dark.pptx", get_templates_dirs())
+        assert template is not None
+        data = json.loads(source_json.read_text())
+        builder = PPTXBuilder(template, fonts=data["fonts"],
+                              base_dir=source_json.parent,
+                              default_text_color=data["defaultTextColor"])
+        for slide_def in data["slides"]:
+            builder.add_slide(slide_def)
+        pptx = tmp_path / "built.pptx"
+        builder.save(pptx)
+
+        from pptx import Presentation
+        prs = Presentation(str(pptx))
+        edited = False
+        for shape in prs.slides[0].shapes:
+            if shape.has_text_frame and "Source Title" in shape.text_frame.text:
+                shape.text_frame.paragraphs[0].runs[0].text = "Edited Source Title"
+                edited = True
+        assert edited, "fixture text not found in built PPTX"
+        edited_pptx = tmp_path / "edited.pptx"
+        prs.save(str(edited_pptx))
+
+        result = diff_report(str(source_json), edited_pptx)
+        assert result["has_diff"] is True
+        assert "Edited Source Title" in result["report"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_pptx_import.py
+++ b/tests/test_pptx_import.py
@@ -151,6 +151,39 @@ class TestConvertPptxThemeHints:
         assert 0.0 <= result.theme_hints["backgroundLuminance"] <= 1.0
 
 
+class TestThemeHintsDdbItem:
+    """theme_hints_ddb_item must tolerate theme_hints=None (PR #215 follow-up, R2).
+
+    shared.ingest._convert_pptx returns theme_hints=None (with deck_structure=True)
+    when theme extraction fails; the Cloud upload path once crashed with
+    AttributeError on ``None.get`` — turning a successful conversion into
+    "Conversion failed".
+    """
+
+    def test_none_theme_hints_returns_empty_defaults(self) -> None:
+        from shared.schema import theme_hints_ddb_item
+
+        item = theme_hints_ddb_item(None)
+        assert item["backgroundLuminance"] is None
+        assert item["accentColors"] == []
+        assert item["fonts"] == {}
+
+    def test_populated_theme_hints_converts_luminance_to_decimal(self) -> None:
+        from decimal import Decimal
+
+        from shared.schema import theme_hints_ddb_item
+
+        item = theme_hints_ddb_item({
+            "backgroundLuminance": 0.12,
+            "accentColors": ["#FF0000"],
+            "fonts": {"halfwidth": "Arial"},
+        })
+        assert isinstance(item["backgroundLuminance"], Decimal)
+        assert item["backgroundLuminance"] == Decimal("0.12")
+        assert item["accentColors"] == ["#FF0000"]
+        assert item["fonts"] == {"halfwidth": "Arial"}
+
+
 # ---------------------------------------------------------------------------
 # T3: Local upload_file returns guide/guideInstruction for PPTX
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #215 (reviewed post-merge to avoid rebasing #149). Fixes the runtime bugs found in review:

- **R1 (Blocker)** `sdpm/diff`: `pptx_builder.py diff <source.json> <edited.pptx>` crashed with `ImportError: cannot import name '_get_templates_dirs'` — the actual export is `get_templates_dirs` (split-PR rename leftover). Fixed the import; added source-JSON baseline regression tests (this path had no coverage).
- **R2 (High)** Cloud upload: `shared.ingest` returns `theme_hints=None` when theme extraction fails (by design, with a warning) — `process_upload` then crashed on `None.get`, reporting a **successful** conversion as *Conversion failed*. Extracted `theme_hints_ddb_item()` into `shared/schema.py` with a None guard. Extraction (vs an inline guard) because `api/index.py` cannot be imported in tests (module-level env vars + powertools dependency) — the pure helper is testable.
- **R3 (High)** `mcp-server/tools/generate.py`: silent fallback to `blank-dark.pptx` when the deck-local `template.pptx` download fails guaranteed an obscure layout mismatch later (imported decks use layout names from the original PPTX). Now raises an explicit `ValueError` with a re-import hint — both call sites (`generate_pptx` tool, `run_python` measure path) catch and surface it as a clean error message.
- Engine version 0.3.8 → 0.4.0: #215's `pptx_to_json` disk-format change (slides.json → deck structure) was breaking; MINOR bump per versioning policy.

## Testing

- `make lint` / `make test` — 335 passed, 2 skipped
- New tests: source-JSON diff baseline (load + end-to-end edit detection), `theme_hints_ddb_item` None/populated
- ASH local scan: no findings in changed files

## Not included

Medium/Low items from the same review (logic dedup, sectionLst cleanup, nits) follow in separate PRs.