### PR TITLE
fix: set explicit max_tokens in model profiles; classify MaxTokensReachedException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cloud agent output-token limit**: model profiles now set an explicit
+  `max_tokens` (Claude 32768, others 8192) — Bedrock's small default truncated
+  long single-call outputs (e.g. writing `specs/brief.md` from a long article)
+  and killed the turn with a generic error. `MaxTokensReachedException` is also
+  classified now (`max_output`) so the Web UI shows an actionable message
+  instead of "something went wrong".
+
 ### Changed
 
 - **L4 agent personas unified**: the cloud agent (Strands) now fetches mode

--- a/agent/errors.py
+++ b/agent/errors.py
@@ -15,6 +15,7 @@ MODEL_NOT_READY = "model_not_ready"
 SERVICE_UNAVAILABLE = "service_unavailable"
 AUTH = "auth"
 BAD_INPUT = "bad_input"
+MAX_OUTPUT = "max_output"
 INTERNAL = "internal"
 
 _PATTERNS: list[tuple[tuple[str, ...], str]] = [
@@ -25,6 +26,7 @@ _PATTERNS: list[tuple[tuple[str, ...], str]] = [
     (("ServiceUnavailable",), SERVICE_UNAVAILABLE),
     (("ExpiredToken", "AccessDenied", "UnrecognizedClient", "invalid_token"), AUTH),
     (("ValidationException",), BAD_INPUT),
+    (("MaxTokensReachedException", "maximum token limit"), MAX_OUTPUT),
 ]
 
 

--- a/agent/model_profiles.py
+++ b/agent/model_profiles.py
@@ -34,11 +34,16 @@ class ModelProfile:
         compose_capable: Whether the model has sufficient capability for
             slide generation (compose). Models below Sonnet-class should
             set this to ``False``.
+        max_tokens: Maximum output tokens per response. Without an explicit
+            value Bedrock applies a small model default, which truncates
+            long single-call outputs (e.g. writing specs/brief.md in one
+            run_python call) and surfaces as MaxTokensReachedException.
     """
 
     temperature: float | None = 0.1
     cache_strategy: Literal["auto", "none"] = "auto"
     compose_capable: bool = True
+    max_tokens: int | None = 32768
 
     def with_overrides(self, **kwargs) -> "ModelProfile":
         """Return a new profile with the given fields overridden.
@@ -55,6 +60,8 @@ class ModelProfile:
             kwargs["temperature"] = self.temperature
         if self.cache_strategy == "auto":
             kwargs["cache_config"] = CacheConfig(strategy="auto")
+        if self.max_tokens is not None:
+            kwargs["max_tokens"] = self.max_tokens
         return kwargs
 
 
@@ -78,16 +85,20 @@ CLAUDE_EXTENDED_THINKING = ModelProfile(temperature=None, cache_strategy="auto")
 CLAUDE_ADAPTIVE_THINKING = ModelProfile(temperature=1.0, cache_strategy="auto")
 
 # Amazon Nova 2 — supports prompt caching.
-NOVA_2_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="auto", compose_capable=False)
+NOVA_2_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="auto", compose_capable=False,
+                              max_tokens=8192)
 
 # DeepSeek — prompt caching not supported on Bedrock at time of writing.
-DEEPSEEK_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capable=False)
+DEEPSEEK_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capable=False,
+                                max_tokens=8192)
 
 # Qwen — prompt caching not supported on Bedrock at time of writing.
-QWEN_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="none", compose_capable=False)
+QWEN_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="none", compose_capable=False,
+                            max_tokens=8192)
 
 # Moonshot Kimi — prompt caching not supported on Bedrock at time of writing.
-KIMI_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capable=False)
+KIMI_DEFAULT = ModelProfile(temperature=0.6, cache_strategy="none", compose_capable=False,
+                            max_tokens=8192)
 
 # OpenAI GPT — bedrock-mantle only (Responses API endpoint).
 GPT_DEFAULT = ModelProfile(temperature=0.7, cache_strategy="none")

--- a/tests/test_agent_errors.py
+++ b/tests/test_agent_errors.py
@@ -23,6 +23,7 @@ AUTH = _errors.AUTH
 BAD_INPUT = _errors.BAD_INPUT
 CONVERSATION_TOO_LONG = _errors.CONVERSATION_TOO_LONG
 INTERNAL = _errors.INTERNAL
+MAX_OUTPUT = _errors.MAX_OUTPUT
 MODEL_NOT_READY = _errors.MODEL_NOT_READY
 SERVICE_UNAVAILABLE = _errors.SERVICE_UNAVAILABLE
 THROTTLED = _errors.THROTTLED
@@ -47,6 +48,11 @@ class TestClassifyError:
     def test_auth_from_exception(self):
         assert classify_error(Exception("ExpiredToken")) == AUTH
 
+    def test_max_output_tokens(self):
+        assert classify_error(
+            "MaxTokensReachedException: Model stopped generating due to maximum token limit."
+        ) == MAX_OUTPUT
+
     def test_unknown_is_internal(self):
         assert classify_error("mystery failure") == INTERNAL
 
@@ -68,7 +74,7 @@ class TestTypeScriptParity:
         ts = _TS_SOURCE.read_text()
         py_codes = {
             CONVERSATION_TOO_LONG, THROTTLED, TIMEOUT, MODEL_NOT_READY,
-            SERVICE_UNAVAILABLE, AUTH, BAD_INPUT, INTERNAL,
+            SERVICE_UNAVAILABLE, AUTH, BAD_INPUT, MAX_OUTPUT, INTERNAL,
         }
         for code in py_codes:
             assert f'"{code}"' in ts, f"code {code!r} missing from agentErrors.ts"
@@ -81,7 +87,7 @@ class TestTypeScriptParity:
         ts_codes = set(re.findall(r'"([a-z_]+)"', union.group(1)))
         py_codes = {
             CONVERSATION_TOO_LONG, THROTTLED, TIMEOUT, MODEL_NOT_READY,
-            SERVICE_UNAVAILABLE, AUTH, BAD_INPUT, INTERNAL,
+            SERVICE_UNAVAILABLE, AUTH, BAD_INPUT, MAX_OUTPUT, INTERNAL,
         }
         assert ts_codes == py_codes, (
             f"code sets differ — TS only: {ts_codes - py_codes}, Python only: {py_codes - ts_codes}"

--- a/web-ui/src/lib/agentErrors.ts
+++ b/web-ui/src/lib/agentErrors.ts
@@ -15,6 +15,7 @@ export type AgentErrorCode =
   | "service_unavailable"
   | "auth"
   | "bad_input"
+  | "max_output"
   | "internal"
 
 const MESSAGES: Record<AgentErrorCode, string> = {
@@ -25,6 +26,7 @@ const MESSAGES: Record<AgentErrorCode, string> = {
   service_unavailable: "The service is temporarily unavailable. Please try again later.",
   auth: "Your session has expired or is not authorized. Please sign in again.",
   bad_input: "The request could not be processed. Please adjust your input and try again.",
+  max_output: "The response hit the model's output limit. Ask for a smaller step and try again.",
   internal: "Sorry, something went wrong. Please try again.",
 }
 
@@ -36,6 +38,7 @@ const PATTERNS: [string[], AgentErrorCode][] = [
   [["ServiceUnavailable"], "service_unavailable"],
   [["ExpiredToken", "AccessDenied", "UnrecognizedClient", "invalid_token"], "auth"],
   [["ValidationException"], "bad_input"],
+  [["MaxTokensReachedException", "maximum token limit"], "max_output"],
 ]
 
 /** Classify a raw error message into a stable code (fallback path). */


### PR DESCRIPTION
## Summary

v0.5.1 の E2E ゲートで発覚した main 由来の潜在バグの修正(personas 変更とは無関係)。

長いブログ記事からの compose で、SPEC agent が `specs/brief.md` を 1 回の run_python で書き切ろうとして Bedrock のデフォルト出力トークン上限に到達 → strands `MaxTokensReachedException` → Web UI に汎用エラー「Sorry, something went wrong」。

## Changes

- **`agent/model_profiles.py`**: `ModelProfile.max_tokens` を新設し `to_bedrock_kwargs()` で適用
  - Claude 系: 32768 / Nova・DeepSeek・Qwen・Kimi: 8192(保守的な上限)
  - メインエージェントと composer の両方に効く(同じ `build_model_kwargs` 経路)
- **`agent/errors.py` + `web-ui/src/lib/agentErrors.ts`**: 新コード `max_output` を追加
  - 万一まだ上限に当たった場合、汎用エラーではなく実行可能なメッセージを表示
  - Python↔TS parity テスト更新済み

## Tested

- `make all` — 525 passed / 1 skipped
- `npx tsc --noEmit` clean
- ap-northeast-1 に本修正をデプロイ済みで、失敗していた E2E(ブログ URL → compose → get_preview)が完走することを確認