### PR TITLE
Pin container dependencies with lock/constraints files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint test format check smoke doctor install-kiro
+.PHONY: all lint test format check smoke doctor install-kiro lock
 
 all: lint test
 
@@ -24,3 +24,14 @@ doctor:
 
 install-kiro:
 	uv run python3 clients/kiro/install.py
+
+# Regenerate container dependency locks (agent + servers/remote).
+# Both images build for linux/arm64 + Python 3.13 (AgentCore Runtime).
+lock:
+	uv pip compile agent/requirements.txt \
+		--python-version 3.13 --python-platform aarch64-unknown-linux-gnu \
+		--no-header -o agent/requirements.lock
+	uv pip compile servers/remote/pyproject.toml \
+		--python-version 3.13 --python-platform aarch64-unknown-linux-gnu \
+		--no-header --no-emit-package sdpm-skill \
+		-o servers/remote/constraints.txt

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR /app
 ENV UV_SYSTEM_PYTHON=1 \
     UV_COMPILE_BYTECODE=1
 
-COPY requirements.txt .
-RUN uv pip install --no-cache -r requirements.txt
+# requirements.lock pins the full dependency tree for reproducible image builds
+# (see the mcp 2.0 breakage). Regenerate with `make lock` after editing requirements.txt.
+COPY requirements.lock .
+RUN uv pip install --no-cache -r requirements.lock
 
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore

--- a/agent/requirements.lock
+++ b/agent/requirements.lock
@@ -1,0 +1,691 @@
+aiofile==3.11.1
+    # via py-key-value-aio
+annotated-doc==0.0.5
+    # via typer
+annotated-types==0.8.0
+    # via pydantic
+anyio==4.14.2
+    # via
+    #   httpx
+    #   mcp
+    #   openai
+    #   py-key-value-aio
+    #   sse-starlette
+    #   starlette
+    #   watchfiles
+asgiref==3.12.1
+    # via opentelemetry-instrumentation-asgi
+attrs==26.1.0
+    # via
+    #   cyclopts
+    #   jsonschema
+    #   jsonschema-path
+    #   referencing
+authlib==1.7.2
+    # via fastmcp-slim
+aws-bedrock-token-generator==1.1.0
+    # via strands-agents
+aws-opentelemetry-distro==0.19.0
+    # via -r agent/requirements.txt
+awscrt==0.36.0
+    # via botocore
+awslabs-aws-pricing-mcp-server==1.0.32
+    # via -r agent/requirements.txt
+beartype==0.22.9
+    # via py-key-value-aio
+bedrock-agentcore==1.19.0
+    # via -r agent/requirements.txt
+boto3==1.43.62
+    # via
+    #   awslabs-aws-pricing-mcp-server
+    #   bedrock-agentcore
+    #   mcp-proxy-for-aws
+    #   strands-agents
+botocore==1.43.62
+    # via
+    #   aws-bedrock-token-generator
+    #   bedrock-agentcore
+    #   boto3
+    #   mcp-proxy-for-aws
+    #   s3transfer
+    #   strands-agents
+cachetools==6.2.4
+    # via
+    #   aws-opentelemetry-distro
+    #   py-key-value-aio
+caio==0.9.25
+    # via aiofile
+certifi==2026.7.22
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.1.0
+    # via cryptography
+charset-normalizer==3.4.9
+    # via requests
+click==8.4.2
+    # via uvicorn
+cryptography==50.0.0
+    # via
+    #   authlib
+    #   joserfc
+    #   pyjwt
+    #   secretstorage
+cyclopts==4.22.3
+    # via fastmcp-slim
+distro==1.9.0
+    # via openai
+dnspython==2.8.0
+    # via email-validator
+docstring-parser==0.18.0
+    # via
+    #   cyclopts
+    #   strands-agents
+email-validator==2.3.0
+    # via pydantic
+exceptiongroup==1.3.1
+    # via fastmcp-slim
+fastmcp==3.4.5
+    # via mcp-proxy-for-aws
+fastmcp-slim==3.4.5
+    # via fastmcp
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+griffelib==2.1.0
+    # via fastmcp-slim
+grpcio==1.83.0
+    # via opentelemetry-exporter-otlp-proto-grpc
+h11==0.16.0
+    # via
+    #   httpcore
+    #   uvicorn
+html2text==2025.4.15
+    # via -r agent/requirements.txt
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via
+    #   fastmcp-slim
+    #   mcp
+    #   openai
+    #   strands-agents
+httpx-sse==0.4.3
+    # via mcp
+idna==3.18
+    # via
+    #   anyio
+    #   email-validator
+    #   httpx
+    #   requests
+iniconfig==2.3.0
+    # via pytest
+jaraco-classes==3.4.0
+    # via keyring
+jaraco-context==6.1.2
+    # via keyring
+jaraco-functools==4.6.0
+    # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
+jiter==0.16.0
+    # via openai
+jmespath==1.1.0
+    # via
+    #   boto3
+    #   botocore
+joserfc==1.7.4
+    # via
+    #   authlib
+    #   fastmcp-slim
+jsonref==1.1.0
+    # via fastmcp-slim
+jsonschema==4.26.0
+    # via
+    #   mcp
+    #   strands-agents
+jsonschema-path==0.5.0
+    # via fastmcp-slim
+jsonschema-specifications==2025.9.1
+    # via jsonschema
+keyring==25.7.0
+    # via py-key-value-aio
+loguru==0.7.3
+    # via awslabs-aws-pricing-mcp-server
+markdown-it-py==4.2.0
+    # via rich
+mcp==1.29.0
+    # via
+    #   -r agent/requirements.txt
+    #   awslabs-aws-pricing-mcp-server
+    #   bedrock-agentcore
+    #   fastmcp-slim
+    #   strands-agents
+mcp-proxy-for-aws==1.6.4
+    # via -r agent/requirements.txt
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==11.1.0
+    # via
+    #   jaraco-classes
+    #   jaraco-functools
+openai==2.52.0
+    # via strands-agents
+openapi-pydantic==0.5.1
+    # via fastmcp-slim
+opentelemetry-api==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   fastmcp-slim
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-propagator-b3
+    #   opentelemetry-propagator-jaeger
+    #   opentelemetry-propagator-ot-trace
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   opentelemetry-util-genai
+    #   strands-agents
+opentelemetry-distro==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   strands-agents
+opentelemetry-instrumentation==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-util-genai
+opentelemetry-instrumentation-aio-pika==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiohttp-client==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiokafka==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiopg==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-asgi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-starlette
+opentelemetry-instrumentation-asyncpg==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aws-lambda==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-boto3sqs==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-botocore==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-cassandra==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-celery==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-confluent-kafka==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-dbapi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-django==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-falcon==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-fastapi==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-flask==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-grpc==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-httpx==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-jinja2==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-kafka-python==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-logging==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-mysql==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-mysqlclient==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-openai-agents-v2==0.1.0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pika==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-psycopg2==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymemcache==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymongo==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymysql==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pyramid==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-redis==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-remoulade==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-requests==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-sqlalchemy==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-sqlite3==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-starlette==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-system-metrics==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-threading==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   strands-agents
+opentelemetry-instrumentation-tornado==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-tortoiseorm==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-urllib==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-urllib3==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-wsgi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-pyramid
+opentelemetry-processor-baggage==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-aws-xray==1.0.2
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-botocore
+opentelemetry-propagator-b3==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-jaeger==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-ot-trace==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-propagator-ot-trace
+    #   opentelemetry-sdk-extension-aws
+    #   strands-agents
+opentelemetry-sdk-extension-aws==2.1.0
+    # via aws-opentelemetry-distro
+opentelemetry-semantic-conventions==0.65b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-util-genai
+opentelemetry-util-genai==1.0b0
+    # via opentelemetry-instrumentation-openai-agents-v2
+opentelemetry-util-http==0.65b0
+    # via
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+packaging==26.2
+    # via
+    #   fastmcp-slim
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   pytest
+partial-json-parser==0.2.1.1.post7
+    # via -r agent/requirements.txt
+pathable==0.6.0
+    # via jsonschema-path
+platformdirs==4.11.0
+    # via fastmcp-slim
+pluggy==1.6.0
+    # via pytest
+protobuf==6.33.5
+    # via
+    #   aws-opentelemetry-distro
+    #   googleapis-common-protos
+    #   opentelemetry-proto
+psutil==7.2.2
+    # via opentelemetry-instrumentation-system-metrics
+py-key-value-aio==0.4.5
+    # via fastmcp-slim
+pycparser==3.0
+    # via cffi
+pydantic==2.13.4
+    # via
+    #   awslabs-aws-pricing-mcp-server
+    #   bedrock-agentcore
+    #   fastmcp-slim
+    #   mcp
+    #   openai
+    #   openapi-pydantic
+    #   pydantic-settings
+    #   strands-agents
+pydantic-core==2.46.4
+    # via pydantic
+pydantic-settings==2.14.2
+    # via
+    #   fastmcp-slim
+    #   mcp
+pygments==2.20.0
+    # via
+    #   pytest
+    #   rich
+    #   rich-rst
+pyjwt==2.13.0
+    # via mcp
+pymupdf==1.28.0
+    # via -r agent/requirements.txt
+pyperclip==1.11.0
+    # via fastmcp-slim
+pytest==9.1.1
+    # via
+    #   awslabs-aws-pricing-mcp-server
+    #   pytest-asyncio
+pytest-asyncio==1.4.0
+    # via awslabs-aws-pricing-mcp-server
+python-dateutil==2.9.0.post0
+    # via
+    #   aws-opentelemetry-distro
+    #   botocore
+python-dotenv==1.2.2
+    # via
+    #   fastmcp-slim
+    #   mcp
+    #   pydantic-settings
+python-multipart==0.0.32
+    # via
+    #   fastmcp-slim
+    #   mcp
+pyyaml==6.0.3
+    # via
+    #   aws-opentelemetry-distro
+    #   fastmcp-slim
+    #   jsonschema-path
+    #   strands-agents
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-path
+    #   jsonschema-specifications
+requests==2.34.2
+    # via
+    #   -r agent/requirements.txt
+    #   opentelemetry-exporter-otlp-proto-http
+rich==15.0.0
+    # via
+    #   cyclopts
+    #   fastmcp-slim
+    #   rich-rst
+    #   typer
+rich-rst==2.1.0
+    # via cyclopts
+rpds-py==2026.6.3
+    # via
+    #   jsonschema
+    #   referencing
+s3transfer==0.19.2
+    # via boto3
+secretstorage==3.5.0
+    # via keyring
+shellingham==1.5.4
+    # via typer
+six==1.17.0
+    # via python-dateutil
+sniffio==1.3.1
+    # via openai
+sse-starlette==3.4.6
+    # via mcp
+starlette==1.3.1
+    # via
+    #   bedrock-agentcore
+    #   fastmcp-slim
+    #   mcp
+    #   sse-starlette
+strands-agents==1.50.2
+    # via
+    #   -r agent/requirements.txt
+    #   bedrock-agentcore
+tqdm==4.70.0
+    # via openai
+typer==0.27.0
+    # via mcp
+typing-extensions==4.16.0
+    # via
+    #   awslabs-aws-pricing-mcp-server
+    #   bedrock-agentcore
+    #   fastmcp-slim
+    #   grpcio
+    #   mcp
+    #   openai
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-propagator-b3
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   py-key-value-aio
+    #   pydantic
+    #   pydantic-core
+    #   strands-agents
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   mcp
+    #   pydantic
+    #   pydantic-settings
+uncalled-for==0.3.2
+    # via fastmcp-slim
+urllib3==2.7.0
+    # via
+    #   aws-opentelemetry-distro
+    #   bedrock-agentcore
+    #   botocore
+    #   requests
+uvicorn==0.52.0
+    # via
+    #   bedrock-agentcore
+    #   fastmcp-slim
+    #   mcp
+watchdog==6.0.0
+    # via strands-agents
+watchfiles==1.2.0
+    # via fastmcp-slim
+websockets==17.0.1
+    # via
+    #   bedrock-agentcore
+    #   fastmcp-slim
+wrapt==2.3.0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-util-genai

--- a/servers/remote/Dockerfile
+++ b/servers/remote/Dockerfile
@@ -18,10 +18,14 @@ RUN dnf install -y --setopt=install_weak_deps=False \
 
 WORKDIR /app
 
+# constraints.txt pins the full dependency tree for reproducible image builds
+# (see the mcp 2.0 breakage). Regenerate with `make lock` after editing pyproject.toml.
+COPY servers/remote/constraints.txt servers/remote/constraints.txt
+
 # Install skill (engine) first for layer caching
 COPY sdpm/pyproject.toml sdpm/pyproject.toml
 COPY sdpm/sdpm/ sdpm/sdpm/
-RUN python3.13 -m pip install --no-cache-dir ./sdpm
+RUN python3.13 -m pip install --no-cache-dir -c servers/remote/constraints.txt ./sdpm
 
 # Bundled knowledge data (references / templates) — served by the shared tool
 # contract via SDPM_SKILL_ROOT. Assets stay on S3 (user-extensible, 36MB).
@@ -37,7 +41,7 @@ COPY servers/remote/tools/ servers/remote/tools/
 COPY servers/remote/storage/ servers/remote/storage/
 COPY servers/remote/server.py servers/remote/server.py
 COPY servers/remote/server_utils.py servers/remote/server_utils.py
-RUN python3.13 -m pip install --no-cache-dir ./servers/remote
+RUN python3.13 -m pip install --no-cache-dir -c servers/remote/constraints.txt ./servers/remote
 
 ENV PYTHONPATH=/app
 

--- a/servers/remote/constraints.txt
+++ b/servers/remote/constraints.txt
@@ -1,0 +1,543 @@
+annotated-doc==0.0.5
+    # via typer
+annotated-types==0.8.0
+    # via pydantic
+anyio==4.14.2
+    # via
+    #   httpx
+    #   mcp
+    #   sse-starlette
+    #   starlette
+asgiref==3.12.1
+    # via opentelemetry-instrumentation-asgi
+attrs==26.1.0
+    # via
+    #   jsonschema
+    #   referencing
+aws-opentelemetry-distro==0.19.0
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+boto3==1.43.62
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+botocore==1.43.62
+    # via
+    #   boto3
+    #   s3transfer
+cachetools==6.2.4
+    # via aws-opentelemetry-distro
+certifi==2026.7.22
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.1.0
+    # via cryptography
+charset-normalizer==3.4.9
+    # via
+    #   pdfminer-six
+    #   requests
+click==8.4.2
+    # via uvicorn
+cryptography==50.0.0
+    # via
+    #   pdfminer-six
+    #   pyjwt
+defusedxml==0.7.1
+    # via sdpm-skill
+et-xmlfile==2.0.0
+    # via openpyxl
+googleapis-common-protos==1.75.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+grpcio==1.83.0
+    # via opentelemetry-exporter-otlp-proto-grpc
+h11==0.16.0
+    # via
+    #   httpcore
+    #   uvicorn
+httpcore==1.0.9
+    # via httpx
+httpx==0.28.1
+    # via mcp
+httpx-sse==0.4.3
+    # via mcp
+idna==3.18
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+jmespath==1.1.0
+    # via
+    #   boto3
+    #   botocore
+jsonschema==4.26.0
+    # via mcp
+jsonschema-specifications==2025.9.1
+    # via jsonschema
+lxml==6.1.1
+    # via
+    #   python-docx
+    #   python-pptx
+    #   sdpm-skill
+markdown-it-py==4.2.0
+    # via rich
+mcp==1.29.0
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+mdurl==0.1.2
+    # via markdown-it-py
+openpyxl==3.1.5
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+opentelemetry-api==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-propagator-b3
+    #   opentelemetry-propagator-jaeger
+    #   opentelemetry-propagator-ot-trace
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   opentelemetry-util-genai
+opentelemetry-distro==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-util-genai
+opentelemetry-instrumentation-aio-pika==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiohttp-client==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiokafka==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aiopg==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-asgi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-starlette
+opentelemetry-instrumentation-asyncpg==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-aws-lambda==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-boto3sqs==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-botocore==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-cassandra==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-celery==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-confluent-kafka==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-dbapi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-mysql
+    #   opentelemetry-instrumentation-mysqlclient
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-pymysql
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-django==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-falcon==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-fastapi==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-flask==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-grpc==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-httpx==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-jinja2==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-kafka-python==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-logging==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-mysql==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-mysqlclient==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-openai-agents-v2==0.1.0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pika==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-psycopg2==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymemcache==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymongo==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pymysql==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-pyramid==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-redis==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-remoulade==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-requests==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-sqlalchemy==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-sqlite3==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-starlette==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-system-metrics==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-threading==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-tornado==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-tortoiseorm==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-urllib==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-urllib3==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-instrumentation-wsgi==0.65b0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-pyramid
+opentelemetry-processor-baggage==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-aws-xray==1.0.2
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-botocore
+opentelemetry-propagator-b3==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-jaeger==1.44.0
+    # via aws-opentelemetry-distro
+opentelemetry-propagator-ot-trace==0.65b0
+    # via aws-opentelemetry-distro
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   aws-opentelemetry-distro
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-propagator-ot-trace
+    #   opentelemetry-sdk-extension-aws
+opentelemetry-sdk-extension-aws==2.1.0
+    # via aws-opentelemetry-distro
+opentelemetry-semantic-conventions==0.65b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
+    #   opentelemetry-instrumentation-aws-lambda
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-kafka-python
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-openai-agents-v2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pymongo
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-remoulade
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-system-metrics
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-tortoiseorm
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-util-genai
+opentelemetry-util-genai==1.0b0
+    # via opentelemetry-instrumentation-openai-agents-v2
+opentelemetry-util-http==0.65b0
+    # via
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-starlette
+    #   opentelemetry-instrumentation-tornado
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+packaging==26.2
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-falcon
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-sqlalchemy
+pdfminer-six==20260107
+    # via pdfplumber
+pdfplumber==0.11.10
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+pillow==12.3.0
+    # via
+    #   pdfplumber
+    #   python-pptx
+    #   sdpm-skill
+protobuf==6.33.5
+    # via
+    #   aws-opentelemetry-distro
+    #   googleapis-common-protos
+    #   opentelemetry-proto
+psutil==7.2.2
+    # via opentelemetry-instrumentation-system-metrics
+pycparser==3.0
+    # via cffi
+pydantic==2.13.4
+    # via
+    #   mcp
+    #   pydantic-settings
+pydantic-core==2.46.4
+    # via pydantic
+pydantic-settings==2.14.2
+    # via mcp
+pygments==2.20.0
+    # via
+    #   rich
+    #   sdpm-skill
+pyjwt==2.13.0
+    # via mcp
+pypdf==6.14.2
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+pypdfium2==5.12.1
+    # via pdfplumber
+python-dateutil==2.9.0.post0
+    # via
+    #   aws-opentelemetry-distro
+    #   botocore
+python-docx==1.2.0
+    # via sdpm-mcp-server (servers/remote/pyproject.toml)
+python-dotenv==1.2.2
+    # via
+    #   mcp
+    #   pydantic-settings
+python-multipart==0.0.32
+    # via mcp
+python-pptx==1.0.2
+    # via sdpm-skill
+pyyaml==6.0.3
+    # via aws-opentelemetry-distro
+qrcode==8.2
+    # via sdpm-skill
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.34.2
+    # via
+    #   sdpm-mcp-server (servers/remote/pyproject.toml)
+    #   opentelemetry-exporter-otlp-proto-http
+rich==15.0.0
+    # via typer
+rpds-py==2026.6.3
+    # via
+    #   jsonschema
+    #   referencing
+s3transfer==0.19.2
+    # via boto3
+shellingham==1.5.4
+    # via typer
+six==1.17.0
+    # via python-dateutil
+sse-starlette==3.4.6
+    # via mcp
+starlette==1.3.1
+    # via
+    #   mcp
+    #   sse-starlette
+typer==0.27.0
+    # via mcp
+typing-extensions==4.16.0
+    # via
+    #   grpcio
+    #   mcp
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation-aiokafka
+    #   opentelemetry-propagator-b3
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+    #   pydantic
+    #   pydantic-core
+    #   python-docx
+    #   python-pptx
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   mcp
+    #   pydantic
+    #   pydantic-settings
+urllib3==2.7.0
+    # via
+    #   aws-opentelemetry-distro
+    #   botocore
+    #   requests
+uvicorn==0.52.0
+    # via mcp
+wrapt==2.3.0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-aiohttp-client
+    #   opentelemetry-instrumentation-aiopg
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-cassandra
+    #   opentelemetry-instrumentation-confluent-kafka
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-pika
+    #   opentelemetry-instrumentation-pymemcache
+    #   opentelemetry-instrumentation-pyramid
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-processor-baggage
+    #   opentelemetry-util-genai
+xlsxwriter==3.2.9
+    # via python-pptx
+
+# The following packages were excluded from the output:
+# sdpm-skill


### PR DESCRIPTION
## Summary
- **agent**: `requirements.lock` (full pinned tree via `uv pip compile`, targeting linux/arm64 + Python 3.13 to match AgentCore Runtime) — Dockerfile now installs from the lock
- **servers/remote**: `constraints.txt` applied to both the `sdpm` and server `pip install` steps (sdpm-skill path dep excluded from output)
- **`make lock`**: single command to regenerate both files after editing `requirements.txt` / `pyproject.toml`

Structurally prevents mcp-2.0-class breakage (transitive dep major bumps landing in image builds unpinned). Key pin: `mcp==1.29.0` (respects the `<2` bound).

## Testing
- `make lock` is idempotent (re-run produces zero diff)
- `make all`: 697 passed / lint clean
- **Validated with a real ARM64 image build + full CodeBuild deploy** (SdpmRuntime / SdpmAgent / SdpmWebUi all green, zero runtime errors post-deploy) — per the plan that pinning must ship together with image build verification