### PR TITLE
fix: regenerate web-ui package-lock for npm 10 peer resolution

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -5816,9 +5816,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5836,9 +5833,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5856,9 +5850,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5876,9 +5867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10186,6 +10174,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13556,6 +13545,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {


### PR DESCRIPTION
## Summary

Cloud deploys started failing at `npm ci` in CodeBuild:

```
npm error Missing: @swc/helpers@0.5.23 from lock file
```

Root cause: `@swc/helpers@0.5.23` was published upstream today, and npm 10.8.2 (CodeBuild's runtime) now requires the peer-resolved version to exist in the lock. npm 11 tolerates the old lock — which is why local installs kept passing and a build from the identical tree succeeded an hour earlier.

Fix: regenerate `package-lock.json` with `npm@10.8.2 install --package-lock-only` (minimal diff: adds the `@swc/helpers@0.5.23` peer entry under next-intl's swc subtree).

## Tested

- `npm ci --dry-run` passes on both npm 10.8.2 and 11.6.2
- web-ui: 49 tests pass, `build:cloud` succeeds