### PR TITLE
ci: add deploy-surface guards (container dep resolution + cdk synth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,11 @@ jobs:
       # lifecycle rule combinations only fail at CloudFormation/S3 API time,
       # but synth at least validates construct-level constraints and config).
       - name: Synth
-        run: npx cdk synth --all --quiet
+        # config.yaml is a local deployment setting (gitignored) — synth against
+        # the committed example config.
+        run: |
+          cp config.example.yaml config.yaml
+          npx cdk synth --quiet
         working-directory: infra
 
   # Deploy-surface guard: the runtime docker builds resolve Python deps with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,38 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
         working-directory: infra
+      # cdk synth catches template-level errors that tsc cannot (e.g. invalid
+      # lifecycle rule combinations only fail at CloudFormation/S3 API time,
+      # but synth at least validates construct-level constraints and config).
+      - name: Synth
+        run: npx cdk synth --all --quiet
+        working-directory: infra
+
+  # Deploy-surface guard: the runtime docker builds resolve Python deps with
+  # pip against committed lockfiles. CI has no docker build, so a lockfile
+  # that pip cannot satisfy (e.g. a Dependabot bump contradicting a
+  # transitive hard pin — cachetools/protobuf under aws-opentelemetry-distro,
+  # 2026-08-02) used to surface only at deploy time. Reproduce the exact
+  # docker-side installs as dry runs here.
+  container-deps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v9.0.0
+      - name: Remote server image deps resolve (mirrors servers/remote/Dockerfile)
+        run: |
+          uv venv /tmp/remote-check --python 3.13
+          VIRTUAL_ENV=/tmp/remote-check uv pip install --dry-run \
+            -c servers/remote/constraints.txt ./sdpm ./servers/remote
+      - name: Agent image deps resolve (mirrors agent/Dockerfile)
+        run: |
+          uv venv /tmp/agent-check --python 3.13
+          VIRTUAL_ENV=/tmp/agent-check uv pip install --dry-run \
+            -r agent/requirements.lock
 
   guard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Three deploy failures on 2026-08-02 shared one root cause: correctness had moved into layers CI never exercises.

| Failure | Layer | Would now be caught by |
|---|---|---|
| S3 rejects lifecycle rule combining tag filters + abort-multipart (#267) | CloudFormation/S3 API | partially — `cdk synth` catches construct/config-level errors (this specific one is API-side, but synth closes the class of template errors below it) |
| Dependabot bump contradicts transitive hard pin, docker pip resolution impossible (#270) | Docker image build | **container-deps job** |

### Changes
- **container-deps job**: reproduces the docker-side pip installs as `uv pip install --dry-run` against the committed lockfiles (`servers/remote/constraints.txt` + `agent/requirements.lock`), mirroring the Dockerfiles. Verified locally that the cachetools 7.1.6 bump (#259) fails this check (`unsatisfiable`).
- **infra job**: adds `cdk synth --all --quiet` after type checking.

## Testing
- Both dry-run steps pass locally against current lockfiles
- Negative test: swapping in cachetools==7.1.6 makes the remote check fail
- `cdk synth --all` verified locally