### PR TITLE
config: release as v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-08-01
+
 ### Changed
 
 - **Kiro CLI: composer sub-agents are now self-spawned** — `make install-kiro`

--- a/sdpm/sdpm/__init__.py
+++ b/sdpm/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"


### PR DESCRIPTION
## Summary

Release prep for v0.5.3 — finalizes the CHANGELOG and bumps `__version__`.

- CHANGELOG: move [Unreleased] entries under **[0.5.3] - 2026-08-01**
  - Kiro CLI: composer sub-agents self-spawned — `make install-kiro` no longer generates `~/.kiro/agents/sdpm-composer.json`; re-run once when upgrading (conservative legacy cleanup)
  - `start_presentation` accepts `mode="single"`
- `sdpm/sdpm/__init__.py`: `__version__` → 0.5.3

Verified latest published tag is v0.5.2 before assigning the number.

## Testing
- `make all`: 697 passed / 4 skipped

## After merge
Tag `v0.5.3` on the merge commit (GitHub Release auto-generates).