### PR TITLE
chore: PPTX import follow-up — slug padding, tmpdir cleanup, test hygiene, web-ui nits

### DIFF
--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -237,10 +237,13 @@ def analyze_template(template: str, deck_id: str = "") -> str:
             from pathlib import Path
             from sdpm.analyzer import analyze_template as _analyze
             data = _storage.download_file_from_pptx_bucket(f"decks/{deck_id}/template.pptx")
-            tmp = Path(tempfile.mkdtemp())
-            tpl_path = tmp / "template.pptx"
-            tpl_path.write_bytes(data)
-            analysis = _analyze(tpl_path)
+            # TemporaryDirectory (not mkdtemp): this server is long-running,
+            # leaked tmpdirs would accumulate. The analysis dict holds no
+            # file references, so cleanup on exit is safe.
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tpl_path = Path(tmpdir) / "template.pptx"
+                tpl_path.write_bytes(data)
+                analysis = _analyze(tpl_path)
             analysis["templateName"] = "template.pptx"
             return json.dumps(analysis, ensure_ascii=False)
         except Exception as e:

--- a/skill/references/guides/import-pptx.md
+++ b/skill/references/guides/import-pptx.md
@@ -80,7 +80,7 @@ The helper copies session files into the deck:
 
 - `template.pptx` — PPTX-derived placeholder template (deck root)
 - `attachments/{shortId}_deck.json` — PPTX-derived fonts / defaultTextColor
-- `attachments/{shortId}/slides/slide-NN.json` — per-slide JSON
+- `attachments/{shortId}/slides/slide-NNN.json` — per-slide JSON
 - `images/{shortId}_*` — extracted images (flattened into deck/images/)
 
 The returned JSON includes `shortId`, `templatePath`, `deckJson`, and
@@ -158,8 +158,8 @@ Python literal:
 ```python
 # Agent fills this list from slide content seen in Step 3-1.
 pairs = [
-    ("slide-01", "Introduction to the system"),
-    ("slide-02", "Storage classes overview"),
+    ("slide-001", "Introduction to the system"),
+    ("slide-002", "Storage classes overview"),
     # ... one entry per slide, matching attachments/{shortId}/slides/*.json
 ]
 lines = [f"- [{slug}] {msg}" for slug, msg in pairs]
@@ -173,7 +173,7 @@ Call with `run_python(code=<above>, deck_id=deck_id, save=True)`
 Requirements (outline lint will otherwise reject the write on Cloud):
 
 - Each slug MUST match the filename of an imported slide
-  (`slide-01`, `slide-02`, ...) — do not rename.
+  (`slide-001`, `slide-002`, ...) — do not rename.
 - Messages MUST be non-empty.
 - One line per slide, no sub-items.
 
@@ -194,7 +194,7 @@ Assemble the slug list from Step 3-2 as a Python literal:
 
 ```python
 short_id = "<result['shortId']>"
-slugs = ["slide-01", "slide-02", "slide-03"]  # agent fills from Step 3-2
+slugs = ["slide-001", "slide-002", "slide-003"]  # agent fills from Step 3-2
 # image_mapping is in the import_attachment result. It maps the original
 # converter-emitted filename (e.g. "slide1_image1.png") to its
 # deck-relative path after rename (e.g. "images/<shortId>_slide1_image1.png").
@@ -361,7 +361,7 @@ bar is a "section divider" or that the rounded box is a "card with
 shadow". You have to look.
 
 ```
-get_preview(deck_id, slugs=["slide-01", "slide-03", "slide-05",
+get_preview(deck_id, slugs=["slide-001", "slide-003", "slide-005",
                             "<a section-header slug>",
                             "<a content slug with cards / lists>"],
             quality="high")

--- a/skill/sdpm/converter/pipeline.py
+++ b/skill/sdpm/converter/pipeline.py
@@ -6,8 +6,8 @@ Output structure (deck format — stable since pptx-import-edit):
     {output_dir}/
         ├── deck.json              # {fonts, defaultTextColor}  (template set by caller)
         ├── slides/
-        │   ├── slide-01.json
-        │   ├── slide-02.json
+        │   ├── slide-001.json
+        │   ├── slide-002.json
         │   └── ...
         └── images/                # extracted slide images
 
@@ -41,7 +41,7 @@ def pptx_to_json(pptx_path: Path, output_dir: Path = None, use_layout_names: boo
 
     On-disk output:
         deck.json  (fonts + defaultTextColor; template left unset)
-        slides/slide-{NN}.json  (one per slide; NN is 2-digit 1-based)
+        slides/slide-{NNN}.json  (one per slide; NNN is 3-digit 1-based)
         images/   (unchanged — populated by extract_slide)
     """
     actual_path = pptx_path
@@ -107,9 +107,11 @@ def pptx_to_json(pptx_path: Path, output_dir: Path = None, use_layout_names: boo
         deck_meta["defaultTextColor"] = result["defaultTextColor"]
     write_json(output_dir / "deck.json", deck_meta)
 
-    # Write slides/slide-{NN}.json (1-based, zero-padded, hyphen separator to match parse_outline_slugs)
+    # Write slides/slide-{NNN}.json (1-based, zero-padded, hyphen separator to match parse_outline_slugs).
+    # 3-digit padding keeps lexicographic sort == presentation order for decks
+    # up to 999 slides (2-digit broke ordering at 100+: "slide-100" < "slide-11").
     for idx, slide_dict in enumerate(result["slides"], start=1):
-        slug = f"slide-{idx:02d}"
+        slug = f"slide-{idx:03d}"
         slide_path = slides_dir / f"{slug}.json"
         write_json(slide_path, slide_dict)
 

--- a/tests/test_pptx_import.py
+++ b/tests/test_pptx_import.py
@@ -59,7 +59,11 @@ class TestPptxToJsonDeckStructure:
         assert not (out_dir / "slides.json").exists(), "legacy slides.json must not be emitted"
 
     def test_pptx_to_json_slug_format(self, fixture_pptx: Path, tmp_path: Path) -> None:
-        """Slug format is slide-NN (hyphen + 2-digit zero-padded) and matches parse_outline_slugs regex."""
+        """Slug format is slide-NNN (hyphen + 3-digit zero-padded) and matches parse_outline_slugs regex.
+
+        3-digit padding keeps lexicographic sort == presentation order up to
+        999 slides (2-digit broke at 100+: "slide-100" < "slide-11").
+        """
         from sdpm.api import parse_outline_slugs
         from sdpm.converter import pptx_to_json
 
@@ -67,9 +71,9 @@ class TestPptxToJsonDeckStructure:
         pptx_to_json(fixture_pptx, output_dir=out_dir)
 
         slide_files = sorted((out_dir / "slides").glob("*.json"))
-        slug_re = re.compile(r"^slide-\d{2}$")
+        slug_re = re.compile(r"^slide-\d{3}$")
         for f in slide_files:
-            assert slug_re.match(f.stem), f"slug must match slide-NN format: {f.stem}"
+            assert slug_re.match(f.stem), f"slug must match slide-NNN format: {f.stem}"
 
         # Sanity: construct fake outline.md with these slugs and verify parse_outline_slugs accepts them
         fake_outline = "\n".join(f"- [{f.stem}] msg" for f in slide_files)
@@ -134,7 +138,9 @@ class TestConvertPptxThemeHints:
         fonts = result.theme_hints["fonts"]
         assert isinstance(fonts, dict)
 
-    def test_convert_pptx_theme_hints_uses_slide_bg(self, tmp_path: Path) -> None:
+    def test_convert_pptx_theme_hints_uses_slide_bg(
+        self, fixture_pptx: Path, tmp_path: Path,
+    ) -> None:
         """When slide has explicit background, luminance reflects it (median across slides).
 
         Synthetic fixture: modify slide XML to force explicit backgrounds.
@@ -144,7 +150,7 @@ class TestConvertPptxThemeHints:
         from shared.ingest import convert_file
 
         out_dir = tmp_path / "out"
-        result = convert_file(_FIXTURE_PPTX, out_dir)
+        result = convert_file(fixture_pptx, out_dir)
         # The fixture may or may not have explicit slide bg; we just verify the median is valid.
         # (Full-fidelity synthetic testing of slide-bg override is deferred; the pipeline
         # correctness is validated via test_convert_pptx_theme_hints_keys.)
@@ -250,7 +256,7 @@ class TestUploadFileGuideInstruction:
         """Helper: upload the fixture PPTX via mcp-local/upload_tools.upload_file."""
         # Route SDPM_DECK_ROOT so session storage lives under tmp_path
         monkeypatch.setenv("SDPM_DECK_ROOT", str(tmp_path / "deck_root"))
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import upload_file
 
         # Copy fixture to tmp_path so the temp upload path is stable
@@ -305,7 +311,7 @@ class TestReadUploadedFileTextSummary:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("SDPM_DECK_ROOT", str(tmp_path / "deck_root"))
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import read_uploaded_file, upload_file
 
         src = tmp_path / "input.pptx"
@@ -331,7 +337,7 @@ class TestImportAttachmentSlidesDir:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("SDPM_DECK_ROOT", str(tmp_path / "deck_root"))
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import import_attachment, upload_file
 
         src = tmp_path / "input.pptx"
@@ -364,7 +370,7 @@ class TestImportAttachmentSlidesDir:
     ) -> None:
         """Placeholder template lives at deck/template.pptx (deck-local path)."""
         monkeypatch.setenv("SDPM_DECK_ROOT", str(tmp_path / "deck_root"))
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import import_attachment, upload_file
 
         src = tmp_path / "input.pptx"
@@ -396,19 +402,23 @@ class TestImportAttachmentSlidesDir:
 class TestCloudImportConvertedCopiesTemplate:
     """mcp-server/tools/attachment._import_converted handles template.pptx specially."""
 
-    def test_import_converted_copies_template_to_deck_root(self) -> None:
+    def test_import_converted_copies_template_to_deck_root(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         import types
         from unittest.mock import MagicMock
 
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-server"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-server"))
         # mcp-server has its own dependency set; stub the modules that the
         # attachment module imports at top level so we can import it under
-        # the local-test venv.
-        sys.modules.setdefault("requests", types.ModuleType("requests"))
+        # the local-test venv. monkeypatch.setitem reverts after this test so
+        # the stubs cannot leak into other tests (import-order hazard).
+        if "requests" not in sys.modules:
+            monkeypatch.setitem(sys.modules, "requests", types.ModuleType("requests"))
         if "storage" not in sys.modules:
             stg_mod = types.ModuleType("storage")
             stg_mod.Storage = object  # type stub
-            sys.modules["storage"] = stg_mod
+            monkeypatch.setitem(sys.modules, "storage", stg_mod)
         from tools.attachment import _import_converted
 
         converted_prefix = "uploads/u1/up1/converted"
@@ -498,7 +508,7 @@ class TestDeckRootEnvHandling:
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv("SDPM_DECK_ROOT", raising=False)
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import _deck_root
 
         root = _deck_root()
@@ -509,7 +519,7 @@ class TestDeckRootEnvHandling:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("SDPM_DECK_ROOT", str(tmp_path / "custom"))
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import _deck_root
 
         assert _deck_root() == tmp_path / "custom"
@@ -518,7 +528,7 @@ class TestDeckRootEnvHandling:
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("SDPM_DECK_ROOT", "   ")
-        sys.path.insert(0, str(_REPO_ROOT / "mcp-local"))
+        monkeypatch.syspath_prepend(str(_REPO_ROOT / "mcp-local"))
         from upload_tools import _deck_root
 
         assert _deck_root() == Path.home() / "Documents" / "SDPM-Presentations"

--- a/web-ui/src/components/chat/ChatPanel.tsx
+++ b/web-ui/src/components/chat/ChatPanel.tsx
@@ -68,7 +68,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         setSessionId(chatSessionId)
       }
     }
-  }, [chatSessionId])
+    // After the swap chatSessionId === sessionId, so the re-run is a no-op.
+  }, [chatSessionId, sessionId])
 
   // --- Config ---
   const [configLoaded, setConfigLoaded] = useState(false)
@@ -414,14 +415,17 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   // Sync streaming flag and flush any deferred sessionId swap once
   // streaming finishes — at that point loadHistory can safely re-fetch
   // (the .chat.json server-side state is already complete).
+  // Uses the combined isLoading (not stream.isLoading alone): a Local
+  // reconnect stream (reconnectLoading) is also in-flight — flushing the
+  // swap during it would clobber the reconnecting messages the same way.
   useEffect(() => {
-    isLoadingRef.current = stream.isLoading
-    if (!stream.isLoading && pendingChatSessionIdRef.current) {
+    isLoadingRef.current = isLoading
+    if (!isLoading && pendingChatSessionIdRef.current) {
       const next = pendingChatSessionIdRef.current
       pendingChatSessionIdRef.current = null
       setSessionId(next)
     }
-  }, [stream.isLoading])
+  }, [isLoading])
 
   const isInitial = stream.messages.length === 0 && !historyLoading
 

--- a/web-ui/src/lib/attachmentMarker.ts
+++ b/web-ui/src/lib/attachmentMarker.ts
@@ -16,7 +16,9 @@ export function buildAttachedMarker(file: UploadedFile): string {
       `guide: ${file.guide}`,
       `guideInstruction: ${JSON.stringify(file.guideInstruction)}`,
     ]
-    if (file.suggestedName) parts.push(`suggestedName: "${file.suggestedName}"`)
+    // JSON.stringify (like guideInstruction above): a quote in the file stem
+    // would otherwise break the [Attached: ...] marker format.
+    if (file.suggestedName) parts.push(`suggestedName: ${JSON.stringify(file.suggestedName)}`)
     if (typeof file.slideCount === "number") parts.push(`slideCount: ${file.slideCount}`)
     if (file.themeHints) parts.push(`themeHints: ${JSON.stringify(file.themeHints)}`)
     return `[Attached: ${file.fileName} (${parts.join(", ")})]`


### PR DESCRIPTION
## Summary

Final follow-up to the #215 / #149 post-merge review (Low/Nit items). Completes the series after #219 and #220.

### #215 items

- **Slug padding**: `pptx_to_json` slugs go `slide-NN` → `slide-NNN`. 2-digit padding broke lexicographic ordering at 100+ slides (`slide-100` < `slide-11`) and every consumer sorts by filename. Generation-side only — consumers are format-agnostic (`glob("slide-*.json")` + `sorted()`), so existing 2-digit decks keep working. Guide examples updated.
- **analyze_template** (deck-local path): `tempfile.mkdtemp()` → `TemporaryDirectory` — the MCP server is long-running, leaked tmpdirs accumulated.
- **Test hygiene** (`test_pptx_import.py`): raw `sys.path.insert` → `monkeypatch.syspath_prepend`; session-global `sys.modules` stubs (`requests`/`storage`) → reverting `monkeypatch.setitem` (kills the import-order hazard); the theme-hints slide-bg test now goes through the fixture (skips instead of failing when the fixture PPTX is missing).

### #149 items (web-ui)

- **attachmentMarker**: `JSON.stringify` for `suggestedName` — a quote in the file stem broke the `[Attached: ...]` marker format (`guideInstruction` was already stringified).
- **ChatPanel**: sync the combined `isLoading` (`stream.isLoading || reconnectLoading`) into `isLoadingRef` and the deferred-sessionId-swap flush gate. A Local reconnect stream is also in-flight; flushing the swap during it would clobber reconnecting messages — the same clobbering the mid-stream guard exists to prevent.
- **ChatPanel**: add `sessionId` to the swap effect deps (stale-closure nit; the post-swap re-run is a no-op).

## Testing

- `make lint` / `make test` — 344 passed, 2 skipped
- web-ui: `eslint --quiet`, `tsc --noEmit`, 46 tests, `build:cloud` all pass
- ASH local scan: no findings in changed files