### PR TITLE
docs: don't pre-assign version numbers to refactoring themes

### DIFF
--- a/.kiro/steering/versioning.md
+++ b/.kiro/steering/versioning.md
@@ -17,6 +17,9 @@
 ## Release
 - Milestone-based (manual decision)
 - Tag when user-facing changes have accumulated
+- Do not pre-assign version numbers to refactoring themes in roadmaps —
+  name them "Theme N" and decide the tag at release time (a tag gated on
+  e.g. E2E can be overtaken by the next theme, breaking the numbering)
 - Breaking changes must always bump MAJOR
 - No release needed for internal-only refactoring
 - Git tag format: `v{MAJOR}.{MINOR}.{PATCH}` (e.g., `v0.1.0`)


### PR DESCRIPTION
## Summary

Adds a release-planning rule to `.kiro/steering/versioning.md`, learned while landing the elements-split refactoring (#245):

- The `v0.5.1` tag is gated on a cloud E2E check, and the next roadmap theme (internal-only refactoring, which needs no tag per this policy) merged into `main` first — so its pre-assigned "v0.5.2" number became a dead letter.
- New rule: name refactoring themes "Theme N" in roadmaps and decide the tag at release time. Tags stay milestone-based; a gated tag being overtaken by the next theme no longer breaks the numbering.

## Testing

Docs-only change (one steering file). No code paths affected.