### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,44 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-03
+
+### Added
+
+- **Web UI: live design studio** — full visual redesign. Light/Dark/System
+  themes (default dark), 90–125% text scaling, studio color tokens (5 agent
+  work colors, ink for deliverables, red reserved for errors), and a
+  two-voice typography system (Bricolage Grotesque for UI chrome, Fraunces
+  for document surfaces).
+- **Web UI: artifact-first review surfaces** — chat tool activity as a
+  compact agent work ledger; brief as a reviewable contract document with
+  approval state; outline as single-column narrative slides (number rail,
+  slim skeleton cards, enriched slide faces with an evidence/visual/notes
+  spec sheet); art direction as per-slide style cards sharing the same rail
+  grammar, with template and style sections on one alignment axis.
+- Outline workflow now asks for `##` section headings when a deck has
+  distinct parts, so review surfaces can render the story arc as chapters.
+
+### Changed
+
+- Style cover extraction is unified client-side: both `/styles` APIs
+  (cloud and local) now serve raw style HTML (`html` field replaces
+  `coverHtml`), and the style gallery opens previews with zero additional
+  round-trips.
+- Style previews and thumbnails keep the style author's own canvas
+  background instead of forcing transparency.
+
+### Fixed
+
+- Style thumbnails rendered the first slide at 70% (standalone-viewing
+  `body zoom` was not reset in the cloud cover path), leaving gutters
+  around the cover; slides now fill thumbnails edge-to-edge.
+- Unpainted regions of style slides (rounded corners, frame decorations)
+  showed as opaque white inside the dark UI.
+- One deck slide always fits the viewport in the full-size carousel view.
+- Prose art direction (`art-direction.md`, no style selected) rendered as
+  raw markdown inside an iframe; it is now typeset as a document.
+
 ## [0.6.0] - 2026-08-02
 
 ### Breaking
@@ -194,7 +232,8 @@ decks and cloud data keep working. See the
 - Initial release: spec-driven slide generation (Engine json ↔ pptx, CLI,
   local/remote MCP servers, Strands Agent, React Web UI, CDK stacks)
 
-[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.1...v0.5.2

--- a/sdpm/sdpm/__init__.py
+++ b/sdpm/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
Bumps the engine version to 0.7.0 and moves the [Unreleased] changelog entries under the 0.7.0 heading.

Release contents: PR #275 (live design studio — Web UI redesign, artifact-first review surfaces, outline section headings, style cover unification).

After merge: tag `v0.7.0` on main.