### PR TITLE
fix(kiro): repair stale MCP registration + surface make install-kiro in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,19 @@ Do NOT work inside this repo for everyday slide generation.
 
 The skill entry point is `skill/SKILL.md` — agents read it to discover workflows.
 
-**Install into an agent's skill directory (recommended)** (e.g. `~/.kiro/skills/sdpm/`):
+**Kiro CLI users — one make target (recommended):**
+
+```bash
+make install-kiro
+```
+
+Symlinks the skills into `~/.kiro/skills/`, generates the composer agent config, and
+registers the `sdpm` local MCP server. Keep the checkout in place (the MCP server runs
+from it); `git pull` is enough to update. See the [README](README.md#-kiro-cli-setup-skill--parallel-compose-sub-agents).
+
+**Claude Code users:** install the plugin instead (`/plugin install sdpm@sdpm`) — it registers the local MCP server, skill, and compose sub-agent automatically. See the README.
+
+**Other agents — install into the agent's skill directory manually:**
 copy or symlink `skill/` into the agent's configured skill path, then install dependencies:
 
 ```bash
@@ -36,8 +48,6 @@ cd skill && uv sync
 ```
 
 Consult your agent's docs for the exact skill path. See [Getting Started](docs/en/getting-started.md#layer-1-kiro-cli-skill).
-
-**Claude Code users:** install the plugin instead (`/plugin install sdpm@sdpm`) — it registers the local MCP server, skill, and compose sub-agent automatically. See the README.
 
 Note: installing `skill/` as a pip package (`pip install git+...#subdirectory=skill`) only installs the `sdpm` Python engine — the SKILL.md, templates, and references are not bundled. It is intended for embedding the engine (e.g. the L3 Docker image), not for end-user skill installs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ Do NOT work inside this repo for everyday slide generation.
 
 | Environment | Layer | AWS |
 |---|---|:---:|
-| SKILL.md-compatible agent (Claude Code, Codex CLI, Cursor, Kiro, Copilot) | **L1** `skill/` | No |
-| Local MCP client (Claude Desktop, Claude Cowork) | **L2** `mcp-local/` | No |
+| SKILL.md-compatible agent, no MCP (Claude Code, Codex CLI, Cursor, Copilot) | **L1** `skill/` | No |
+| Local MCP client (Kiro CLI, Claude Desktop, Claude Cowork) | **L2** `mcp-local/` | No |
 | Remote-only MCP client (Claude.ai web) | **L3** `mcp-server/` + `infra/` | Yes |
 | Web UI in browser | **L4** Full stack | Yes |
 
@@ -27,27 +27,22 @@ Do NOT work inside this repo for everyday slide generation.
 ## Layer 1: Agent Skill
 
 The skill entry point is `skill/SKILL.md` — agents read it to discover workflows.
+The agent calls the engine through `scripts/pptx_builder.py` — no MCP server involved.
 
-**Kiro CLI users — one make target (recommended):**
-
-```bash
-make install-kiro
-```
-
-Symlinks the skills into `~/.kiro/skills/`, generates the composer agent config, and
-registers the `sdpm` local MCP server. Keep the checkout in place (the MCP server runs
-from it); `git pull` is enough to update. See the [README](README.md#-kiro-cli-setup-skill--parallel-compose-sub-agents).
+**Kiro CLI users:** you probably want [Layer 2](#layer-2-local-mcp-server) instead —
+`make install-kiro` sets up the local MCP server plus the skills that drive it
+(including parallel composer sub-agents).
 
 **Claude Code users:** install the plugin instead (`/plugin install sdpm@sdpm`) — it registers the local MCP server, skill, and compose sub-agent automatically. See the README.
 
-**Other agents — install into the agent's skill directory manually:**
+**Install into an agent's skill directory:**
 copy or symlink `skill/` into the agent's configured skill path, then install dependencies:
 
 ```bash
 cd skill && uv sync
 ```
 
-Consult your agent's docs for the exact skill path. See [Getting Started](docs/en/getting-started.md#layer-1-kiro-cli-skill).
+Consult your agent's docs for the exact skill path. See [Getting Started](docs/en/getting-started.md#layer-1-agent-skill-no-mcp).
 
 Note: installing `skill/` as a pip package (`pip install git+...#subdirectory=skill`) only installs the `sdpm` Python engine — the SKILL.md, templates, and references are not bundled. It is intended for embedding the engine (e.g. the L3 Docker image), not for end-user skill installs.
 
@@ -61,6 +56,19 @@ uv run python3 scripts/download_material_icons.py
 ---
 
 ## Layer 2: Local MCP Server
+
+**Kiro CLI — one make target:**
+
+```bash
+make install-kiro
+```
+
+Registers the `sdpm` MCP server in `~/.kiro/settings/mcp.json`, symlinks the skills into
+`~/.kiro/skills/`, and generates the composer agent config. Keep the checkout in place
+(the MCP server runs from it); `git pull` is enough to update. Re-run only if you move
+the checkout.
+
+**Other MCP clients:**
 
 ```bash
 cd mcp-local && uv sync

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ agent config at `~/.kiro/agents/sdpm-composer.json`, and registers the `sdpm` lo
 server in the global `~/.kiro/settings/mcp.json` (pass `--agent NAME` to
 `clients/kiro/install.py` to target a specific agent config instead). It is safe to re-run.
 
+**Keep the checkout in place:** the local MCP server runs from it (`uv run --directory
+<checkout>/mcp-local`), so deleting or moving the clone breaks the sdpm tools in Kiro.
+
 **Updating:** `git pull` in the checkout is enough — skills are symlinks and the composer
 prompt is a `file://` reference into the checkout, so no reinstall is needed. Re-run
 `make install-kiro` only if you move the checkout to a different path.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Choose your environment and follow the setup guide:
 
 | Environment | Setup |
 |---|---|
-| Agent skill (Claude Code, Codex CLI, Cursor, Kiro, Copilot) | [Getting Started — Layer 1](docs/en/getting-started.md#layer-1-kiro-cli-skill) |
+| Agent skill, no MCP (Claude Code, Codex CLI, Cursor, Copilot) | [Getting Started — Layer 1](docs/en/getting-started.md#layer-1-agent-skill-no-mcp) |
+| Kiro CLI (MCP + skills, one command) | [`make install-kiro`](#-kiro-cli-setup-mcp-server--skills--parallel-compose-sub-agents) |
 | Local MCP client (Claude Desktop, Claude Cowork) | [Getting Started — Layer 2](docs/en/getting-started.md#layer-2-local-mcp-server) |
 | Remote MCP / Web UI (AWS deployment) | [Deploy Guide](docs/en/deploy-cloudshell.md) |
 
@@ -74,7 +75,7 @@ composer sub-agents, and finishes with review.
 > other MCP clients** → use the Layer 2 local MCP server. **Claude Code** → use this plugin (it
 > wraps the same Layer 2 MCP server with a CC-native skill + parallel compose sub-agent).
 
-### 🛠 Kiro CLI setup (skill + parallel compose sub-agents)
+### 🛠 Kiro CLI setup (MCP server + skills + parallel compose sub-agents)
 
 Kiro CLI users get the same flow — the `sdpm-vibe` skill drives Phase 1, then dispatches
 parallel `sdpm-composer` sub-agents for Phase 2 — via one make target. The same
@@ -126,8 +127,8 @@ Built on a 4-layer architecture. Each layer is a thin wrapper around the previou
 
 | Use Case | Layer | AWS |
 |---|---|:---:|
-| Personal use with Kiro CLI | Layer 1: `skill/` | Not required |
-| Local MCP (Claude Desktop, VS Code, Kiro) | Layer 2: `skill/` + `mcp-local/` | Not required |
+| Agent skill only (no MCP) | Layer 1: `skill/` | Not required |
+| Local MCP (Kiro CLI, Claude Desktop, VS Code) | Layer 2: `skill/` + `mcp-local/` | Not required |
 | Team deployment | Layer 3: + `mcp-server/` + `infra/` | Required |
 | Full stack | Layer 4: + `agent/` + `api/` + `web-ui/` | Required |
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -96,6 +96,10 @@ kiro-cli chat   # あとは「〇〇のスライドを作って」と頼むだ�
 `~/.kiro/settings/mcp.json` に登録します（特定のエージェント設定に追加したい場合は
 `clients/kiro/install.py --agent NAME` を直接実行）。再実行しても安全です。
 
+**チェックアウトはそのまま置いてください:** ローカル MCP サーバーはチェックアウトから起動するため
+（`uv run --directory <checkout>/mcp-local`）、clone を削除・移動すると Kiro の sdpm ツールが
+動かなくなります。
+
 **更新:** チェックアウトで `git pull` するだけで反映されます — skill は symlink、composer
 プロンプトはチェックアウトへの `file://` 参照のため再インストール不要です。チェックアウトを
 別パスへ移動した場合のみ `make install-kiro` を再実行してください。

--- a/README_ja.md
+++ b/README_ja.md
@@ -42,7 +42,8 @@
 
 | 環境 | セットアップ |
 |---|---|
-| エージェントスキル（Claude Code, Codex CLI, Cursor, Kiro, Copilot） | [はじめに — Layer 1](docs/ja/getting-started.md#layer-1-kiro-cli-スキル) |
+| エージェントスキル（MCP なし: Claude Code, Codex CLI, Cursor, Copilot） | [はじめに — Layer 1](docs/ja/getting-started.md#layer-1-エージェントスキルmcp-なし) |
+| Kiro CLI（MCP + skill、1 コマンド） | [`make install-kiro`](#-kiro-cli-セットアップmcp-サーバー--skill--並列-compose-サブエージェント) |
 | ローカル MCP クライアント（Claude Desktop, Claude Cowork） | [はじめに — Layer 2](docs/ja/getting-started.md#layer-2-ローカル-mcp-サーバー) |
 | リモート MCP / Web UI（AWS デプロイ） | [デプロイ手順](docs/ja/deploy-cloudshell.md) |
 
@@ -77,7 +78,7 @@ review まで実施します。
 > MCP クライアント** → Layer 2 のローカル MCP サーバー。**Claude Code** → このプラグイン（同じ
 > Layer 2 MCP サーバーを CC ネイティブの skill + 並列 compose サブエージェントで包んだもの）。
 
-### 🛠 Kiro CLI セットアップ（skill + 並列 compose サブエージェント）
+### 🛠 Kiro CLI セットアップ（MCP サーバー + skill + 並列 compose サブエージェント）
 
 Kiro CLI ユーザーも同じフロー — `sdpm-vibe` skill が Phase 1 を進め、Phase 2 を
 `sdpm-composer` サブエージェントへ並列委譲 — を make ターゲット 1 つで導入できます。
@@ -130,7 +131,7 @@ kiro-cli chat   # あとは「〇〇のスライドを作って」と頼むだ�
 
 | ユースケース | レイヤー | AWS |
 |---|---|:---:|
-| Kiro CLI で個人利用 | Layer 1: `skill/` | 不要 |
+| エージェントスキルのみ（MCP なし） | Layer 1: `skill/` | 不要 |
 | ローカル MCP（Claude Desktop, VS Code, Kiro） | Layer 2: `skill/` + `mcp-local/` | 不要 |
 | チームデプロイ | Layer 3: + `mcp-server/` + `infra/` | 必要 |
 | フルスタック | Layer 4: + `agent/` + `api/` + `web-ui/` | 必要 |

--- a/clients/kiro/install.py
+++ b/clients/kiro/install.py
@@ -89,8 +89,8 @@ def render_composer_agent() -> Path:
     return dest
 
 
-def _mcp_server_registered(config_path: Path) -> bool:
-    """Return True if the sdpm MCP server is present in the given config file."""
+def _mcp_server_name_present(config_path: Path) -> bool:
+    """Return True if an entry named sdpm exists (regardless of where it points)."""
     try:
         data = json.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -98,15 +98,39 @@ def _mcp_server_registered(config_path: Path) -> bool:
     return MCP_SERVER_NAME in data.get("mcpServers", {})
 
 
+def _mcp_server_registered(config_path: Path, expected_dir: Path) -> bool:
+    """Return True if the sdpm MCP server already points at this checkout.
+
+    Checking the name alone is not enough: a registration left behind by a
+    checkout that has since moved or been deleted would be treated as valid,
+    so ``make install-kiro`` could not repair it (which is exactly what the
+    README tells users to do after moving the checkout).
+    """
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    server = data.get("mcpServers", {}).get(MCP_SERVER_NAME)
+    if not isinstance(server, dict):
+        return False
+    return str(expected_dir) in [str(a) for a in server.get("args", [])]
+
+
 def register_mcp_server(kiro_cli: str | None, agent: str | None) -> None:
-    """Register the sdpm MCP server via `kiro-cli mcp add` (idempotent)."""
+    """Register the sdpm MCP server via `kiro-cli mcp add` (idempotent).
+
+    Re-registers with ``--force`` when an entry exists but points elsewhere
+    (moved checkout, or switching between multiple checkouts).
+    """
     target = f"agent '{agent}'" if agent else "global ~/.kiro/settings/mcp.json"
     print(f"[3/3] Registering MCP server '{MCP_SERVER_NAME}' in {target}")
 
     config_path = AGENTS_DEST / f"{agent}.json" if agent else GLOBAL_MCP_JSON
-    if _mcp_server_registered(config_path):
+    mcp_dir = REPO_ROOT / "mcp-local"
+    if _mcp_server_registered(config_path, mcp_dir):
         info(f"'{MCP_SERVER_NAME}' already registered in {config_path} (skipped)")
         return
+    stale = _mcp_server_name_present(config_path)
 
     if kiro_cli is None:
         warn(
@@ -116,7 +140,7 @@ def register_mcp_server(kiro_cli: str | None, agent: str | None) -> None:
         )
         return
 
-    args = ["run", "--directory", str(REPO_ROOT / "mcp-local"), "python", "server.py"]
+    args = ["run", "--directory", str(mcp_dir), "python", "server.py"]
     cmd = [
         kiro_cli,
         "mcp",
@@ -130,6 +154,8 @@ def register_mcp_server(kiro_cli: str | None, agent: str | None) -> None:
         "--timeout",
         "120000",
     ]
+    if stale:
+        cmd.append("--force")
     if agent:
         cmd += ["--agent", agent]
     else:
@@ -138,7 +164,7 @@ def register_mcp_server(kiro_cli: str | None, agent: str | None) -> None:
     if result.returncode != 0:
         warn(f"`{' '.join(cmd)}` failed:\n{result.stderr.strip() or result.stdout.strip()}")
         return
-    info(f"'{MCP_SERVER_NAME}' registered in {config_path}")
+    info(f"'{MCP_SERVER_NAME}' {'updated' if stale else 'registered'} in {config_path}")
 
 
 def main() -> int:

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -33,7 +33,29 @@ Additional requirements for **deploying Layer 3–4 with local CDK directly** (n
 
 ## Layer 1: Kiro CLI Skill
 
-The simplest way to use spec-driven-presentation-maker. Copy the `skill/` directory to your Kiro CLI skills directory.
+The simplest way to use spec-driven-presentation-maker.
+
+### Kiro CLI — one make target (recommended)
+
+```bash
+git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
+cd sample-spec-driven-presentation-maker
+make install-kiro
+kiro-cli chat   # then just ask: "make slides about ..."
+```
+
+This symlinks the skills into `~/.kiro/skills/`, generates the composer agent config at
+`~/.kiro/agents/sdpm-composer.json`, and registers the `sdpm` local MCP server in
+`~/.kiro/settings/mcp.json`. Prerequisites: [`uv`](https://docs.astral.sh/uv/) on your
+`PATH`, plus **LibreOffice** and **poppler** for slide previews.
+
+Keep the checkout where it is — the MCP server runs from it. `git pull` is enough to
+update (skills are symlinks; the composer prompt is a `file://` reference). Re-run
+`make install-kiro` only if you move the checkout.
+
+### Other agents — manual install
+
+Copy or symlink the `skill/` directory to your agent's skills directory, then:
 
 ```bash
 # Install dependencies

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -31,31 +31,15 @@ Additional requirements for **deploying Layer 3–4 with local CDK directly** (n
 
 ---
 
-## Layer 1: Kiro CLI Skill
+## Layer 1: Agent Skill (no MCP)
 
-The simplest way to use spec-driven-presentation-maker.
+The simplest way to use spec-driven-presentation-maker: copy or symlink the `skill/`
+directory into your agent's skills directory. The agent calls the engine through
+`scripts/pptx_builder.py` — no MCP server involved.
 
-### Kiro CLI — one make target (recommended)
-
-```bash
-git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
-cd sample-spec-driven-presentation-maker
-make install-kiro
-kiro-cli chat   # then just ask: "make slides about ..."
-```
-
-This symlinks the skills into `~/.kiro/skills/`, generates the composer agent config at
-`~/.kiro/agents/sdpm-composer.json`, and registers the `sdpm` local MCP server in
-`~/.kiro/settings/mcp.json`. Prerequisites: [`uv`](https://docs.astral.sh/uv/) on your
-`PATH`, plus **LibreOffice** and **poppler** for slide previews.
-
-Keep the checkout where it is — the MCP server runs from it. `git pull` is enough to
-update (skills are symlinks; the composer prompt is a `file://` reference). Re-run
-`make install-kiro` only if you move the checkout.
-
-### Other agents — manual install
-
-Copy or symlink the `skill/` directory to your agent's skills directory, then:
+> **Kiro CLI users:** you probably want [Layer 2](#layer-2-local-mcp-server) instead —
+> `make install-kiro` sets up the local MCP server plus the skills that drive it,
+> including parallel composer sub-agents.
 
 ```bash
 # Install dependencies
@@ -78,7 +62,30 @@ The engine, references (design patterns, workflows, guides), sample templates (d
 
 Connect spec-driven-presentation-maker to any MCP-compatible client. No AWS account required.
 
-### Start the Server
+### Kiro CLI — one make target (recommended)
+
+Kiro CLI users get the MCP server plus the skills that drive it (including parallel
+composer sub-agents) from a single target:
+
+```bash
+git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
+cd sample-spec-driven-presentation-maker
+make install-kiro
+kiro-cli chat   # then just ask: "make slides about ..."
+```
+
+This registers the `sdpm` local MCP server in `~/.kiro/settings/mcp.json`, symlinks the
+skills into `~/.kiro/skills/`, and generates the composer agent config at
+`~/.kiro/agents/sdpm-composer.json`. Prerequisites: [`uv`](https://docs.astral.sh/uv/) on
+your `PATH`, plus **LibreOffice** and **poppler** for slide previews.
+
+Keep the checkout where it is — the MCP server runs from it. `git pull` is enough to
+update (skills are symlinks; the composer prompt is a `file://` reference). Re-run
+`make install-kiro` only if you move the checkout.
+
+### Other MCP clients — manual setup
+
+#### Start the Server
 
 ```bash
 cd mcp-local
@@ -86,7 +93,7 @@ uv sync
 uv run python server.py
 ```
 
-### Configure Your MCP Client
+#### Configure Your MCP Client
 
 Add to your client's MCP configuration file (`claude_desktop_config.json`, `.vscode/mcp.json`, etc.):
 
@@ -101,7 +108,7 @@ Add to your client's MCP configuration file (`claude_desktop_config.json`, `.vsc
 }
 ```
 
-### Verify
+#### Verify
 
 Ask your agent to "create a presentation." The following workflow runs automatically:
 

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -31,31 +31,15 @@ Layer 3〜4 を **ローカル CDK で直接デプロイする場合** は追加
 
 ---
 
-## Layer 1: Kiro CLI スキル
+## Layer 1: エージェントスキル（MCP なし）
 
-最もシンプルな使い方です。
+最もシンプルな使い方です。`skill/` ディレクトリをエージェントのスキルディレクトリにコピーまたは
+symlink します。エージェントは `scripts/pptx_builder.py` 経由でエンジンを呼び出すため、MCP
+サーバーは不要です。
 
-### Kiro CLI — make ターゲット 1 つ（推奨）
-
-```bash
-git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
-cd sample-spec-driven-presentation-maker
-make install-kiro
-kiro-cli chat   # あとは「〜のスライドを作って」と頼むだけ
-```
-
-skill を `~/.kiro/skills/` へ symlink し、composer エージェント設定を
-`~/.kiro/agents/sdpm-composer.json` に生成し、`sdpm` ローカル MCP サーバーを
-`~/.kiro/settings/mcp.json` に登録します。前提: [`uv`](https://docs.astral.sh/uv/) が
-`PATH` にあること、プレビュー用に **LibreOffice** と **poppler**。
-
-MCP サーバーはこの clone 先から起動するため、**ディレクトリはそのまま置いておいてください**。
-更新は `git pull` だけで十分です（skill は symlink、composer プロンプトは `file://` 参照）。
-別パスへ移動した場合のみ `make install-kiro` を再実行してください。
-
-### その他のエージェント — 手動インストール
-
-`skill/` ディレクトリをエージェントのスキルディレクトリにコピーまたは symlink し、以下を実行します。
+> **Kiro CLI ユーザーの方:** [Layer 2](#layer-2-ローカル-mcp-サーバー) をご覧ください —
+> `make install-kiro` でローカル MCP サーバーと、それを駆動する skill（並列 composer
+> サブエージェントを含む）が一度に設定されます。
 
 ```bash
 # 依存関係のインストール
@@ -78,7 +62,30 @@ uv run python3 scripts/pptx_builder.py examples
 
 spec-driven-presentation-maker を MCP 対応の任意のクライアントに接続します。AWS アカウントは不要です。
 
-### サーバーの起動
+### Kiro CLI — make ターゲット 1 つ（推奨）
+
+Kiro CLI では、MCP サーバーとそれを駆動する skill（並列 composer サブエージェントを含む）が
+1 つのターゲットで設定できます。
+
+```bash
+git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
+cd sample-spec-driven-presentation-maker
+make install-kiro
+kiro-cli chat   # あとは「〜のスライドを作って」と頼むだけ
+```
+
+`sdpm` ローカル MCP サーバーを `~/.kiro/settings/mcp.json` に登録し、skill を
+`~/.kiro/skills/` へ symlink し、composer エージェント設定を
+`~/.kiro/agents/sdpm-composer.json` に生成します。前提: [`uv`](https://docs.astral.sh/uv/) が
+`PATH` にあること、プレビュー用に **LibreOffice** と **poppler**。
+
+MCP サーバーはこの clone 先から起動するため、**ディレクトリはそのまま置いておいてください**。
+更新は `git pull` だけで十分です（skill は symlink、composer プロンプトは `file://` 参照）。
+別パスへ移動した場合のみ `make install-kiro` を再実行してください。
+
+### その他の MCP クライアント — 手動セットアップ
+
+#### サーバーの起動
 
 ```bash
 cd mcp-local
@@ -86,7 +93,7 @@ uv sync
 uv run python server.py
 ```
 
-### MCP クライアントの設定
+#### MCP クライアントの設定
 
 クライアントの MCP 設定ファイル（`claude_desktop_config.json`、`.vscode/mcp.json` 等）に以下を追加します。
 
@@ -101,7 +108,7 @@ uv run python server.py
 }
 ```
 
-### 動作確認
+#### 動作確認
 
 エージェントに「プレゼンテーションを作って」と依頼してください。以下のワークフローが自動的に実行されます。
 

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -33,7 +33,29 @@ Layer 3〜4 を **ローカル CDK で直接デプロイする場合** は追加
 
 ## Layer 1: Kiro CLI スキル
 
-最もシンプルな使い方です。`skill/` ディレクトリを Kiro CLI のスキルディレクトリにコピーするだけで動作します。
+最もシンプルな使い方です。
+
+### Kiro CLI — make ターゲット 1 つ（推奨）
+
+```bash
+git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
+cd sample-spec-driven-presentation-maker
+make install-kiro
+kiro-cli chat   # あとは「〜のスライドを作って」と頼むだけ
+```
+
+skill を `~/.kiro/skills/` へ symlink し、composer エージェント設定を
+`~/.kiro/agents/sdpm-composer.json` に生成し、`sdpm` ローカル MCP サーバーを
+`~/.kiro/settings/mcp.json` に登録します。前提: [`uv`](https://docs.astral.sh/uv/) が
+`PATH` にあること、プレビュー用に **LibreOffice** と **poppler**。
+
+MCP サーバーはこの clone 先から起動するため、**ディレクトリはそのまま置いておいてください**。
+更新は `git pull` だけで十分です（skill は symlink、composer プロンプトは `file://` 参照）。
+別パスへ移動した場合のみ `make install-kiro` を再実行してください。
+
+### その他のエージェント — 手動インストール
+
+`skill/` ディレクトリをエージェントのスキルディレクトリにコピーまたは symlink し、以下を実行します。
 
 ```bash
 # 依存関係のインストール


### PR DESCRIPTION
Two follow-ups to the Kiro CLI support added in #207, both hit while re-installing after a checkout moved.

## 1. Stale MCP registration could not be repaired

`make install-kiro` treated **any** entry named `sdpm` in `mcp.json` as valid, checking only the name and never the path it points to.

So when a checkout is moved (or removed and re-cloned elsewhere), re-running the installer updates the skills symlinks and the composer prompt but silently leaves the MCP server pointing at the old, now non-existent directory — Kiro starts with no sdpm tools. The README explicitly tells users to re-run `make install-kiro` after moving the checkout, so following the documented recovery path did not actually recover.

**Fix:** validate the registered `args` against this checkout's `mcp-local` path; re-register with `kiro-cli mcp add --force` when they differ (log says `updated`). Same-path re-runs still skip, so the installer stays idempotent.

Verified with the real installer against `~/.kiro/settings/mcp.json`:

| Case | Result |
|---|---|
| entry points at a stale path | `'sdpm' updated` → args now point at this checkout |
| entry already correct | `'sdpm' already registered (skipped)` |
| entry missing | `'sdpm' registered` |

## 2. `make install-kiro` was documented only in the READMEs

Readers entering through `AGENTS.md` or `getting-started.md` followed the older manual "copy `skill/` into your skills dir" path, which sets up neither the composer agent nor the sdpm MCP server.

- **AGENTS.md** Layer 1: lead with `make install-kiro` for Kiro CLI, keep the manual path for other agents
- **docs/{en,ja}/getting-started.md** Layer 1: same split, plus prerequisites and the update/move rules
- **README/README_ja**: state explicitly that the checkout must stay in place (the MCP server runs from it) — deleting or moving it breaks the tools

## Verification

`ruff check` clean; test suite unchanged (409 passed, 1 pre-existing failure on main: `test_latin_label_width`). Cross-doc anchor link matches the existing README heading format.