### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-31
+
+### Added
+
+- `make doctor` — diagnoses local setup (uv / LibreOffice / poppler, checkout
+  path anchors) with a moved-checkout hint
+- `make smoke` — boots the local MCP server over real stdio and verifies
+  template/persona resolution (also runs in CI)
+- GitHub Releases are now created automatically on tag push (notes extracted
+  from this changelog)
+
 ### Fixed
 
 - **Cloud agent output-token limit**: model profiles now set an explicit

--- a/sdpm/sdpm/__init__.py
+++ b/sdpm/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
## Summary

v0.5.1 リリース準備。

- `__version__` 0.5.0 → 0.5.1(pyproject は dynamic 読込なのでここだけ)
- CHANGELOG: `[Unreleased]` の内容を `[0.5.1] - 2026-07-31` にセクション化
  - **Added**: `make doctor` / `make smoke` / タグ push での GitHub Release 自動作成
  - **Fixed**: cloud agent の出力トークン上限(#239)
  - **Changed**: L4 personas 統合(#231)/ internal API 移動(#230)

## Verified

- `make all` — 525 passed / 1 skipped
- release.yml と同一の awk 抽出ロジックで `[0.5.1]` セクションが正しく取り出せることを確認済み
- E2E: ap-northeast-1 デプロイ + Web UI compose(persona プリフェッチ → compose_slides → get_preview)完走確認済み

## After merge

タグ `v0.5.1` を作成して push すると、release.yml が CHANGELOG から本文を抽出して GitHub Release を自動作成します。
