### PR TITLE
docs: document tool surface design intent and 0.x release policy

### DIFF
--- a/.kiro/steering/versioning.md
+++ b/.kiro/steering/versioning.md
@@ -20,7 +20,11 @@
 - Do not pre-assign version numbers to refactoring themes in roadmaps —
   name them "Theme N" and decide the tag at release time (a tag gated on
   e.g. E2E can be overtaken by the next theme, breaking the numbering)
-- Breaking changes must always bump MAJOR
+- Breaking changes bump MAJOR once 1.0.0 is reached; while in 0.x they may
+  ship in a MINOR release (consistent with the SemVer section above)
+- While in 0.x, tool/API removals may ship without a deprecation period —
+  breaking changes are announced in the CHANGELOG (with migration notes),
+  not via in-product deprecation warnings. Revisit this policy at 1.0.0
 - No release needed for internal-only refactoring
 - Git tag format: `v{MAJOR}.{MINOR}.{PATCH}` (e.g., `v0.1.0`)
 

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -248,6 +248,29 @@ To add custom roles (e.g., team-based access), modify the `resolve_role` functio
 |------|-------------|
 | `web_fetch` | Fetch a URL and convert to Markdown (supports HTML, PDF, images) |
 
+### Tool Surface Design Notes
+
+Deliberate asymmetries between surfaces — these are design decisions, not gaps:
+
+- **`hearing` is ACP-only (Local) / agent-level (Cloud).** Interactive hearing
+  depends on a client-side UI (the ACP session prompt on Local, the Strands
+  agent loop on Cloud). Plain MCP has no interaction channel, so `hearing` is
+  intentionally not part of the `sdpm.tools` contract — it is a
+  transport-specific addition, which the local server is allowed to carry.
+- **ACP agents have no `start_presentation`.** `start_presentation(mode=...)`
+  exists for clients where the mode is decided *in conversation*. ACP agents
+  are spawned with a fixed persona (definitions re-derived from `acp-agents/`
+  at spawn), so the mode is already known at the entry point and a mode-fetch
+  tool would be dead weight.
+- **The CLI surface is kept even where MCP tools overlap.** The CLI +
+  `sdpm/SKILL.md` form the no-MCP adapter (Layer 1). CLI subcommands cost no
+  MCP schema tokens and are the only operability for agents without MCP
+  support, so overlap with MCP tools is acceptable — they are two adapters
+  over the same engine.
+- **`search_slides` redesign is deferred.** The KB-backed search tool is kept
+  as-is on Layer 3; rethinking it (scope, index lifecycle) is a separate
+  theme, tracked outside the attachment/tool-cleanup work.
+
 ---
 
 ## CDK Stack Structure


### PR DESCRIPTION
## Summary

Completes SPEC 1 Track A-2 (documentation follow-up to #264 / #265).

### docs/en/architecture.md — new "Tool Surface Design Notes" section
Records deliberate tool-surface asymmetries as design decisions:
- `hearing` is ACP-only (Local) / agent-level (Cloud) — interactive hearing needs a client-side UI, so it is intentionally not in the `sdpm.tools` contract
- ACP agents have no `start_presentation` — persona is fixed at spawn, so a mode-fetch tool would be dead weight
- CLI surface is kept despite MCP overlap — it is the Layer 1 (no-MCP) adapter with zero MCP schema cost
- `search_slides` redesign is deferred as a separate theme

### .kiro/steering/versioning.md
- Resolves the contradiction between "Breaking changes must always bump MAJOR" and the 0.x SemVer section: MAJOR bump applies from 1.0.0; 0.x may ship breaking changes in MINOR
- Records the 0.x release policy used by #265: tool/API removals may ship without a deprecation period, announced via CHANGELOG migration notes

## Testing
Docs-only change. No code paths affected.