### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-02
+
 ### Breaking
 
 - **Stateless attachment pipeline** — `upload_file`, `read_uploaded_file`, and
@@ -47,6 +49,21 @@ Entries before v0.5.0 were written retroactively as summaries.
   composition workflow, so architecture, system, and flow diagrams use automatic
   routing and crossing minimization instead of silently falling back to manual
   placement.
+- Attachment presigned PUTs now use Signature Version 4 — S3 rejects the
+  conditional write (`If-None-Match`) with legacy SigV2 URLs, which broke all
+  browser uploads in some regions (e.g. ap-northeast-1).
+- The Web UI no longer sends a message when an attachment upload fails: input
+  and attachments are kept for retry and the actual error (e.g. quota
+  exceeded) is shown instead of a generic failure.
+- Per-user raw attachment caps recalibrated for internal/team deployments
+  (1000 objects / 50GB, overridable via `ATTACHMENT_MAX_OBJECTS` /
+  `ATTACHMENT_MAX_BYTES`), and S3 lifecycle rules are prefix-only so
+  attachment objects from pre-0.6 releases (which carry no `sdpm-class` tag)
+  also expire. Deployments upgrading from the old upload pipeline should
+  purge leftover `uploads/` objects — they otherwise count toward the quota.
+- `servers/remote/constraints.txt` regenerated via `make lock`;
+  `cachetools` / `protobuf` are pinned by `aws-opentelemetry-distro` and are
+  now excluded from Dependabot bumps until the distro itself is upgraded.
 
 ## [0.5.3] - 2026-08-01
 
@@ -177,7 +194,9 @@ decks and cloud data keep working. See the
 - Initial release: spec-driven slide generation (Engine json ↔ pptx, CLI,
   local/remote MCP servers, Strands Agent, React Web UI, CDK stacks)
 
-[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.3...v0.6.0
+[0.5.3]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.4.0...v0.5.0

--- a/sdpm/sdpm/__init__.py
+++ b/sdpm/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"

--- a/tests/test_attachment_pipeline.py
+++ b/tests/test_attachment_pipeline.py
@@ -333,10 +333,12 @@ class TestCache:
     """Tests for stage cache identity and publish."""
 
     def test_pipeline_version_format(self):
+        import sdpm
         from sdpm.tools.attachment.cache import pipeline_version
         pv = pipeline_version()
         assert ":attachment-" in pv
-        assert pv.startswith("0.5.3:attachment-1")
+        # Derived from sdpm.__version__ so cache keys rotate on engine releases.
+        assert pv.startswith(f"{sdpm.__version__}:attachment-")
 
     def test_import_key_deterministic(self):
         from sdpm.tools.attachment.cache import compute_import_key


### PR DESCRIPTION
## Summary

Moves `[Unreleased]` to `[0.6.0] - 2026-08-02` and bumps `sdpm.__version__`.

v0.6.0 is the joint breaking release shipped in #265 (stateless attachment pipeline + MCP tool cleanup), already deployed and E2E-verified, plus the deploy-verification fixes #267–#270 (added to the Fixed section).

Also:
- Repairs CHANGELOG compare links (the 0.5.3 entry was missing)
- Fixes a brittle test that hard-coded the version string in the attachment pipeline cache key (now derived from `sdpm.__version__`)

## After merge
Tag `v0.6.0` on the merge commit — the release workflow extracts the section for the GitHub Release notes.

## Testing
make test: 755 passed, 5 skipped