### PR TITLE
ci: bump node 20 -> 24 to match lockfile-generating environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: web-ui/package-lock.json
       - name: Install
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: web-ui/package-lock.json
       - name: Install
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: infra/package-lock.json
       - name: Install


### PR DESCRIPTION
Dependabot and local dev
  generate `package-lock.json` with npm 11, whose lockfiles fail npm 10.8.2's `npm ci` sync check (missing transitive
  entries like `@swc/helpers` / `@emnapi/*`). This broke every web-ui deps PR (#213, #214 required manual lockfile
  regeneration).

  npm lockfile compatibility is backward-only — the verifying side (CI) must run npm >= the generating side (Dependabot,
  contributors). Node 24 (npm 11) satisfies Next.js 16 (>=20.9) and CDK requirements.

  ## Validation
  - Local dev already runs node 24 / npm 11: web-ui `npm ci` + lint + tsc + test + `build:cloud` all pass (verified on #214)
  - infra: npm 10-generated lockfile remains readable by npm 11 (backward compat)