### PR TITLE
docs: finalize CHANGELOG for v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,7 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
-### Changed
-
-- `run_python` / `run_style_python`: file writes now always persist — the
-  `save` flag is deprecated and ignored (silent data loss when omitting
-  `save=True` on Cloud is no longer possible). The deck's PPTX artifact
-  refreshes automatically whenever the deck changes; `measure_slides`
-  remains the trigger for the expensive verification pass (render, text
-  overflow measurement, previews)
-- Cloud sandbox write-back is now diff-based (changed/new files only),
-  preventing a stale sandbox copy from overwriting newer S3 writes
-
-## [0.5.1] - 2026-07-31
+## [0.5.1] - 2026-08-01
 
 ### Added
 
@@ -36,8 +25,7 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 - Cloud: superseded PPTX artifacts are now deleted after each refresh — the
   automatic artifact refresh no longer accumulates orphaned objects in S3
-  (`update_deck` returns previous values via `UPDATED_OLD`).
-
+  (`update_deck` returns previous values via `UPDATED_OLD`)
 - **Cloud agent output-token limit**: model profiles now set an explicit
   `max_tokens` (Claude 32768, others 8192) — Bedrock's small default truncated
   long single-call outputs (e.g. writing `specs/brief.md` from a long article)
@@ -47,6 +35,14 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ### Changed
 
+- **`run_python` persistence semantics unified**: file writes now always
+  persist — the `save` flag is deprecated and ignored (silent data loss when
+  omitting `save=True` on Cloud is no longer possible). The deck's PPTX
+  artifact refreshes automatically whenever the deck changes;
+  `measure_slides` remains the trigger for the expensive verification pass
+  (render, text overflow measurement, previews). Cloud sandbox write-back is
+  now diff-based (changed/new files only), preventing a stale sandbox copy
+  from overwriting newer S3 writes
 - **L4 agent personas unified**: the cloud agent (Strands) now fetches mode
   behavior from `personas/*.md` through the same `start_presentation(mode=...)`
   port as every other client, instead of carrying its own copies in
@@ -122,7 +118,8 @@ decks and cloud data keep working. See the
 - Initial release: spec-driven slide generation (Engine json ↔ pptx, CLI,
   local/remote MCP servers, Strands Agent, React Web UI, CDK stacks)
 
-[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.3.8...v0.4.0
 [0.3.x]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.2.1...v0.3.8


### PR DESCRIPTION
## Summary

Release-notes finalization for the v0.5.1 tag:

- Fold the `[Unreleased]` run_python persistence-semantics entries into the **[0.5.1]** Changed section
- Set the release date to **2026-08-01** (the section was pre-dated 07-31 before the E2E gate)
- Add the `[0.5.1]` compare link; `[Unreleased]` now compares from v0.5.1

After merge, `v0.5.1` will be tagged on the merge commit (tag push triggers the automated GitHub Release with notes extracted from this changelog).