### PR TITLE
fix: separate abort-multipart rule from tag-filtered lifecycle rule

### DIFF
--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -82,6 +82,12 @@ export class DataStack extends cdk.Stack {
           tagFilters: { "sdpm-class": "attachment-source" },
           expiration: cdk.Duration.days(90),
           noncurrentVersionExpiration: cdk.Duration.days(7),
+        },
+        {
+          // Incomplete multipart uploads have no tags yet, so S3 forbids
+          // combining AbortIncompleteMultipartUpload with tag filters —
+          // keep it in a separate prefix-only rule.
+          prefix: "uploads/",
           abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
         },
         {


### PR DESCRIPTION
## Summary

First full-stack deploy after #265 failed: SdpmData went UPDATE_FAILED because S3 rejects a lifecycle rule that combines `AbortIncompleteMultipartUpload` with tag filters (incomplete multipart uploads carry no tags yet):

```
AbortIncompleteMultipartUpload cannot be specified with Tags.
(Service: S3, Status Code: 400)
```

This splits the abort setting into a separate prefix-only rule on `uploads/` with the same 1-day window. Expiration/tag-filter behavior is unchanged.

## Testing
- `npx tsc --noEmit` and `cdk synth SdpmData` pass
- Synthesized template verified: tag-filtered expiration rule and prefix-only abort rule are separate
- Full-stack deploy re-run from this source is in progress (CodeBuild `sdpm-deploy:dfee321f`); will confirm SdpmData reaches UPDATE_COMPLETE

## Notes
CI does not catch this class of error (synth-valid but rejected by the S3 API at deploy time).