### PR TITLE
refactor: PPTX import follow-up — gradient sync, summary dedup, sectionLst cleanup

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -32,6 +32,7 @@ from chat_history import (
     truncate_tool_inputs,
 )
 from common import get_user_id, now_iso, presigned_url
+from shared.ingest import PPTX_GUIDE_INSTRUCTION as _PPTX_GUIDE_INSTRUCTION
 from shared.schema import (
     deck_pk, deck_sk, shared_pk, fav_sk, upload_sk,
     DECK_SK_PREFIX, FAV_SK_PREFIX,
@@ -1459,19 +1460,6 @@ def presign_upload() -> Dict[str, Any]:
 
 # Text-extractable MIME types (can be read directly from S3 in Lambda)
 _TEXT_EXTRACTABLE = {"text/plain", "text/markdown", "application/json"}
-
-
-# Shared guide instruction for PPTX uploads — same text as Local mode.
-_PPTX_GUIDE_INSTRUCTION = (
-    "This PPTX can either be converted into an editable deck, or used as "
-    "reference material for a new deck. "
-    "If the user's intent is to edit this PPTX, call read_guides(['import-pptx']) "
-    "and follow it exactly. "
-    "If the intent is to use as reference, proceed with the normal briefing flow "
-    "and call read_uploaded_file to access content. "
-    "If the user's intent is ambiguous, use the `hearing` tool once to clarify "
-    "before choosing."
-)
 
 
 def _pptx_guide_fields(item_or_values: Dict[str, Any]) -> Dict[str, Any]:

--- a/mcp-local/upload_tools.py
+++ b/mcp-local/upload_tools.py
@@ -30,7 +30,12 @@ from pathlib import Path
 from mcp.server.fastmcp.utilities.types import Image
 from PIL import Image as PILImage
 
-from shared.ingest import IMAGE_EXTS, TEXT_EXTS, convert_file
+from shared.ingest import (
+    IMAGE_EXTS,
+    TEXT_EXTS,
+    PPTX_GUIDE_INSTRUCTION as _GUIDE_INSTRUCTION,
+    convert_file,
+)
 
 _JPEG_QUALITY = 80
 _MAX_LONG_EDGE = 1280
@@ -132,17 +137,6 @@ def _analyze_colors(file_path: Path) -> dict | None:
     except Exception:
         return None
 
-
-_GUIDE_INSTRUCTION = (
-    "This PPTX can either be converted into an editable deck, or used as "
-    "reference material for a new deck. "
-    "If the user's intent is to edit this PPTX, call read_guides(['import-pptx']) "
-    "and follow it exactly. "
-    "If the intent is to use as reference, proceed with the normal briefing flow "
-    "and call read_uploaded_file to access content. "
-    "If the user's intent is ambiguous, use the `hearing` tool once to clarify "
-    "before choosing."
-)
 
 
 def upload_file(session_id: str, file_path: str, filename: str = "") -> str:
@@ -286,77 +280,23 @@ def _format_cat_n(text: str, file_name: str, offset: int, limit: int) -> str:
 def _format_deck_text_summary(upload_dir: Path, file_name: str, offset: int, limit: int) -> str:
     """Format a deck-structure upload (deck.json + slides/) as a markdown-style text summary.
 
-    Output shape::
-
-        --- Slide 1: <title> ---
-        <body text>
-
-        --- Slide 2: <title> ---
-        ...
-
-    The title is taken from slide["title"] (string or dict-with-text).
-    Body text concatenates element ``text``, ``paragraphs[].text``, ``items``,
-    table ``headers`` / ``rows``, and recursive group elements.
+    Summary content comes from the engine (``sdpm.utils.deck_summary``);
+    this wrapper only performs filesystem I/O and cat -n pagination.
     """
+    from sdpm.utils.deck_summary import deck_text_summary
+
     slides_dir = upload_dir / "slides"
     if not slides_dir.is_dir():
         return f"No slides/ directory found in {file_name}."
 
-    def _extract_title(data: dict) -> str:
-        t = data.get("title")
-        if isinstance(t, str):
-            return t
-        if isinstance(t, dict):
-            return t.get("text", "") or ""
-        return ""
-
-    def _collect_text(node, out: list[str]) -> None:
-        if isinstance(node, dict):
-            for key in ("text", "subtitle", "label", "date", "notes"):
-                v = node.get(key)
-                if isinstance(v, str) and v.strip():
-                    out.append(v)
-            for p in node.get("paragraphs", []) or []:
-                if isinstance(p, dict):
-                    t = p.get("text")
-                    if isinstance(t, str) and t.strip():
-                        out.append(t)
-            for item in node.get("items", []) or []:
-                if isinstance(item, str) and item.strip():
-                    out.append(item)
-            headers = node.get("headers")
-            if isinstance(headers, list):
-                out.extend(str(c) for c in headers if c)
-            rows = node.get("rows")
-            if isinstance(rows, list):
-                for row in rows:
-                    if isinstance(row, list):
-                        out.extend(str(c) for c in row if c)
-            for child in node.get("elements", []) or []:
-                _collect_text(child, out)
-
-    sections: list[str] = []
-    for i, slide_file in enumerate(sorted(slides_dir.glob("slide-*.json")), start=1):
+    slides: list[dict] = []
+    for slide_file in sorted(slides_dir.glob("slide-*.json")):
         try:
-            data = json.loads(slide_file.read_text(encoding="utf-8"))
+            slides.append(json.loads(slide_file.read_text(encoding="utf-8")))
         except Exception:
-            continue
-        title = _extract_title(data)
-        header = f"--- Slide {i}: {title} ---" if title else f"--- Slide {i} ---"
-        body_parts: list[str] = []
-        for el in data.get("elements", []) or []:
-            _collect_text(el, body_parts)
-        # Drop duplicates while keeping order
-        seen: set[str] = set()
-        deduped: list[str] = []
-        for p in body_parts:
-            if p not in seen:
-                seen.add(p)
-                deduped.append(p)
-        body = "\n".join(deduped)
-        sections.append(f"{header}\n{body}".rstrip())
+            slides.append({})  # keep slide numbering aligned with file order
 
-    return _format_cat_n("\n\n".join(sections), file_name, offset, limit)
+    return _format_cat_n(deck_text_summary(slides), file_name, offset, limit)
 
 
 def read_uploaded_file(upload_id: str, offset: int = 0, limit: int = 2000) -> list:

--- a/mcp-server/tools/upload.py
+++ b/mcp-server/tools/upload.py
@@ -212,10 +212,13 @@ def _format_deck_summary_from_s3(
 ) -> str | None:
     """Return a markdown-style slide summary when the S3 prefix contains deck structure.
 
-    Output shape mirrors the Local `_format_deck_text_summary` helper so agents
-    receive identical content from both modes.
+    Summary content comes from the engine (``sdpm.utils.deck_summary``) so
+    agents receive identical content from Local and Cloud modes; this
+    wrapper only performs S3 I/O and cat -n pagination.
     """
     import json as _json
+
+    from sdpm.utils.deck_summary import deck_text_summary
 
     # Cheap check: is there a deck.json + at least one slides/slide-*.json?
     try:
@@ -231,61 +234,16 @@ def _format_deck_summary_from_s3(
     if not slide_keys:
         return None
 
-    def _extract_title(data: dict) -> str:
-        t = data.get("title")
-        if isinstance(t, str):
-            return t
-        if isinstance(t, dict):
-            return t.get("text", "") or ""
-        return ""
-
-    def _collect_text(node, out: list[str]) -> None:
-        if isinstance(node, dict):
-            for key in ("text", "subtitle", "label", "date", "notes"):
-                v = node.get(key)
-                if isinstance(v, str) and v.strip():
-                    out.append(v)
-            for p in node.get("paragraphs", []) or []:
-                if isinstance(p, dict):
-                    t = p.get("text")
-                    if isinstance(t, str) and t.strip():
-                        out.append(t)
-            for item in node.get("items", []) or []:
-                if isinstance(item, str) and item.strip():
-                    out.append(item)
-            headers = node.get("headers")
-            if isinstance(headers, list):
-                out.extend(str(c) for c in headers if c)
-            rows = node.get("rows")
-            if isinstance(rows, list):
-                for row in rows:
-                    if isinstance(row, list):
-                        out.extend(str(c) for c in row if c)
-            for child in node.get("elements", []) or []:
-                _collect_text(child, out)
-
-    sections: list[str] = []
-    for i, key in enumerate(sorted(slide_keys), start=1):
+    slides: list[dict] = []
+    for key in sorted(slide_keys):
         try:
-            data = _json.loads(
+            slides.append(_json.loads(
                 storage.download_file_from_pptx_bucket(key).decode("utf-8"),
-            )
+            ))
         except Exception:
-            continue
-        title = _extract_title(data)
-        header = f"--- Slide {i}: {title} ---" if title else f"--- Slide {i} ---"
-        body_parts: list[str] = []
-        for el in data.get("elements", []) or []:
-            _collect_text(el, body_parts)
-        seen: set[str] = set()
-        deduped: list[str] = []
-        for p in body_parts:
-            if p not in seen:
-                seen.add(p)
-                deduped.append(p)
-        sections.append(f"{header}\n{chr(10).join(deduped)}".rstrip())
+            slides.append({})  # keep slide numbering aligned with key order
 
-    return _format_cat_n("\n\n".join(sections), file_name, offset, limit)
+    return _format_cat_n(deck_text_summary(slides), file_name, offset, limit)
 
 
 def _read_converted(

--- a/scripts/translate_apply.py
+++ b/scripts/translate_apply.py
@@ -15,11 +15,13 @@ Structural attributes (layout, type, shape, src, fontColor, fontFamily, etc.)
 are never touched. ``\x0b`` (vertical tab) is preserved because the map file
 round-trips via ``json``.
 
-Entire-paragraph gradients sync automatically:  when a paragraph carries
-``_textGradientRuns`` whose concatenated text equals the paragraph's
-``text``, the runs are replaced so they stay consistent with the translated
-paragraph. Partial paragraph gradients are left unchanged — the operator
-must adjust the runs manually.
+Entire-paragraph gradients sync on a best-effort basis: when a paragraph
+carries ``_textGradientRuns`` whose concatenated text equals the paragraph's
+pre-translation ``text`` AND all runs share the same gradient, the runs are
+collapsed into a single run carrying the translated text. Multi-gradient
+runs and partial paragraph gradients cannot be re-segmented reliably after
+translation — they are left unchanged with a warning, and the operator must
+adjust the runs manually.
 """
 
 from __future__ import annotations
@@ -83,6 +85,10 @@ def _apply(
 ):
     """Recursively rewrite translatable strings in-place and return node."""
     if isinstance(node, dict):
+        # Capture the pre-translation paragraph text: _sync_gradient_runs
+        # must decide "did the runs span the entire paragraph?" against the
+        # ORIGINAL text (comparing against the translated text is meaningless).
+        original_text = node.get("text") if isinstance(node.get("text"), str) else None
         for key, value in list(node.items()):
             if key in _SKIP_KEYS:
                 continue
@@ -121,37 +127,59 @@ def _apply(
                         _apply(child, dictionary, counter)
             elif isinstance(value, dict):
                 _apply(value, dictionary, counter)
-        _sync_gradient_runs(node)
+        _sync_gradient_runs(node, original_text)
     elif isinstance(node, list):
         for child in node:
             _apply(child, dictionary, counter)
     return node
 
 
-def _sync_gradient_runs(node: dict) -> None:
-    """When a paragraph's gradient covers the whole text, rewrite runs.text.
+def _sync_gradient_runs(node: dict, original_text: str | None) -> None:
+    """Best-effort sync of ``_textGradientRuns`` after paragraph translation.
 
-    Only applies when sum of run texts equalled the original ``text`` — that
-    is the entire-paragraph gradient case. Partial gradients keep the runs
-    intact; the operator must adjust them manually.
+    The builder re-applies per-run gradients by EXACT text match
+    (``_apply_text_gradient_runs``), so stale run texts silently lose their
+    gradient in the built PPTX. Sync is only attempted when the runs
+    originally spanned the entire paragraph — their concatenation equals the
+    pre-translation ``text``:
+
+    - All runs share the same gradient → collapse to a single run carrying
+      the translated text (visually identical: whole paragraph, one gradient).
+    - Runs carry different gradients → left unchanged and a warning is
+      printed; translation moves word boundaries, so there is no reliable
+      re-segmentation. The operator must adjust the runs manually.
+
+    Partial-paragraph gradients are always left unchanged (with a warning
+    when the paragraph was translated), never expanded to the whole text.
     """
-    if not isinstance(node, dict):
-        return
     runs = node.get("_textGradientRuns")
     text = node.get("text")
-    if not isinstance(runs, list) or not isinstance(text, str):
+    if not isinstance(runs, list) or not isinstance(text, str) or original_text is None:
         return
     if not all(isinstance(r, dict) and isinstance(r.get("text", ""), str) for r in runs):
         return
+    if text == original_text:
+        return  # paragraph not translated; runs still in sync
     run_concat = "".join(r.get("text", "") for r in runs)
-    # Only sync when the runs originally spanned the entire paragraph.
-    if run_concat and run_concat == text:
-        # Already in sync (pre-translation state); no-op.
+    if not run_concat or run_concat != original_text:
+        # Partial-paragraph gradient: the run texts no longer occur in the
+        # translated paragraph, so the gradient will not re-apply on build.
+        print(
+            "WARNING: partial-paragraph gradient runs left unsynced for "
+            f"translated text {text[:40]!r} — adjust _textGradientRuns manually.",
+            file=sys.stderr,
+        )
         return
-    if run_concat and run_concat != text:
-        # If the text is now shorter/longer (translated), collapse to single run.
-        if len(runs) == 1:
-            runs[0]["text"] = text
+    gradients = {json.dumps(r.get("gradient"), sort_keys=True) for r in runs}
+    if len(gradients) == 1:
+        node["_textGradientRuns"] = [{"text": text, "gradient": runs[0].get("gradient")}]
+    else:
+        print(
+            "WARNING: multi-gradient runs spanning the paragraph could not be "
+            f"synced for translated text {text[:40]!r} — adjust "
+            "_textGradientRuns manually.",
+            file=sys.stderr,
+        )
 
 
 def _diff_summary(before: dict, after: dict) -> list[tuple[str, str]]:

--- a/shared/ingest.py
+++ b/shared/ingest.py
@@ -39,6 +39,21 @@ _IMAGE_EXTS = IMAGE_EXTS
 _TEXT_EXTS = TEXT_EXTS
 _PASSTHROUGH_EXTS = PASSTHROUGH_EXTS
 
+# Agent-facing hint returned with PPTX uploads (deck-structure conversions).
+# Single source shared by the Cloud upload path (api/index.py) and the Local
+# upload path (mcp-local/upload_tools.py) — keep intent-branching wording
+# identical across modes.
+PPTX_GUIDE_INSTRUCTION = (
+    "This PPTX can either be converted into an editable deck, or used as "
+    "reference material for a new deck. "
+    "If the user's intent is to edit this PPTX, call read_guides(['import-pptx']) "
+    "and follow it exactly. "
+    "If the intent is to use as reference, proceed with the normal briefing flow "
+    "and call read_uploaded_file to access content. "
+    "If the user's intent is ambiguous, use the `hearing` tool once to clarify "
+    "before choosing."
+)
+
 
 @dataclass
 class ConversionResult:

--- a/skill/sdpm/converter/template.py
+++ b/skill/sdpm/converter/template.py
@@ -19,6 +19,29 @@ from pptx import Presentation
 
 _REL_NS = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
 
+# Extension URI of the PowerPoint section list (p14:sectionLst) inside
+# presentation.xml's <p:extLst>.
+_SECTION_EXT_URI = "{521415D9-36F7-43E2-AB2F-B90AF26B5E84}"
+
+
+def _drop_section_list(presentation_el) -> None:
+    """Remove the section-list ext from a <p:presentation> element.
+
+    Args:
+        presentation_el: The lxml ``<p:presentation>`` element
+            (parent of ``<p:sldIdLst>``).
+    """
+    from pptx.oxml.ns import qn
+
+    ext_lst = presentation_el.find(qn("p:extLst"))
+    if ext_lst is None:
+        return
+    for ext in list(ext_lst.findall(qn("p:ext"))):
+        if ext.get("uri") == _SECTION_EXT_URI:
+            ext_lst.remove(ext)
+    if len(ext_lst) == 0:
+        presentation_el.remove(ext_lst)
+
 
 def extract_placeholder_template(
     pptx_path: str | Path,
@@ -64,6 +87,14 @@ def extract_placeholder_template(
             except KeyError:
                 pass
         sldIdLst.remove(entry)
+
+    # Step 2b: drop the section list (p14:sectionLst) if present. Sections
+    # reference the original slide IDs; keeping them after the slides are
+    # dropped leaves stale IDs that trigger PowerPoint's repair prompt.
+    # Removing the whole ext (rather than patching individual entries) is
+    # the safest option — section grouping is meaningless for a
+    # placeholder-only template anyway.
+    _drop_section_list(sldIdLst.getparent())
 
     # Step 3: emit one placeholder-only sample slide per *used* layout.
     # Iterate masters/layouts in their original order so the output

--- a/skill/sdpm/utils/deck_summary.py
+++ b/skill/sdpm/utils/deck_summary.py
@@ -1,0 +1,102 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Deck-structure text summary: slide dicts → readable text.
+
+Pure "dict → text" logic shared by the Local (filesystem) and Cloud (S3)
+upload-reading paths. Each consumer performs its own I/O (reading slide
+JSONs) and output formatting (pagination, line numbering); this module owns
+only the summary content so agents receive identical text from both modes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def extract_slide_title(data: dict) -> str:
+    """Return the slide title from ``title`` (plain string or dict-with-text).
+
+    Args:
+        data: A slide JSON dict.
+
+    Returns:
+        Title string, or "" when absent.
+    """
+    t = data.get("title")
+    if isinstance(t, str):
+        return t
+    if isinstance(t, dict):
+        return t.get("text", "") or ""
+    return ""
+
+
+def collect_slide_text(node, out: list[str]) -> None:
+    """Recursively append human-readable text found in a slide element.
+
+    Collects element ``text``, ``subtitle``, ``label``, ``date``, ``notes``,
+    ``paragraphs[].text``, ``items``, table ``headers`` / ``rows``, and
+    recurses into group ``elements``.
+
+    Args:
+        node: Slide element (dict) or arbitrary JSON node.
+        out: List to append found strings to (in document order).
+    """
+    if isinstance(node, dict):
+        for key in ("text", "subtitle", "label", "date", "notes"):
+            v = node.get(key)
+            if isinstance(v, str) and v.strip():
+                out.append(v)
+        for p in node.get("paragraphs", []) or []:
+            if isinstance(p, dict):
+                t = p.get("text")
+                if isinstance(t, str) and t.strip():
+                    out.append(t)
+        for item in node.get("items", []) or []:
+            if isinstance(item, str) and item.strip():
+                out.append(item)
+        headers = node.get("headers")
+        if isinstance(headers, list):
+            out.extend(str(c) for c in headers if c)
+        rows = node.get("rows")
+        if isinstance(rows, list):
+            for row in rows:
+                if isinstance(row, list):
+                    out.extend(str(c) for c in row if c)
+        for child in node.get("elements", []) or []:
+            collect_slide_text(child, out)
+
+
+def deck_text_summary(slides: Iterable[dict]) -> str:
+    """Format ordered slide dicts as a markdown-style text summary.
+
+    Output shape::
+
+        --- Slide 1: <title> ---
+        <body text>
+
+        --- Slide 2: <title> ---
+        ...
+
+    Args:
+        slides: Slide JSON dicts in presentation order.
+
+    Returns:
+        Summary text (sections joined by blank lines).
+    """
+    sections: list[str] = []
+    for i, data in enumerate(slides, start=1):
+        title = extract_slide_title(data)
+        header = f"--- Slide {i}: {title} ---" if title else f"--- Slide {i} ---"
+        body_parts: list[str] = []
+        for el in data.get("elements", []) or []:
+            collect_slide_text(el, body_parts)
+        # Drop duplicates while keeping order
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for p in body_parts:
+            if p not in seen:
+                seen.add(p)
+                deduped.append(p)
+        body = "\n".join(deduped)
+        sections.append(f"{header}\n{body}".rstrip())
+    return "\n\n".join(sections)

--- a/tests/test_pptx_import.py
+++ b/tests/test_pptx_import.py
@@ -533,6 +533,65 @@ class TestExtractPlaceholderTemplate:
     """extract_placeholder_template keeps every master/layout, replaces slides
     with one placeholder-only sample per *used* layout."""
 
+    def test_drops_stale_section_list(self, fixture_pptx: Path, tmp_path: Path) -> None:
+        """Sections referencing dropped slide IDs must be removed (R6).
+
+        Corporate templates often use sections; stale slide IDs inside
+        <p14:sectionLst> trigger PowerPoint's repair prompt.
+        """
+        from lxml import etree
+        from pptx import Presentation
+        from pptx.oxml.ns import qn
+        from sdpm.converter.template import extract_placeholder_template
+
+        _P14 = "http://schemas.microsoft.com/office/powerpoint/2010/main"
+        _SECTION_URI = "{521415D9-36F7-43E2-AB2F-B90AF26B5E84}"
+
+        # Build a section-bearing fixture: wrap all slides in one section.
+        prs = Presentation(str(fixture_pptx))
+        pres_el = prs.slides._sldIdLst.getparent()
+        slide_ids = [e.get("id") for e in prs.slides._sldIdLst]
+        assert slide_ids, "fixture must have slides"
+        ext_lst = pres_el.find(qn("p:extLst"))
+        if ext_lst is None:
+            ext_lst = etree.SubElement(pres_el, qn("p:extLst"))
+        ext = etree.SubElement(ext_lst, qn("p:ext"))
+        ext.set("uri", _SECTION_URI)
+        section_lst = etree.SubElement(ext, f"{{{_P14}}}sectionLst")
+        section = etree.SubElement(section_lst, f"{{{_P14}}}section")
+        section.set("name", "Intro")
+        section.set("id", "{11111111-1111-1111-1111-111111111111}")
+        sect_slides = etree.SubElement(section, f"{{{_P14}}}sldIdLst")
+        for sid in slide_ids:
+            sld = etree.SubElement(sect_slides, f"{{{_P14}}}sldId")
+            sld.set("id", sid)
+        src = tmp_path / "with_sections.pptx"
+        prs.save(str(src))
+
+        out = tmp_path / "template.pptx"
+        extract_placeholder_template(src, out)
+
+        out_prs = Presentation(str(out))
+        out_xml = etree.tostring(
+            out_prs.slides._sldIdLst.getparent(), encoding="unicode",
+        )
+        assert "sectionLst" not in out_xml, "stale sectionLst must be dropped"
+        assert _SECTION_URI not in out_xml
+        # Output must still be loadable with slides present.
+        assert len(out_prs.slides) > 0
+
+    def test_source_without_sections_is_unaffected(
+        self, fixture_pptx: Path, tmp_path: Path
+    ) -> None:
+        """No-section sources keep working (guard for the cleanup step)."""
+        from pptx import Presentation
+        from sdpm.converter.template import extract_placeholder_template
+
+        out = tmp_path / "template.pptx"
+        meta = extract_placeholder_template(fixture_pptx, out)
+        assert meta["used_layout_count"] > 0
+        assert len(Presentation(str(out)).slides) > 0
+
     def test_drops_source_content_emits_one_slide_per_used_layout(
         self, fixture_pptx: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_pptx_import.py
+++ b/tests/test_pptx_import.py
@@ -151,6 +151,7 @@ class TestConvertPptxThemeHints:
         assert 0.0 <= result.theme_hints["backgroundLuminance"] <= 1.0
 
 
+
 class TestThemeHintsDdbItem:
     """theme_hints_ddb_item must tolerate theme_hints=None (PR #215 follow-up, R2).
 
@@ -182,6 +183,59 @@ class TestThemeHintsDdbItem:
         assert item["backgroundLuminance"] == Decimal("0.12")
         assert item["accentColors"] == ["#FF0000"]
         assert item["fonts"] == {"halfwidth": "Arial"}
+
+
+class TestDeckTextSummaryEngine:
+    """sdpm.utils.deck_summary — single source for Local/Cloud text summaries.
+
+    PR #215 follow-up (R5): the summary logic was verbatim-duplicated in
+    mcp-local/upload_tools.py and mcp-server/tools/upload.py; it now lives
+    in the engine per the logic-sharing steering.
+    """
+
+    def test_summary_shape_titles_and_dedup(self) -> None:
+        from sdpm.utils.deck_summary import deck_text_summary
+
+        slides = [
+            {
+                "title": "Plain Title",
+                "elements": [
+                    {"type": "textbox", "text": "Body text"},
+                    {"type": "textbox", "text": "Body text"},  # duplicate → dropped
+                ],
+            },
+            {
+                "title": {"text": "Dict Title"},
+                "elements": [
+                    {
+                        "type": "group",
+                        "elements": [{"type": "textbox", "text": "Nested"}],
+                    },
+                    {
+                        "type": "table",
+                        "headers": ["H1", "H2"],
+                        "rows": [["a", "b"]],
+                    },
+                    {"type": "textbox", "items": ["Item A"]},
+                ],
+            },
+            {},  # unparseable/empty slide keeps its number
+        ]
+        out = deck_text_summary(slides)
+        assert "--- Slide 1: Plain Title ---" in out
+        assert out.count("Body text") == 1
+        assert "--- Slide 2: Dict Title ---" in out
+        assert "Nested" in out and "H1" in out and "Item A" in out
+        assert "--- Slide 3 ---" in out
+
+    def test_local_and_cloud_wrappers_delegate_to_engine(self) -> None:
+        """Guard against re-duplication: neither consumer defines the logic."""
+        local_src = (_REPO_ROOT / "mcp-local" / "upload_tools.py").read_text(encoding="utf-8")
+        cloud_src = (_REPO_ROOT / "mcp-server" / "tools" / "upload.py").read_text(encoding="utf-8")
+        for src, name in ((local_src, "mcp-local"), (cloud_src, "mcp-server")):
+            assert "deck_text_summary" in src, f"{name} must use the engine helper"
+            assert "def _collect_text" not in src, f"{name} re-duplicates _collect_text"
+            assert "def _extract_title" not in src, f"{name} re-duplicates _extract_title"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -313,3 +313,86 @@ class TestTranslateApply:
         assert proc.returncode == 0
         brief = (derived / "specs" / "brief.md").read_text(encoding="utf-8")
         assert "Original English content" in brief, "specs/ must remain in source language"
+
+
+# ---------------------------------------------------------------------------
+# _sync_gradient_runs — gradient run sync after translation (PR #215 follow-up, R4)
+# ---------------------------------------------------------------------------
+
+
+def _load_apply_module():
+    """Import scripts/translate_apply.py as a module for unit-level tests."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("translate_apply", _APPLY_CLI)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_GRAD_A = {"angle": 0, "stops": [{"position": 0.0, "color": "#FF0000"}]}
+_GRAD_B = {"angle": 0, "stops": [{"position": 0.0, "color": "#0000FF"}]}
+
+
+class TestSyncGradientRuns:
+    """Sync decisions must compare against the PRE-translation text.
+
+    The old implementation ran after text replacement and compared
+    run-concat against the translated text, so: multi-run whole-paragraph
+    gradients were never synced, and a partial-gradient single run was
+    wrongly expanded to the full translated text.
+    """
+
+    def _apply_node(self, node: dict, dictionary: dict[str, str]) -> dict:
+        mod = _load_apply_module()
+        return mod._apply(node, dictionary, {})
+
+    def test_whole_paragraph_multi_run_same_gradient_collapses(self) -> None:
+        node = {
+            "text": "Hello World",
+            "_textGradientRuns": [
+                {"text": "Hello ", "gradient": _GRAD_A},
+                {"text": "World", "gradient": _GRAD_A},
+            ],
+        }
+        self._apply_node(node, {"Hello World": "こんにちは世界"})
+        assert node["text"] == "こんにちは世界"
+        assert node["_textGradientRuns"] == [
+            {"text": "こんにちは世界", "gradient": _GRAD_A},
+        ]
+
+    def test_whole_paragraph_single_run_syncs(self) -> None:
+        node = {
+            "text": "Hello",
+            "_textGradientRuns": [{"text": "Hello", "gradient": _GRAD_A}],
+        }
+        self._apply_node(node, {"Hello": "こんにちは"})
+        assert node["_textGradientRuns"] == [
+            {"text": "こんにちは", "gradient": _GRAD_A},
+        ]
+
+    def test_partial_gradient_single_run_is_not_expanded(self) -> None:
+        """Regression: a partial-paragraph gradient run must stay untouched."""
+        node = {
+            "text": "Hello World",
+            "_textGradientRuns": [{"text": "World", "gradient": _GRAD_A}],
+        }
+        self._apply_node(node, {"Hello World": "こんにちは世界"})
+        # Old code rewrote runs[0].text to the full translated text,
+        # expanding the gradient to the entire paragraph.
+        assert node["_textGradientRuns"] == [{"text": "World", "gradient": _GRAD_A}]
+
+    def test_multi_gradient_runs_left_unchanged(self) -> None:
+        runs = [
+            {"text": "Hello ", "gradient": _GRAD_A},
+            {"text": "World", "gradient": _GRAD_B},
+        ]
+        node = {"text": "Hello World", "_textGradientRuns": [dict(r) for r in runs]}
+        self._apply_node(node, {"Hello World": "こんにちは世界"})
+        assert node["_textGradientRuns"] == runs
+
+    def test_untranslated_paragraph_is_untouched(self) -> None:
+        runs = [{"text": "Hello", "gradient": _GRAD_A}]
+        node = {"text": "Hello", "_textGradientRuns": [dict(r) for r in runs]}
+        self._apply_node(node, {})
+        assert node["_textGradientRuns"] == runs


### PR DESCRIPTION
## Summary

Second follow-up to #215 (post-merge review items, Medium severity). Companion to #219.

- **R4** `scripts/translate_apply.py`: `_sync_gradient_runs` ran **after** text replacement and compared run-concat against the *translated* text, so the whole-paragraph judgment never held — multi-run gradients were never synced, and a partial-gradient single run was **wrongly expanded to the full translated text**. Now captures the pre-translation text, collapses same-gradient whole-paragraph runs into one run (visually identical), and warns on unsyncable cases instead of silently skipping. Module docstring aligned with actual behavior.
  - Deliberately **not** implementing proportional re-segmentation for multi-gradient runs: the builder re-applies gradients by exact run-text match, and translation moves word boundaries — mechanical splits would not match at build time.
- **R5** Deck text summary (`_extract_title` / `_collect_text`) was verbatim-duplicated in `mcp-local/upload_tools.py` and `mcp-server/tools/upload.py`. Moved the pure dict→text logic to `sdpm.utils.deck_summary` per the logic-sharing principle; each layer keeps only its I/O (filesystem vs S3) and cat -n pagination. `_PPTX_GUIDE_INSTRUCTION` single-sourced in `shared/ingest.py` (both consumers already import it). Added a source-inspection test that fails if the logic gets re-duplicated.
- **R6** `extract_placeholder_template`: after dropping all original slides, the section list in presentation.xml (`<p:ext uri={521415D9-...}><p14:sectionLst>`) kept stale slide IDs — PowerPoint shows a repair prompt for section-using decks (common in corporate templates). The whole section ext is now removed (section grouping is meaningless for a placeholder-only template). Tested with a synthesized section-bearing fixture.

## Testing

- `make lint` / `make test` — 340 passed, 2 skipped
- New tests: 5 gradient-sync unit tests (incl. regression for the partial-gradient expansion bug), engine deck-summary tests + re-duplication guard, sectionLst cleanup + no-section guard

## Note

Both this PR and #219 touch the import block of `api/index.py` — whichever merges second may need a trivial conflict resolution.