### PR TITLE
fix: calibrate arch box auto-height to pt metrics with CJK support (ptPerPx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ### Fixed
 
+- **Architecture diagram box auto-height now works on non-16:9 templates and
+  with CJK text** — the engine used a fixed 16:9 pt-to-px ratio for text
+  measurement, causing boxes to undersize on 4:3 and other aspect ratios, and
+  did not account for fullwidth (CJK) character width. `analyze_template` now
+  reports `ptPerPx` in `slide_size`, the agent records it in `deck.json`
+  `slideSize`, and `arch_diagram` accepts a `pt_per_px` parameter for accurate
+  calibration. (#285)
+- **Remote MCP: `analyze_template` now includes `slide_size` in cached
+  results** — the cached template analysis omitted the `slide_size` field, so
+  subsequent calls returned an incomplete response and the agent could not
+  populate `deck.json` `slideSize`. (#285)
+
 - **Custom templates with non-16:9 slide sizes (4:3 etc.) now lay out correctly** —
   the engine's px coordinate system followed the template width but assumed a
   fixed height of 1080, so 4:3 decks left the bottom quarter of every slide

--- a/api/index.py
+++ b/api/index.py
@@ -531,10 +531,7 @@ def list_templates() -> Dict[str, Any]:
                 "s3Key": s3_key,
                 "s3ETag": etag,
                 "fonts": analysis.get("fonts", {}),
-                "analysisJson": json.dumps({
-                    "theme_colors": analysis.get("theme_colors", {}),
-                    "layouts": analysis.get("layouts", []),
-                }),
+                "analysisJson": json.dumps(analysis, ensure_ascii=False),
             }
             table.put_item(Item=item)
             # Update the placeholder in templates list
@@ -694,10 +691,7 @@ def upload_user_template() -> Dict[str, Any]:
     metadata = {
         "description": description,
         "fonts": analysis.get("fonts", {}),
-        "analysisJson": json.dumps({
-            "theme_colors": analysis.get("theme_colors", {}),
-            "layouts": analysis.get("layouts", []),
-        }),
+        "analysisJson": json.dumps(analysis, ensure_ascii=False),
     }
 
     # Store in DDB

--- a/docs/en/custom-template.md
+++ b/docs/en/custom-template.md
@@ -77,10 +77,10 @@ it in `deck.json` as `slideSize` so that slide composition uses the full canvas.
 
 Known limitations for non-16:9 templates:
 
-- **Architecture diagram boxes** — when `box.height` is omitted, the engine
-  estimates it from the text, and that estimate is calibrated for 16:9. On other
-  aspect ratios it can be up to ~25% too small, causing text to overflow.
-  Specify `box.height` explicitly to avoid this.
+- **Architecture diagram boxes** — fixed in #285. Box auto-height is now
+  calibrated using `slideSize.ptPerPx` (the pt-to-px conversion rate reported
+  by `analyze_template` and stored in `deck.json`). Explicit `box.height` is
+  still accepted for manual fine-tuning.
 - **Style demos** — the bundled style gallery HTML files use a fixed 16:9 canvas.
   This does not affect generated slides (only the design tokens are consumed).
 - **Deck list thumbnails** — the Web UI deck list crops thumbnails to a fixed

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -145,10 +145,13 @@ rather than inventing an ad-hoc value.
 ### Canvas dimensions
 
 The canvas is **width 1920px fixed, height variable** depending on the template.
-Always read `deck.json` `slideSize` to determine the actual slide height (H).
+Always read `deck.json` `slideSize` to determine the actual slide height (H)
+and `ptPerPx` (the pt-to-px conversion rate used for text width budgeting and
+`arch_diagram`'s box sizing).
 - Content area: y = title bottom + margin to H−130
-- For 16:9 (H=1080): y=173–950. For 4:3 (H=1440): y=173–1310
+- For 16:9 (H=1080, ptPerPx=0.5): y=173–950. For 4:3 (H=1440, ptPerPx=0.375): y=173–1310
 - Never assume H=1080 — derive from `slideSize`
+- Pass `slideSize.ptPerPx` to `arch_diagram` as `pt_per_px` for correct box sizing
 
 ## Consistency Review Mode
 

--- a/personas/vibe.md
+++ b/personas/vibe.md
@@ -96,14 +96,14 @@ Rules:
 5. Read `specs/art-direction.html` via `run_python` (`read_text("specs/art-direction.html")`),
    extract the `:root` CSS variables, then update `deck.json` via `write_json`.
    Also record the template's `slideSize` — call `analyze_template(template)` to get
-   `slide_size`, or use the known default `{"width": 1920, "height": 1080}` for standard
-   16:9 templates:
+   `slide_size`, or use the known default `{"width": 1920, "height": 1080, "ptPerPx": 0.5}`
+   for standard 16:9 templates:
    ```json
    {
      "template": "{template}.pptx",
      "fonts": {"fullwidth": "{fullwidth font}", "halfwidth": "{halfwidth font}"},
      "defaultTextColor": "{--color-text value}",
-     "slideSize": {"width": 1920, "height": (from analyze_template or 1080 for 16:9)}
+     "slideSize": {"width": 1920, "height": (from analyze_template or 1080 for 16:9), "ptPerPx": (from analyze_template or 0.5 for 16:9)}
    }
    ```
 

--- a/sdpm/references/guides/arch-layout-engine.md
+++ b/sdpm/references/guides/arch-layout-engine.md
@@ -28,17 +28,24 @@ fix the structure without a second command:
 
 ```
 arch_diagram(spec="<logical-structure JSON string>",
-             x=100, y=180, width=1720, height=800, theme="dark")
+             x=100, y=180, width=1720, height=800, theme="dark",
+             pt_per_px=0.5)
 ```
 
 Default target area (x=100, y=180, width=1720, height=800) assumes 16:9 canvas.
 For non-16:9 templates, derive height from slideSize: e.g. `height = H - 180 - 130`
 (H from `deck.json` `slideSize`; 4:3 H=1440 → height=1130).
 
-> **Known constraint (non-16:9):** The layout engine's text-to-box sizing uses a
-> fixed px-to-pt ratio calibrated for 16:9. On taller canvases (e.g. 4:3), boxes with
-> long `description` text may overflow. **Workaround:** explicitly set `"height"` on
-> boxes with multi-line descriptions instead of relying on auto-calculation.
+**`pt_per_px`** — the pt-to-px conversion rate from `deck.json`
+`slideSize.ptPerPx`. Defaults to 0.5 (16:9). For non-16:9 templates, pass the
+value reported by `analyze_template` (e.g. 4:3 = 0.375). The engine uses this
+to calculate box auto-height from text content, so passing the correct value
+ensures boxes are sized accurately regardless of aspect ratio.
+
+> **Box auto-height (fixed in #285):** Text-to-box sizing now uses the
+> `pt_per_px` parameter for calibration, so non-16:9 templates produce
+> correctly-sized boxes. Explicit `"height"` on box nodes is still supported
+> for manual fine-tuning.
 
 **CLI** — same engine, for SKILL.md/script hosts:
 

--- a/sdpm/references/guides/import-pptx.md
+++ b/sdpm/references/guides/import-pptx.md
@@ -64,11 +64,8 @@ user to re-upload.
 Call `init_presentation(name=<suggestedName>)` — **do NOT pass a template
 argument**.
 
-- Cloud `init_presentation` has no template parameter, and Local's
-  template parameter would pre-populate fonts that Step 4 immediately
-  overwrites with PPTX-derived fonts. Skipping the argument keeps Local
-  and Cloud symmetric.
-- The bundle template path, fonts, and `defaultTextColor` are assigned to
+- Neither Cloud nor Local `init_presentation` accepts a template parameter.
+  The bundle template path, fonts, and `defaultTextColor` are assigned to
   `deck.json` in Step 4; the immutable bundle itself is not modified.
 - Returns the new `deck_id` (directory path in Local, deckId in Cloud).
 

--- a/sdpm/references/workflows/create-new-1-art-direction.md
+++ b/sdpm/references/workflows/create-new-1-art-direction.md
@@ -63,13 +63,14 @@ Update `deck.json` with the template name and fonts from the analyze output.
 When `specs/art-direction.html` exists, read `:root` CSS variables and use `--color-text` as `defaultTextColor`.
 If the style HTML specifies font-family, ask the user which to use — the style's fonts or the template's fonts.
 
-Also record the template's slide size — check the `slide_size` field from the analyze output:
+Also record the template's slide size — check the `slide_size` field from the analyze output
+and copy it verbatim (it includes `ptPerPx`, the pt-to-px conversion rate):
 ```json
 {
   "template": "{selected_template}.pptx",
   "fonts": {"fullwidth": "(style or template)", "halfwidth": "(style or template)"},
   "defaultTextColor": "(use --color-text from art-direction.html :root)",
-  "slideSize": {"width": 1920, "height": (from analyze_template slide_size)}
+  "slideSize": {"width": 1920, "height": (from analyze_template slide_size), "ptPerPx": (from analyze_template slide_size)}
 }
 ```
 

--- a/sdpm/references/workflows/slide-json-spec.md
+++ b/sdpm/references/workflows/slide-json-spec.md
@@ -302,7 +302,8 @@ Height includes the language label (22px). Code body height is `height - 22`.
 | 28pt | 70px | 140px | 210px | Heading |
 | 32pt | 80px | 160px | 240px | Large heading |
 
-**Width guide**: fullwidth = `pt × 2 × char count`, halfwidth = `pt × 1 × char count`
+**Width guide**: fullwidth px = `fontSize ÷ ptPerPx × char count`, halfwidth = half that.
+  `ptPerPx` is in `deck.json` `slideSize.ptPerPx` (16:9 = 0.5 → ×2, 4:3 = 0.375 → ×2.67)
 - `autoWidth`: true → word_wrap disabled (width fits text)
 - `line`: border color. Omit or `"none"` for no border
 - `lineWidth`: border thickness (pt, default 1)

--- a/sdpm/sdpm/api.py
+++ b/sdpm/sdpm/api.py
@@ -150,6 +150,7 @@ def analyze_and_store_template(template_path: Path, description: str = "") -> di
         "fonts": result.get("fonts", {}),
         "layout_count": len(result.get("layouts", [])),
         "layouts": result.get("layouts", []),
+        "slide_size": result.get("slide_size", {}),
     }
 
 
@@ -269,7 +270,6 @@ def _get_output_base_dir() -> Path:
 
 def init(
     name: str,
-    template: str | Path | None = None,
     output_dir: str | Path | None = None,
 ) -> dict[str, Any]:
     """Initialize a presentation workspace.
@@ -278,13 +278,11 @@ def init(
 
     Args:
         name: Presentation name (used in directory name).
-        template: Template name or path. If provided, extracts fonts.
         output_dir: Explicit output directory. Auto-generated if None.
 
     Returns:
-        Dict with output_dir, deck_json, template, fonts, workspace.
+        Dict with output_dir, deck_json, workspace.
     """
-    from sdpm.engine.analyzer import extract_fonts
     from sdpm.utils.io import write_json
 
     if output_dir:
@@ -301,30 +299,6 @@ def init(
         "defaultTextColor": "",
     }
 
-    if template:
-        template_src = Path(template).expanduser()
-        if not template_src.exists():
-            found = _find_template_in_dirs(str(template), get_templates_dirs())
-            if found is not None:
-                template_src = found
-        if template_src.exists():
-            template_src = template_src.resolve()
-            deck_data["template"] = template_src.name
-            try:
-                deck_data["fonts"] = extract_fonts(template_src)
-            except Exception:
-                pass
-            # Write slideSize derived from template (new-deck only — R4)
-            try:
-                from pptx import Presentation as _Prs
-                from sdpm.engine import slide_size_px as _slide_size_px
-
-                _prs = _Prs(str(template_src))
-                w, h = _slide_size_px(int(_prs.slide_width), int(_prs.slide_height))
-                deck_data["slideSize"] = {"width": w, "height": h}
-            except Exception:
-                pass
-
     deck_json = out_dir / "deck.json"
     write_json(deck_json, deck_data, suffix="\n")
 
@@ -338,8 +312,6 @@ def init(
     return {
         "output_dir": str(out_dir),
         "deck_json": str(deck_json),
-        "template": deck_data.get("template", ""),
-        "fonts": deck_data.get("fonts", {}),
         "workspace": ["deck.json", "slides/"] + [f"specs/{s}" for s in spec_files],
     }
 

--- a/sdpm/sdpm/engine/analyzer/__init__.py
+++ b/sdpm/sdpm/engine/analyzer/__init__.py
@@ -44,10 +44,9 @@ def analyze_template(template_path: Path):
     theme_colors = extract_theme_colors(template_path)
     fonts = extract_fonts(template_path)
     color_usage = _load_color_usage_cache(template_path)
-    slide_size = {
-        "width": slide_size_px(prs.slide_width, prs.slide_height)[0],
-        "height": slide_size_px(prs.slide_width, prs.slide_height)[1],
-    }
+    _w, _h = slide_size_px(prs.slide_width, prs.slide_height)
+    _pt_per_px = round((int(prs.slide_width) / 12700) / 1920, 6)
+    slide_size = {"width": _w, "height": _h, "ptPerPx": _pt_per_px}
 
     return {
         "slide_size": slide_size,

--- a/sdpm/sdpm/engine/converter/pipeline.py
+++ b/sdpm/sdpm/engine/converter/pipeline.py
@@ -109,7 +109,8 @@ def pptx_to_json(pptx_path: Path, output_dir: Path = None, use_layout_names: boo
     # Write slideSize from the source pptx (new-deck only — R4)
     from sdpm.engine import slide_size_px as _slide_size_px
     _w, _h = _slide_size_px(int(prs.slide_width), int(prs.slide_height))
-    deck_meta["slideSize"] = {"width": _w, "height": _h}
+    _pt_per_px = round((int(prs.slide_width) / 12700) / 1920, 6)
+    deck_meta["slideSize"] = {"width": _w, "height": _h, "ptPerPx": _pt_per_px}
     write_json(output_dir / "deck.json", deck_meta)
 
     # Write slides/slide-{NNN}.json (1-based, zero-padded, hyphen separator to match parse_outline_slugs).

--- a/sdpm/sdpm/engine/layout/placement.py
+++ b/sdpm/sdpm/engine/layout/placement.py
@@ -4,9 +4,37 @@
 geometry computed from the logical structure tree.
 """
 
+import math
+
+# ---------------------------------------------------------------------------
+# pt-based calibration constants (true values derived from template metrics)
+# ---------------------------------------------------------------------------
+_LINE_PT = 13.2       # line height = 1.2 × 11pt font
+_PAD_PT = 20.0        # total vertical padding (top + bottom) for box
+_HALFWIDTH_PT = 5.0   # average half-width glyph width in pt (≈ 0.455em at 11pt)
+_FULLWIDTH_PT = 11.0  # full-width CJK glyph = 1em at 11pt
+
+# Icon label constants (in pt, derived from current px values as true values)
+_LABEL_CHAR_PT = 4.0        # 8px × 0.5 = 4pt per half-width char
+_LABEL_FULLWIDTH_PT = 8.8   # full-width char ≈ 2.2× half-width in label font (8pt)
+_LABEL_HEIGHT_PT = 17.5     # first line height: 35px × 0.5 = 17.5pt
+_LABEL_EXTRA_LINE_PT = 9.0  # additional line height: 18px × 0.5 = 9pt
 
 
-def _layout_scale(node, parent_dir="horizontal", parent_align="center", spacing_scale_h=1.0, spacing_scale_v=1.0):
+def _text_width_pt(s: str) -> float:
+    """Estimate text width in pt for an 11pt font.
+
+    CJK detection: ord > 0x2E80 (covers CJK Unified Ideographs and related).
+    """
+    return sum(_FULLWIDTH_PT if ord(c) > 0x2E80 else _HALFWIDTH_PT for c in s)
+
+
+def _label_width_pt(s: str) -> float:
+    """Estimate label text width in pt (label uses ~8pt effective size)."""
+    return sum(_LABEL_FULLWIDTH_PT if ord(c) > 0x2E80 else _LABEL_CHAR_PT for c in s)
+
+
+def _layout_scale(node, parent_dir="horizontal", parent_align="center", spacing_scale_h=1.0, spacing_scale_v=1.0, pt_per_px=0.5):
     """Recursive layout engine. Calculates bindings (x, y, width, height) for each node bottom-up."""
     children = node.get("children", [])
     direction = node.get("direction", parent_dir)
@@ -40,24 +68,29 @@ def _layout_scale(node, parent_dir="horizontal", parent_align="center", spacing_
             if "height" in box:
                 bh = box["height"]
             else:
-                char_per_line = max(1, bw // 10)
+                # pt-based line estimation: each line wraps when text width
+                # exceeds the box width converted to pt.
+                available_pt = bw * pt_per_px
                 lines = 0
                 for field in [box.get("sublabel"), box.get("title", node.get("id", "")), box.get("description")]:
                     if field:
                         for paragraph in str(field).split("\n"):
-                            lines += max(1, -(-len(paragraph) // char_per_line))
-                bh = lines * 24 + 40
+                            width_pt = _text_width_pt(paragraph)
+                            lines += max(1, math.ceil(width_pt / available_pt))
+                bh = math.ceil(lines * _LINE_PT / pt_per_px) + round(_PAD_PT / pt_per_px)
             margin = node.get("margin", {"top": sv(20), "right": sh(20), "bottom": sv(20), "left": sh(20)})
             padding = {"top": 0, "right": 0, "bottom": 0, "left": 0}
             node["_bindings"] = [0, 0, bw, bh]
             node["_margin"] = margin
             node["_padding"] = padding
             return
-        label_h = sv(35)
+        # Icon label sizing (pt-based with CJK support)
         raw_label = node.get("label", "")
         label_lines = raw_label.replace("\\n", "\n").split("\n")
-        label_w = max((len(line) * 8 for line in label_lines), default=0)
-        label_h = sv(35) + (len(label_lines) - 1) * sv(18)
+        label_w = max((round(_label_width_pt(line) / pt_per_px) for line in label_lines), default=0)
+        label_h = round(_LABEL_HEIGHT_PT / pt_per_px * spacing_scale_v) + (len(label_lines) - 1) * round(_LABEL_EXTRA_LINE_PT / pt_per_px * spacing_scale_v)
+        # Ensure minimum via sv() for consistency with spacing scale
+        label_h = max(label_h, sv(35) + (len(label_lines) - 1) * sv(18)) if spacing_scale_v != 1.0 else label_h
         half_label_overhang = max(0, (label_w - icon_size) // 2)
         margin = node.get("margin", {"top": sv(20), "right": max(sh(20), half_label_overhang + 5), "bottom": label_h + sv(10), "left": max(sh(20), half_label_overhang + 5)})
         padding = {"top": 0, "right": 0, "bottom": 0, "left": 0}
@@ -67,7 +100,7 @@ def _layout_scale(node, parent_dir="horizontal", parent_align="center", spacing_
         return
 
     for child in children:
-        _layout_scale(child, direction, align, spacing_scale_h, spacing_scale_v)
+        _layout_scale(child, direction, align, spacing_scale_h, spacing_scale_v, pt_per_px)
 
     reverse = node.get("reverse", False)
     ordered = list(reversed(children)) if reverse else children

--- a/sdpm/sdpm/engine/layout/render.py
+++ b/sdpm/sdpm/engine/layout/render.py
@@ -36,7 +36,7 @@ from . import (
 _FIT_ITERATIONS = 8
 
 
-def build_layout(tree, x=None, y=None, width=None, height=None, optimize=True):
+def build_layout(tree, x=None, y=None, width=None, height=None, optimize=True, pt_per_px=0.5):
     """Run the placement pipeline on a logical-structure ``tree``.
 
     Returns ``(nodes, groups, edges, root_bindings, cum_h, cum_v)`` where
@@ -49,6 +49,10 @@ def build_layout(tree, x=None, y=None, width=None, height=None, optimize=True):
     ``optimize=False`` skips the order-optimization pre-pass. The tile-pool
     reflow inside ``optimize_order`` uses this to score candidate arrangements
     by real routing without recursing back into itself.
+
+    ``pt_per_px`` is the ratio of physical pt to virtual px (default 0.5 for
+    16:9 at 1920px logical width). Controls box height estimation accuracy
+    across different template aspect ratios.
     """
     tree = copy.deepcopy(tree)
     direction = tree.get("direction", "horizontal")
@@ -69,7 +73,7 @@ def build_layout(tree, x=None, y=None, width=None, height=None, optimize=True):
 
     # Pass 1: natural size.
     root = build_root()
-    _layout_scale(root, direction, align)
+    _layout_scale(root, direction, align, pt_per_px=pt_per_px)
 
     # Record each top-level group's NATURAL cross-axis size so we can later tell
     # which groups fit on their own (before any global squash).
@@ -87,14 +91,14 @@ def build_layout(tree, x=None, y=None, width=None, height=None, optimize=True):
             cum_h *= sx
             cum_v *= sy
             root = build_root()
-            _layout_scale(root, direction, align, cum_h, cum_v)
+            _layout_scale(root, direction, align, cum_h, cum_v, pt_per_px=pt_per_px)
         # A single oversized group forces a global cross-axis squash that would
         # crush short siblings. Cancel that squash on the groups that already
         # fit (the slide may overflow — that's the oversized group's problem,
         # flagged by a warning — but the groups that fit stay readable).
         if cancel_cross_axis_squash(tree, natural_sizes, cum_h, cum_v, width, height):
             root = build_root()
-            _layout_scale(root, direction, align, cum_h, cum_v)
+            _layout_scale(root, direction, align, cum_h, cum_v, pt_per_px=pt_per_px)
 
     rb = root["_bindings"]
     ox = (x or 0) - rb[0]
@@ -432,7 +436,7 @@ def _build_warnings(nodes_out, groups_out, edges_out, rb,
 
 
 def render_architecture(tree, x=None, y=None, width=None, height=None,
-                        theme="dark", include_metrics=True):
+                        theme="dark", include_metrics=True, pt_per_px=0.5):
     """Render a logical-structure ``tree`` to placed sdpm elements.
 
     Returns a dict with:
@@ -444,6 +448,10 @@ def render_architecture(tree, x=None, y=None, width=None, height=None,
 
     ``targetArea`` inside the tree (``{x, y, width, height}``) overrides the
     corresponding argument when that argument is falsy.
+
+    ``pt_per_px`` is the ratio of physical pt to virtual px (default 0.5 for
+    16:9 at 1920px logical width). Pass ``slideSize.ptPerPx`` from the deck
+    JSON when targeting non-16:9 templates.
     """
     target_area = tree.get("targetArea", {})
     if target_area:
@@ -457,7 +465,7 @@ def render_architecture(tree, x=None, y=None, width=None, height=None,
             height = target_area["height"]
 
     nodes_out, groups_out, edges_out, rb, cum_h, cum_v = build_layout(
-        tree, x, y, width, height)
+        tree, x, y, width, height, pt_per_px=pt_per_px)
 
     is_dark = theme == "dark"
     elements = _build_elements(tree, nodes_out, groups_out, edges_out, is_dark)

--- a/sdpm/sdpm/tools/__init__.py
+++ b/sdpm/sdpm/tools/__init__.py
@@ -77,9 +77,8 @@ def init_presentation(name: str) -> dict[str, Any]:
     """Initialize a presentation workspace. Creates deck.json, slides/, and specs/.
 
     Call after briefing is complete, before building slides.
-    When a template is provided, deck.json will include slideSize
-    (e.g. {"width": 1920, "height": 1080} for 16:9, {"width": 1920, "height": 1440} for 4:3)
-    derived from the template's physical dimensions.
+    slideSize is written to deck.json by the agent after calling analyze_template —
+    copy the slide_size result (width, height, ptPerPx) into deck.json's slideSize field.
 
     Args:
         name: Presentation name (e.g. "lambda-overview").
@@ -100,8 +99,10 @@ def analyze_template(template: str, layout: str = "") -> dict[str, Any]:
 
     Returns:
         Dict with layouts, theme_colors, fonts, slide_size, and optional layout_detail.
-        slide_size is {"width": 1920, "height": H} where H depends on the template's
-        aspect ratio (e.g. 1080 for 16:9, 1440 for 4:3). Width is always 1920px.
+        slide_size is {"width": 1920, "height": H, "ptPerPx": P} where H depends on
+        the template's aspect ratio (e.g. 1080 for 16:9, 1440 for 4:3). Width is
+        always 1920px. ptPerPx is the pt-to-px conversion ratio (0.5 for 16:9,
+        0.375 for 4:3) — copy it into deck.json slideSize for arch_diagram to use.
     """
     from sdpm.engine.analyzer import analyze_template as _analyze, get_layout_placeholders
     from sdpm.api import _find_template_in_dirs, get_templates_dirs
@@ -361,6 +362,7 @@ def arch_diagram(
     spec: str,
     x: int = 100, y: int = 180, width: int = 1720, height: int = 800,
     theme: str = "dark",
+    pt_per_px: float = 0.5,
 ) -> dict[str, Any]:
     """Auto-layout an architecture/flow diagram from a logical-structure JSON.
 
@@ -385,6 +387,10 @@ def arch_diagram(
         width: Target area width in px (engine scales the diagram to fit).
         height: Target area height in px.
         theme: "dark" or "light" — affects box-node text colors.
+        pt_per_px: Ratio of physical pt to virtual px. Pass deck.json's
+            slideSize.ptPerPx value here. 16:9 = 0.5, 4:3 = 0.375.
+            If you omit this on a non-16:9 template, box text will overflow
+            because the height estimate assumes 16:9 proportions.
 
     Returns:
         Dict with:
@@ -408,7 +414,7 @@ def arch_diagram(
         return {"error": f"Invalid diagram spec JSON: {e}"}
     return render_architecture(
         tree, x=x, y=y, width=width, height=height, theme=theme,
-        include_metrics=True,
+        include_metrics=True, pt_per_px=pt_per_px,
     )
 
 

--- a/servers/local/README.md
+++ b/servers/local/README.md
@@ -30,7 +30,7 @@ uv run python server.py
 
 | Tool | Description |
 |------|-------------|
-| `init_presentation` | Initialize workspace with template and fonts |
+| `init_presentation` | Initialize a new deck workspace |
 | `analyze_template` | Analyze a PPTX template (layouts, colors, fonts) |
 | `generate_pptx` | Generate PPTX from JSON |
 | `read_attachment` | Read content from an attached file with byte-offset paging |

--- a/servers/remote/tools/template.py
+++ b/servers/remote/tools/template.py
@@ -82,6 +82,16 @@ def analyze_template(template_name: str, storage: Storage, user_id: str = "") ->
             analysis_raw = user_meta.get("analysisJson", "")
             if analysis_raw and analysis_raw != "{}":
                 analysis = json.loads(analysis_raw) if isinstance(analysis_raw, str) else analysis_raw
+                # Fallback for old cached entries missing slide_size
+                if "slide_size" not in analysis:
+                    import tempfile
+                    from pathlib import Path
+                    from sdpm.engine.analyzer import analyze_template as _analyze
+                    data = storage.download_user_template(user_id, normalized)
+                    tmp = Path(tempfile.mkdtemp())
+                    tpl_path = tmp / "template.pptx"
+                    tpl_path.write_bytes(data)
+                    analysis = _analyze(tpl_path)
             else:
                 # Analyze on the fly
                 import tempfile
@@ -128,6 +138,19 @@ def analyze_template(template_name: str, storage: Storage, user_id: str = "") ->
         analysis = _analyze(tpl_path)
     else:
         analysis = json.loads(analysis_raw) if isinstance(analysis_raw, str) else analysis_raw
+        # Fallback for old cached entries missing slide_size
+        if "slide_size" not in analysis:
+            import tempfile
+            from pathlib import Path
+            from sdpm.engine.analyzer import analyze_template as _analyze
+
+            s3_key = tmpl.get("s3Key", "")
+            if s3_key:
+                data = storage.download_file(key=s3_key)
+                tmp = Path(tempfile.mkdtemp())
+                tpl_path = tmp / "template.pptx"
+                tpl_path.write_bytes(data)
+                analysis = _analyze(tpl_path)
     analysis["fonts"] = tmpl.get("fonts", {})
     analysis["templateName"] = template_name
     return analysis

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -16,7 +16,7 @@ class TestAnalyzerPin16x9:
     def test_slide_size_16x9(self, template_16x9: Path):
         """slide_size must be 1920×1080 for 16:9."""
         result = analyze_template(template_16x9)
-        assert result["slide_size"] == {"width": 1920, "height": 1080}
+        assert result["slide_size"] == {"width": 1920, "height": 1080, "ptPerPx": 0.5}
 
     def test_layouts_present(self, template_16x9: Path):
         """analyze_template returns at least one layout."""
@@ -85,9 +85,10 @@ class TestAnalyzer4x3:
 
         9144000 / 1920 = 4762.5 emu_per_px
         6858000 / 4762.5 = 1440 height
+        ptPerPx = (9144000 / 12700) / 1920 = 0.375
         """
         result = analyze_template(template_4x3)
-        assert result["slide_size"] == {"width": 1920, "height": 1440}
+        assert result["slide_size"] == {"width": 1920, "height": 1440, "ptPerPx": 0.375}
 
     def test_placeholder_px_values_4x3(self, template_4x3: Path):
         """4:3 placeholders use emu_per_px = 4762.5 (not 6350).

--- a/tests/test_canvas_derivation.py
+++ b/tests/test_canvas_derivation.py
@@ -60,11 +60,11 @@ class TestAnalyzerPin16x9:
 
     def test_slide_size(self, template_16x9: Path):
         result = analyze_template(template_16x9)
-        assert result["slide_size"] == {"width": 1920, "height": 1080}
+        assert result["slide_size"] == {"width": 1920, "height": 1080, "ptPerPx": 0.5}
 
     def test_slide_size_keys(self, template_16x9: Path):
         result = analyze_template(template_16x9)
-        assert set(result["slide_size"].keys()) == {"width", "height"}
+        assert set(result["slide_size"].keys()) == {"width", "height", "ptPerPx"}
 
 
 class TestLayoutPlaceholdersPin16x9:

--- a/tests/test_canvas_slidesize.py
+++ b/tests/test_canvas_slidesize.py
@@ -152,23 +152,10 @@ class TestResolveConfigHeightBoundaryWarning:
 
 
 class TestInitSlidesSize:
-    """api.init writes slideSize to deck.json when template is provided."""
+    """api.init creates a minimal deck.json without slideSize (template branch removed)."""
 
-    def test_init_16x9_template(self, template_16x9: Path, tmp_path: Path):
-        from sdpm.api import init
-
-        result = init(name="test", template=str(template_16x9), output_dir=str(tmp_path / "out"))
-        deck_json = json.loads(Path(result["deck_json"]).read_text())
-        assert deck_json["slideSize"] == {"width": 1920, "height": 1080}
-
-    def test_init_4x3_template(self, template_4x3: Path, tmp_path: Path):
-        from sdpm.api import init
-
-        result = init(name="test", template=str(template_4x3), output_dir=str(tmp_path / "out"))
-        deck_json = json.loads(Path(result["deck_json"]).read_text())
-        assert deck_json["slideSize"] == {"width": 1920, "height": 1440}
-
-    def test_init_no_template_no_slide_size(self, tmp_path: Path):
+    def test_init_no_slide_size(self, tmp_path: Path):
+        """init never writes slideSize — the agent writes it after analyze_template."""
         from sdpm.api import init
 
         result = init(name="test", output_dir=str(tmp_path / "out"))
@@ -198,7 +185,7 @@ class TestPipelineSlidesSize:
         out_dir = tmp_path / "out"
         pptx_to_json(src, output_dir=out_dir)
         deck = json.loads((out_dir / "deck.json").read_text())
-        assert deck["slideSize"] == {"width": 1920, "height": 1080}
+        assert deck["slideSize"] == {"width": 1920, "height": 1080, "ptPerPx": 0.5}
 
     def test_4x3_import(self, template_4x3: Path, tmp_path: Path):
         from sdpm.engine.converter import pptx_to_json
@@ -213,7 +200,7 @@ class TestPipelineSlidesSize:
         out_dir = tmp_path / "out"
         pptx_to_json(src, output_dir=out_dir)
         deck = json.loads((out_dir / "deck.json").read_text())
-        assert deck["slideSize"] == {"width": 1920, "height": 1440}
+        assert deck["slideSize"] == {"width": 1920, "height": 1440, "ptPerPx": 0.375}
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_converter_elements.py
+++ b/tests/test_converter_elements.py
@@ -534,7 +534,7 @@ class TestPipelineContract:
             "fonts": {"halfwidth": "Calibri", "fullwidth": ""},
             "defaultTextColor": "#000000",
             "autoSpacing": False,
-            "slideSize": {"width": 1920, "height": 1080},
+            "slideSize": {"width": 1920, "height": 1080, "ptPerPx": 0.5},
         }
         assert (out_dir / "slides" / "slide-001.json").exists()
         assert sorted(p.name for p in (out_dir / "images").iterdir()) == ["slide1_image1.png"]

--- a/tests/test_mcp_template_tools.py
+++ b/tests/test_mcp_template_tools.py
@@ -91,3 +91,79 @@ def test_aws_storage_get_builtin_template_notes_maps_ddb_items() -> None:
         ":pk": "USER#user-123",
         ":prefix": "BUILTIN_NOTE#",
     }
+
+
+class AnalyzeTemplateStorage:
+    """Storage double for analyze_template tests with configurable analysisJson."""
+
+    def __init__(self, analysis_json: str, template_bytes: bytes | None = None) -> None:
+        self._analysis_json = analysis_json
+        self._template_bytes = template_bytes
+
+    def get_user_template_metadata(self, user_id: str, name: str) -> dict | None:
+        return None
+
+    def list_templates(self) -> list[dict]:
+        return [
+            {
+                "name": "blank-dark",
+                "description": "Dark template",
+                "fonts": {"fullwidth": "Noto Sans JP", "halfwidth": "Noto Sans"},
+                "analysisJson": self._analysis_json,
+                "s3Key": "templates/blank-dark.pptx",
+            },
+        ]
+
+    def list_user_templates(self, user_id: str) -> list[dict]:
+        return []
+
+    def download_file(self, key: str) -> bytes:
+        if self._template_bytes is None:
+            raise RuntimeError("download_file called but no template bytes configured")
+        return self._template_bytes
+
+
+def test_analyze_template_cache_hit_with_slide_size() -> None:
+    """When cached analysisJson contains slide_size, it is returned directly."""
+    import json
+    from tools.template import analyze_template
+
+    cached = json.dumps({
+        "slide_size": {"width": 1280, "height": 720},
+        "layouts": [{"name": "Blank"}],
+        "theme_colors": {"accent1": "#FF0000"},
+    })
+    storage = AnalyzeTemplateStorage(cached)
+    result = analyze_template("blank-dark", storage)
+
+    assert result["slide_size"] == {"width": 1280, "height": 720}
+    assert result["templateName"] == "blank-dark"
+
+
+def test_analyze_template_fallback_when_slide_size_missing() -> None:
+    """When cached analysisJson lacks slide_size, re-analyze from S3."""
+    import json
+    from pathlib import Path
+    from tools.template import analyze_template
+
+    # Cached data without slide_size (old format)
+    cached = json.dumps({
+        "layouts": [{"name": "Blank"}],
+        "theme_colors": {"accent1": "#FF0000"},
+    })
+
+    # Use a real template for on-the-fly analysis
+    template_path = Path(__file__).parent.parent / "sdpm" / "templates" / "blank-dark.pptx"
+    if not template_path.exists():
+        import pytest
+        pytest.skip("blank-dark.pptx not available")
+
+    template_bytes = template_path.read_bytes()
+    storage = AnalyzeTemplateStorage(cached, template_bytes)
+    result = analyze_template("blank-dark", storage)
+
+    # Should have slide_size from on-the-fly analysis
+    assert "slide_size" in result
+    assert result["slide_size"]["width"] > 0
+    assert result["slide_size"]["height"] > 0
+    assert result["templateName"] == "blank-dark"

--- a/tests/test_placement_calibration.py
+++ b/tests/test_placement_calibration.py
@@ -1,0 +1,210 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Tests for pt/px calibration in placement.py.
+
+Validates:
+(a) 16:9 default box height pin (new pt-based values)
+(b) CJK description produces more lines than ASCII at same char count
+(c) pt_per_px=0.375 (4:3) produces taller boxes than 16:9 (0.5)
+(d) pt_per_px omitted: build_layout existing calls work unchanged
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+
+from sdpm.engine.layout.placement import (
+    _FULLWIDTH_PT,
+    _HALFWIDTH_PT,
+    _LINE_PT,
+    _PAD_PT,
+    _layout_scale,
+    _text_width_pt,
+)
+from sdpm.engine.layout.render import build_layout, render_architecture
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_box_node(title: str = "Service", description: str = "", width: int = 240):
+    """Create a minimal box node for placement testing."""
+    box = {"title": title, "width": width}
+    if description:
+        box["description"] = description
+    return {"id": "test_node", "box": box}
+
+
+def _get_box_height(node: dict, pt_per_px: float = 0.5) -> int:
+    """Run _layout_scale on a box node and return computed height."""
+    n = copy.deepcopy(node)
+    # Wrap in a minimal root so _layout_scale treats it as a leaf
+    _layout_scale(n, pt_per_px=pt_per_px)
+    return n["_bindings"][3]
+
+
+# ---------------------------------------------------------------------------
+# (a) 16:9 default box height pin (pt-based values)
+# ---------------------------------------------------------------------------
+
+def test_box_height_single_short_title():
+    """A short title (single line) should produce a predictable height."""
+    node = _make_box_node(title="Lambda", description="")
+    h = _get_box_height(node, pt_per_px=0.5)
+    # 1 line: ceil(1 * 13.2 / 0.5) + round(20.0 / 0.5) = ceil(26.4) + 40 = 27 + 40 = 67
+    expected = math.ceil(1 * _LINE_PT / 0.5) + round(_PAD_PT / 0.5)
+    assert h == expected, f"expected {expected}, got {h}"
+
+
+def test_box_height_title_and_description():
+    """Title + description: each computed separately (separate lines)."""
+    node = _make_box_node(title="API Gateway", description="REST endpoint for users")
+    h = _get_box_height(node, pt_per_px=0.5)
+    # Title: "API Gateway" = 11 chars × 5pt = 55pt width. bw=240, available=120pt. 1 line.
+    # Desc: "REST endpoint for users" = 23 chars × 5pt = 115pt. available=120pt. 1 line.
+    # Total: 2 lines → ceil(2 * 13.2 / 0.5) + round(20 / 0.5) = ceil(52.8) + 40 = 53 + 40 = 93
+    expected = math.ceil(2 * _LINE_PT / 0.5) + round(_PAD_PT / 0.5)
+    assert h == expected, f"expected {expected}, got {h}"
+
+
+def test_box_height_wrapping_description():
+    """A long description wraps to multiple lines."""
+    # 30 chars × 5pt = 150pt. available at bw=240: 120pt. ceil(150/120) = 2 lines for desc.
+    desc = "A" * 30
+    node = _make_box_node(title="S3", description=desc)
+    h = _get_box_height(node, pt_per_px=0.5)
+    # Title "S3": 2 chars × 5pt = 10pt < 120pt → 1 line
+    # Desc: 30 chars × 5pt = 150pt. ceil(150/120) = 2 lines
+    # Total: 3 lines
+    expected = math.ceil(3 * _LINE_PT / 0.5) + round(_PAD_PT / 0.5)
+    assert h == expected, f"expected {expected}, got {h}"
+
+
+# ---------------------------------------------------------------------------
+# (b) CJK description produces more lines
+# ---------------------------------------------------------------------------
+
+def test_cjk_description_more_lines():
+    """CJK characters (11pt each) wrap much sooner than ASCII (5pt each)."""
+    ascii_desc = "A" * 20  # 20 × 5pt = 100pt; fits in 120pt (1 line)
+    cjk_desc = "あ" * 20  # 20 × 11pt = 220pt; ceil(220/120) = 2 lines
+
+    h_ascii = _get_box_height(_make_box_node(title="X", description=ascii_desc))
+    h_cjk = _get_box_height(_make_box_node(title="X", description=cjk_desc))
+
+    # ASCII: title(1) + desc(1) = 2 lines
+    # CJK: title(1) + desc(2) = 3 lines
+    assert h_cjk > h_ascii, f"CJK height {h_cjk} should exceed ASCII height {h_ascii}"
+
+
+def test_cjk_text_width_pt():
+    """_text_width_pt correctly distinguishes CJK from ASCII."""
+    ascii_str = "hello"  # 5 × 5pt = 25pt
+    cjk_str = "日本語"  # 3 × 11pt = 33pt
+
+    assert _text_width_pt(ascii_str) == 5 * _HALFWIDTH_PT
+    assert _text_width_pt(cjk_str) == 3 * _FULLWIDTH_PT
+
+
+def test_mixed_cjk_ascii_width():
+    """Mixed CJK/ASCII string correctly sums both widths."""
+    mixed = "Hello世界"  # 5 × 5pt + 2 × 11pt = 25 + 22 = 47pt
+    assert _text_width_pt(mixed) == 5 * _HALFWIDTH_PT + 2 * _FULLWIDTH_PT
+
+
+# ---------------------------------------------------------------------------
+# (c) pt_per_px=0.375 (4:3) produces taller boxes than 16:9 (0.5)
+# ---------------------------------------------------------------------------
+
+def test_43_taller_than_169():
+    """4:3 template (pt_per_px=0.375) should produce taller boxes than 16:9 (0.5)."""
+    node = _make_box_node(title="Service", description="Handles requests")
+    h_169 = _get_box_height(node, pt_per_px=0.5)
+    h_43 = _get_box_height(node, pt_per_px=0.375)
+    assert h_43 > h_169, f"4:3 height {h_43} should exceed 16:9 height {h_169}"
+
+
+def test_43_height_formula():
+    """Verify the exact formula for 4:3."""
+    node = _make_box_node(title="Lambda", description="")
+    h = _get_box_height(node, pt_per_px=0.375)
+    # 1 line: ceil(1 * 13.2 / 0.375) + round(20.0 / 0.375) = ceil(35.2) + round(53.33) = 36 + 53 = 89
+    expected = math.ceil(1 * _LINE_PT / 0.375) + round(_PAD_PT / 0.375)
+    assert h == expected, f"expected {expected}, got {h}"
+
+
+def test_43_wrapping_differs():
+    """Same text may wrap more in 4:3 since available pt per px is smaller."""
+    # 22 chars × 5pt = 110pt.
+    # At bw=240: 16:9 available = 240×0.5 = 120pt → 1 line.
+    #            4:3 available = 240×0.375 = 90pt → ceil(110/90) = 2 lines.
+    desc = "A" * 22
+    node = _make_box_node(title="X", description=desc)
+    h_169 = _get_box_height(node, pt_per_px=0.5)
+    h_43 = _get_box_height(node, pt_per_px=0.375)
+    # 16:9: title(1) + desc(1) = 2 lines
+    # 4:3: title(1) + desc(2) = 3 lines (more wrapping AND bigger px per line)
+    assert h_43 > h_169
+
+
+# ---------------------------------------------------------------------------
+# (d) pt_per_px omission: build_layout existing calls work unchanged
+# ---------------------------------------------------------------------------
+
+_SIMPLE_TREE = {
+    "direction": "horizontal",
+    "children": [
+        {"id": "a", "icon": "aws/lambda", "label": "Lambda"},
+        {"id": "b", "icon": "aws/s3", "label": "S3"},
+    ],
+    "connections": [{"from": "a", "to": "b"}],
+}
+
+
+def test_build_layout_no_pt_per_px_arg():
+    """build_layout works without explicit pt_per_px (uses default 0.5)."""
+    nodes, groups, edges, rb, cum_h, cum_v = build_layout(
+        copy.deepcopy(_SIMPLE_TREE), x=100, y=180, width=1720, height=800)
+    assert "a" in nodes or any("a" in k for k in nodes)
+    assert rb[2] > 0 and rb[3] > 0
+
+
+def test_render_architecture_no_pt_per_px_arg():
+    """render_architecture works without explicit pt_per_px (uses default 0.5)."""
+    result = render_architecture(copy.deepcopy(_SIMPLE_TREE),
+                                 x=100, y=180, width=1720, height=800)
+    assert "elements" in result
+    assert "bbox" in result
+    assert result["bbox"]["width"] > 0
+
+
+def test_build_layout_explicit_pt_per_px():
+    """build_layout accepts explicit pt_per_px keyword."""
+    nodes, groups, edges, rb, cum_h, cum_v = build_layout(
+        copy.deepcopy(_SIMPLE_TREE), x=100, y=180, width=1720, height=800,
+        pt_per_px=0.375)
+    assert rb[2] > 0 and rb[3] > 0
+
+
+def test_render_architecture_explicit_pt_per_px():
+    """render_architecture accepts explicit pt_per_px keyword."""
+    result = render_architecture(copy.deepcopy(_SIMPLE_TREE),
+                                 x=100, y=180, width=1720, height=800,
+                                 pt_per_px=0.375)
+    assert "elements" in result
+    assert result["bbox"]["width"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Box with explicit height: pt_per_px should NOT affect it
+# ---------------------------------------------------------------------------
+
+def test_explicit_height_ignores_pt_per_px():
+    """When box has explicit height, pt_per_px should not change it."""
+    node = {"id": "n", "box": {"title": "Fixed", "width": 240, "height": 100}}
+    h_05 = _get_box_height(node, pt_per_px=0.5)
+    h_0375 = _get_box_height(node, pt_per_px=0.375)
+    assert h_05 == 100
+    assert h_0375 == 100

--- a/tests/test_templates_resolution.py
+++ b/tests/test_templates_resolution.py
@@ -178,3 +178,9 @@ def test_analyze_and_store_template() -> None:
     assert isinstance(result["fonts"], dict)
     assert result["layout_count"] > 0
     assert len(result["layouts"]) == result["layout_count"]
+    # slide_size must be present (regression: was previously omitted)
+    assert "slide_size" in result
+    assert "width" in result["slide_size"]
+    assert "height" in result["slide_size"]
+    assert result["slide_size"]["width"] > 0
+    assert result["slide_size"]["height"] > 0


### PR DESCRIPTION
Fixes #285

## Summary

Calibrates the architecture-diagram box/label auto-sizing to true pt metrics with
CJK-aware character widths, and introduces `ptPerPx` into `deck.json`'s `slideSize`
as the declared pt↔px unit relationship. Also fixes a #208 gap found during impact
analysis (the remote template-analysis cache drops `slide_size`) and removes a dead
code path in `api.init`.

Follow-up to #208 / PR #283 (first item in its out-of-scope table).

## The bug

`placement.py`'s box auto-height used px constants (`lines * 24 + 40`, `bw // 10`)
that are the pt truth (11pt font, 13.2pt line height, 20pt padding, ~5pt average
halfwidth char) converted at the **16:9 rate only** (1px = 0.5pt), and assumed
**halfwidth characters only** (fullwidth chars are 11pt ≈ 2.2× wider).

Measured estimate vs. required height (box width 240px, title + description —
old estimate was a flat 88px for all cases):

| Case | Old shortfall | New estimate | Required |
|---|---|---|---|
| 16:9 halfwidth + description | -5% | 93px | 93px |
| 16:9 Japanese + description | **-26%** | 120px | 119px |
| 4:3 Japanese + description | **-51%** | 194px | 181px (+7% safe side) |

Note the CJK defect affects **16:9 too** — this changes existing 16:9 arch layouts
slightly (boxes grow ~5-10% for halfwidth, more for CJK). Intentional: the old
values under-estimated everywhere.

## Design

### `pt_per_px` explicit argument (default 0.5)

`render_architecture` → `build_layout` → `_layout_scale` gain a keyword argument;
estimates are pt-true values converted by the rate. The default `0.5` is the exact
16:9 value (`12192000 / 1920 / 12700`), so existing callers are unchanged. The
`layout/` package keeps its "template-agnostic pure px space" property — it learns
one scalar, not EMU or template concepts.

Rejected: passing `slide_width_emu` (EMU is infra vocabulary; layout imports only
stdlib today), reusing the converter's `conversion_scale` ContextVar (dependency
DAG inversion + implicit state breaks pure-function tests), deriving from canvas
height (swaps the 16:9 burn-in for a 7.5in burn-in — wrong for 16:10), scaling the
font instead (arch text would diverge from the engine-wide "pt is physical"
convention), and adding text-overflow checks to lint (budgeting belongs to the
knowledge layer; accurate verification already exists at generate/preview via real
LibreOffice rendering).

### `ptPerPx` in `slideSize` — the deck's unit declaration

Slide JSON mixes px (layout, width normalized to 1920) and pt (fonts, physical).
The exchange rate `ptPerPx = physical width in pt / 1920` cannot be derived from
the canvas size (4:3 and 16:10 presets are both 0.375 — it depends on physical
width, not aspect ratio). `slideSize` is the spec's coordinate-system declaration
(like an SVG `viewBox`); the unit relationship is part of it:

```json
"slideSize": {"width": 1920, "height": 1440, "ptPerPx": 0.375}
```

Information flow (transcription pattern — values originate from tools):

```
analyze_template reports slide_size {width, height, ptPerPx}
  → agent transcribes verbatim into deck.json
  → consumers: text budgeting (width guide), arch_diagram(pt_per_px=...)
  → generate validates declaration vs. template (existing key-based check,
    unaffected by the new key)
(exception: pptx import writes the same shape directly)
```

Omitting the parameter degrades safely to current behaviour (16:9 calibration).

### Knowledge layer had the same burn-in

The width guide in `slide-json-spec.md` taught `fullwidth = pt × 2 × char count` —
the «× 2» is the 16:9 rate. Agents budgeted text 33% too optimistically on 4:3 for
every textbox. Now parameterized: `px = fontSize ÷ ptPerPx × char count` (16:9:
ptPerPx 0.5 → ×2), same derivation-plus-example pattern as #208.

## Also fixed

1. **#208 gap — remote analysis cache drops `slide_size`**: the DDB `analysisJson`
   stored only `{theme_colors, layouts}`, so cache hits on `analyze_template`
   returned no `slide_size`, silently defeating #208's transcription flow for
   uploaded templates. The cache now stores the full analyzer output, with an
   on-the-fly re-analysis fallback for stale cached entries (2 regression tests).
2. **Dead code — `api.init(template=...)`**: zero production callers since PR #152
   removed the tool-side passthrough (the MCP tool takes no template; remote init
   documents "Template is NOT set at init time"; the CLI has no `--template` flag).
   PR #283 unknowingly extended this branch and added tests for it. Removed the
   branch, its tests, the misleading `init_presentation` docstring, and two stale
   doc references. `slideSize` writers reduce to: agent transcription + pptx import.

## Testing

- `make all` — **818 passed, 6 skipped**, lint clean
- New `tests/test_placement_calibration.py` (14 tests): 16:9 pins (new values), CJK
  line counts, 4:3 scaling, default-argument compatibility, explicit-height bypass
- `test_layout_render.py` / `test_layout_properties.py` pass unchanged (they assert
  structure/fit, not exact box heights)
- Updated: `test_analyzer.py`, `test_canvas_derivation.py`, `test_canvas_slidesize.py`,
  `test_converter_elements.py`, `test_mcp_template_tools.py` (+2 cache regression
  tests), `test_templates_resolution.py`
- Verified live (SdpmRuntime + SdpmWebUi deployed): 4:3 deck with a Japanese
  architecture diagram — labels and captions fit without overflow

## Out of scope

- `layout/graph.py` unreachable code (zero call sites, own 1920×1080 hardcode) — #286
- Edge labels (fontSize 9 annotations) and pure-design px constants (group padding, gaps)
- Style gallery fixed 16:9 canvas (accepted in #208)
