### PR TITLE
fix: presign attachment PUT with SigV4 and stop silent attachment drop

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -25,6 +25,7 @@ from aws_lambda_powertools import Logger, Metrics
 from aws_lambda_powertools.event_handler import APIGatewayHttpResolver, CORSConfig
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from boto3.dynamodb.conditions import Key
+from botocore.config import Config as BotoConfig
 from authz import authorize
 from chat_history import (
     cap_messages_size,
@@ -96,7 +97,7 @@ logger = Logger()
 metrics = Metrics()
 dynamodb = boto3.resource("dynamodb")
 table = dynamodb.Table(TABLE_NAME)
-s3_client = boto3.client("s3")
+s3_client = boto3.client("s3", config=BotoConfig(signature_version="s3v4"))
 app = APIGatewayHttpResolver(cors=cors_config)
 
 # --- KB (optional) ---

--- a/web-ui/src/components/chat/ChatInput.tsx
+++ b/web-ui/src/components/chat/ChatInput.tsx
@@ -156,6 +156,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
 
     // Upload pending attachments
     const uploadedFiles: UploadedFile[] = []
+    let uploadFailed = false
     for (const att of attachments) {
       if (att.status === "pending") {
         try {
@@ -164,9 +165,17 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
           uploadedFiles.push(result)
           setAttachments((prev) => prev.map((a) => (a.id === att.id ? { ...a, status: "completed" as const, source: result.source } : a)))
         } catch {
+          uploadFailed = true
           setAttachments((prev) => prev.map((a) => (a.id === att.id ? { ...a, status: "failed" as const, error: t("uploadFailed") } : a)))
         }
       }
+    }
+
+    // Do not send a message that silently drops attachments the user meant
+    // to include — keep input and failed attachments so they can retry.
+    if (uploadFailed) {
+      toast.error(t("uploadFailed"))
+      return
     }
 
     const sentSnippets = snippets.map((s) => ({ label: t("textSnippet"), text: s.text }))


### PR DESCRIPTION
## Summary

First Cloud E2E of the stateless attachment flow (#265) failed: attaching a PPTX in the Web UI resulted in the agent replying that no file was attached.

Two root causes:

1. **Presigned URL was SigV2.** `boto3.client(\"s3\")` generates legacy SigV2 presigned URLs in ap-northeast-1, and S3 rejects conditional writes (`If-None-Match: *`) unless SigV4 is used — every browser PUT failed with:
   ```
   InvalidRequest: Requests specifying conditional writes require AWS Signature Version 4.
   ```
   Fix: pin the API's s3 client to `signature_version=\"s3v4\"`.

2. **ChatInput swallowed the failure.** On upload error it marked the chip failed but still sent the message without the attachment marker — which surfaced as the confusing agent reply. Fix: abort the send, keep input + attachments, show an error toast so the user can retry.

## Testing
- Reproduced the 400 against the deployed API with a Cognito test user
- Verified with SigV4: presigned conditional PUT returns 200; second PUT to the same key correctly returns 412
- ruff / eslint / tsc / Vitest (65) pass
- Full-stack deploy from this branch + Web UI attachment re-test: in progress (will comment results)