### PR TITLE
fix: calibrate attachment quota for internal use and surface upload errors

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1422,8 +1422,13 @@ ALLOWED_CONTENT_TYPES = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "image/png", "image/jpeg", "image/webp", "image/gif", "image/svg+xml",
 }
-CLOUD_RAW_MAX_OBJECTS = 100
-CLOUD_RAW_MAX_BYTES = 1024 * 1024 * 1024
+# Per-user raw attachment caps. These are safety valves against runaway
+# automation and leaked-token cost exposure — not usage discipline for
+# legitimate users. Defaults are deliberately generous for an internal /
+# team deployment (PPTX sources can be ~100MB each); override via Lambda
+# environment variables if your deployment needs tighter or looser bounds.
+CLOUD_RAW_MAX_OBJECTS = int(os.environ.get("ATTACHMENT_MAX_OBJECTS", "1000"))
+CLOUD_RAW_MAX_BYTES = int(os.environ.get("ATTACHMENT_MAX_BYTES", str(50 * 1024 * 1024 * 1024)))
 
 
 def _raw_attachment_usage(user_id: str) -> tuple[int, int]:

--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -77,23 +77,19 @@ export class DataStack extends cdk.Stack {
       ],
       lifecycleRules: [
         {
-          // Raw user attachment sources are temporary; committed import bundles live under decks/.
+          // Raw user attachment sources are temporary; committed import bundles
+          // live under decks/. Prefix-only (no tag filter) so that objects from
+          // older releases — which carry no sdpm-class tag — also expire, and
+          // so the abort-multipart setting can live in the same rule (S3 forbids
+          // combining it with tag filters).
           prefix: "uploads/",
-          tagFilters: { "sdpm-class": "attachment-source" },
           expiration: cdk.Duration.days(90),
           noncurrentVersionExpiration: cdk.Duration.days(7),
-        },
-        {
-          // Incomplete multipart uploads have no tags yet, so S3 forbids
-          // combining AbortIncompleteMultipartUpload with tag filters —
-          // keep it in a separate prefix-only rule.
-          prefix: "uploads/",
           abortIncompleteMultipartUploadAfter: cdk.Duration.days(1),
         },
         {
           // Rebuildable attachment conversion cache.
           prefix: "attachment-cache/v1/",
-          tagFilters: { "sdpm-class": "attachment-cache" },
           expiration: cdk.Duration.days(7),
           noncurrentVersionExpiration: cdk.Duration.days(7),
         },

--- a/web-ui/src/components/chat/ChatInput.tsx
+++ b/web-ui/src/components/chat/ChatInput.tsx
@@ -157,6 +157,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     // Upload pending attachments
     const uploadedFiles: UploadedFile[] = []
     let uploadFailed = false
+    let uploadError: string | null = null
     for (const att of attachments) {
       if (att.status === "pending") {
         try {
@@ -164,9 +165,11 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
           const result = await uploadFile(att.file, idToken ?? "", sessionId ?? "")
           uploadedFiles.push(result)
           setAttachments((prev) => prev.map((a) => (a.id === att.id ? { ...a, status: "completed" as const, source: result.source } : a)))
-        } catch {
+        } catch (err) {
           uploadFailed = true
-          setAttachments((prev) => prev.map((a) => (a.id === att.id ? { ...a, status: "failed" as const, error: t("uploadFailed") } : a)))
+          const message = err instanceof Error && err.message ? err.message : t("uploadFailed")
+          uploadError = message
+          setAttachments((prev) => prev.map((a) => (a.id === att.id ? { ...a, status: "failed" as const, error: message } : a)))
         }
       }
     }
@@ -174,7 +177,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     // Do not send a message that silently drops attachments the user meant
     // to include — keep input and failed attachments so they can retry.
     if (uploadFailed) {
-      toast.error(t("uploadFailed"))
+      toast.error(uploadError ?? t("uploadFailed"))
       return
     }
 


### PR DESCRIPTION
## Summary

Follow-ups from the first Cloud E2E of the stateless attachment flow (after #268). Attaching a file still failed — this time with the (previously invisible) `Raw attachment quota exceeded`.

Root causes and fixes:

1. **Quota miscalibrated + legacy contamination.** The per-user cap (100 objects / 1GB) was sized like a public free tier, and 1,100+ legacy objects from the pre-v0.6 upload pipeline counted toward it, soft-locking any user who had used the old flow. New defaults: **1000 objects / 50GB**, overridable via `ATTACHMENT_MAX_OBJECTS` / `ATTACHMENT_MAX_BYTES`. The quota's role is bounding runaway automation and leaked-token cost exposure, not user discipline (documented in code).

2. **Tag-filtered lifecycle rules never matched legacy objects.** Pre-v0.6 objects carry no `sdpm-class` tag, so they would linger (and eat quota) forever. Rules are now prefix-only, which also lets the abort-multipart setting merge back into the main `uploads/` rule.

3. **Upload errors were invisible.** ChatInput showed a generic failure toast; now it surfaces the API's actual error message.

One-time cleanup already performed in the deployed environment: purged 1,162 legacy objects under `uploads/` (old converted bundles + `uploads/tmp`).

## Testing
- ruff / eslint / tsc / Vitest (65) pass
- `cdk synth SdpmData`: lifecycle rules verified prefix-only, abort merged
- Post-purge presign against the deployed API succeeds