### PR TITLE
fix: expose arch_diagram to deck agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+### Fixed
+
+- Cloud and local ACP deck agents now expose `arch_diagram`, as required by the
+  composition workflow, so architecture, system, and flow diagrams use automatic
+  routing and crossing minimization instead of silently falling back to manual
+  placement.
+
 ## [0.5.3] - 2026-08-01
 
 ### Changed

--- a/agent/modes/__init__.py
+++ b/agent/modes/__init__.py
@@ -65,7 +65,7 @@ _DECK_TOOLS = [
     "read_workflows", "list_guides", "read_guides", "search_assets",
     "list_asset_sources", "list_templates",
     "run_python", "generate_pptx", "get_preview", "code_to_slide",
-    "grid", "import_attachment",
+    "grid", "arch_diagram", "import_attachment",
 ]
 
 _STYLE_TOOLS = [

--- a/servers/local/.kiro/acp-agents/sdpm-composer.json
+++ b/servers/local/.kiro/acp-agents/sdpm-composer.json
@@ -4,6 +4,7 @@
   "tools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/generate_pptx",
     "@sdpm/grid",
@@ -28,6 +29,7 @@
   "allowedTools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/generate_pptx",
     "@sdpm/grid",

--- a/servers/local/.kiro/acp-agents/sdpm-single.json
+++ b/servers/local/.kiro/acp-agents/sdpm-single.json
@@ -16,6 +16,7 @@
   "tools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",
@@ -45,6 +46,7 @@
   "allowedTools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",

--- a/servers/local/.kiro/acp-agents/sdpm-spec.json
+++ b/servers/local/.kiro/acp-agents/sdpm-spec.json
@@ -19,6 +19,7 @@
   "tools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",
@@ -49,6 +50,7 @@
   "allowedTools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",

--- a/servers/local/.kiro/acp-agents/sdpm-vibe.json
+++ b/servers/local/.kiro/acp-agents/sdpm-vibe.json
@@ -16,6 +16,7 @@
   "tools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",
@@ -46,6 +47,7 @@
   "allowedTools": [
     "@sdpm/analyze_template",
     "@sdpm/apply_style",
+    "@sdpm/arch_diagram",
     "@sdpm/code_to_slide",
     "@sdpm/diff_pptx",
     "@sdpm/generate_pptx",

--- a/tests/test_acp_agent_definitions.py
+++ b/tests/test_acp_agent_definitions.py
@@ -18,12 +18,12 @@ theme 3) and judged intentional, not accretion:
 
 - ``sdpm-style`` (9): style-only surface — run_style_python + hearing +
   browsing; no deck tools
-- ``sdpm-composer`` (22): no dialogue (hearing), no nested dispatch
+- ``sdpm-composer`` (23): no dialogue (hearing), no nested dispatch
   (use_subagent), no web fetch/search, no upload/diff — composers only
   compose
-- ``sdpm-single`` (27): spec surface minus use_subagent (single agent
+- ``sdpm-single`` (28): spec surface minus use_subagent (single agent
   does everything itself, no dispatch)
-- ``sdpm-spec`` / ``sdpm-vibe`` (28): full orchestrator surface
+- ``sdpm-spec`` / ``sdpm-vibe`` (29): full orchestrator surface
 
 The snapshot below pins those counts; widening any allowlist is a
 deliberate decision that must update this test.
@@ -45,7 +45,8 @@ _AGENT_FILES = sorted(_ACP_AGENTS_DIR.glob("*.json"))
 # intentional (see module docstring).
 _FULL_ORCHESTRATOR = {
     "read", "glob", "grep", "use_subagent", "web_fetch", "web_search",
-    "@sdpm/analyze_template", "@sdpm/apply_style", "@sdpm/code_to_slide",
+    "@sdpm/analyze_template", "@sdpm/apply_style", "@sdpm/arch_diagram",
+    "@sdpm/code_to_slide",
     "@sdpm/diff_pptx", "@sdpm/generate_pptx", "@sdpm/grid", "@sdpm/hearing",
     "@sdpm/import_attachment", "@sdpm/init_presentation",
     "@sdpm/list_asset_sources", "@sdpm/list_guides", "@sdpm/list_styles",
@@ -147,6 +148,10 @@ def test_cloud_deck_tools_are_subset_of_local_orchestrator():
     m = re.search(r"_DECK_TOOLS = \[(.*?)\]", modes_src, re.DOTALL)
     assert m, "agent/modes/__init__.py: _DECK_TOOLS not found"
     cloud_tools = set(re.findall(r'"([a-z_]+)"', m.group(1)))
+    assert "arch_diagram" in cloud_tools, (
+        "Cloud deck agents must expose arch_diagram because the compose workflow "
+        "requires it for architecture, system, and flow diagrams"
+    )
     cloud_only = {"read_uploaded_file", "get_preview"}  # S3/presign transport tools
 
     spec_tools = {


### PR DESCRIPTION
## Summary
- expose `arch_diagram` to all Cloud deck modes and local ACP deck agents
- update orchestrator/composer tool snapshots and add a regression assertion for the Cloud deck surface
- document the user-visible fix in the changelog

## Root cause
`arch_diagram` was added to the tool contract, server bindings, and composition workflow, but the Cloud and ACP agent allowlists were not updated. Both surfaces therefore silently fell back to manual placement for architecture, system, and flow diagrams.

## Testing
- `make all` — 697 passed, 5 skipped
- `make smoke` — real stdio MCP smoke passed
- fresh `sdpm-composer` + ACP stdio integration smoke — `arch_diagram` generated 6 elements with 0 crossings, 0 pierces, and 0 overflow

ASH was not run per maintainer direction.
