### PR TITLE
fix: accept nested styled-text notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ### Fixed
 
+- **Nested styled-text notation no longer leaks raw tags onto slides** —
+  agents sometimes emit `{{bold:{{#FF0000:X}}}}` instead of the canonical
+  `{{bold,#FF0000:X}}`; the parser could not see through nesting and rendered
+  the inner tag as literal text. A flatten pre-pass now normalizes nesting
+  (any depth, partial nesting included) to the comma form, with inner
+  attributes taking priority. Non-nested input is untouched. (#123)
 - **Builtin template download works from the Web UI** — downloading blank-dark /
   blank-light did nothing: the download used a `fetch()`+blob path that requires
   CORS, and the builtin resource bucket has no CORS configuration (user templates

--- a/sdpm/references/workflows/slide-json-spec.md
+++ b/sdpm/references/workflows/slide-json-spec.md
@@ -681,6 +681,11 @@ Native PPTX chart (editable in PowerPoint).
 {{link:https://example.com:Link text}}
 ```
 
+> NOTE: Combine styles with commas (`{{bold,#FF0000:x}}`), not by nesting.
+> Nested tags (`{{bold:{{#FF0000:x}}}}`) are tolerated by the engine — they
+> are normalized to the comma form with inner attributes taking priority —
+> but the comma form is the canonical syntax. Nesting `link` is not supported.
+
 ## Placeholder (for user editing)
 
 ```json

--- a/sdpm/sdpm/utils/text.py
+++ b/sdpm/sdpm/utils/text.py
@@ -91,23 +91,28 @@ def _flatten_nested_styles(text):
     """
     if '{{' not in text:
         return text
-    out = []
-    i = 0
-    while i < len(text):
-        if text.startswith('{{', i):
-            scanned = _scan_styled_tag(text, i)
-            if scanned is not None:
-                end, attrs, parts, has_nest = scanned
-                out.append(_emit_flat_tag(attrs, parts) if has_nest else text[i:end])
-                i = end
-                continue
-        out.append(text[i])
-        i += 1
-    return ''.join(out)
+    try:
+        out = []
+        i = 0
+        while i < len(text):
+            if text.startswith('{{', i):
+                scanned = _scan_styled_tag(text, i)
+                if scanned is not None:
+                    end, attrs, parts, has_nest = scanned
+                    out.append(_emit_flat_tag(attrs, parts) if has_nest else text[i:end])
+                    i = end
+                    continue
+            out.append(text[i])
+            i += 1
+        return ''.join(out)
+    except RecursionError:
+        # Pathologically deep nesting (adversarial input): fall back to the
+        # original text, consistent with the unbalanced-input guarantee.
+        return text
 
 
 def _is_link_attrs(attrs):
-    return 'link' in (a.strip() for a in attrs.split(','))
+    return 'link' in [a.strip() for a in attrs.split(',')]
 
 
 def _scan_styled_tag(text, start):

--- a/sdpm/sdpm/utils/text.py
+++ b/sdpm/sdpm/utils/text.py
@@ -66,6 +66,120 @@ def normalize_spacing(text):
     return ''.join(result)
 
 
+def _flatten_nested_styles(text):
+    """Flatten nested {{attrs:...}} notation into comma-separated attrs form.
+
+    Agents sometimes emit nested styled text (issue #123):
+
+        {{bold:{{#FF0000:X}}}}      ->  {{bold,#FF0000:X}}
+        {{bold:a{{#FF0000:b}}c}}    ->  {{bold:a}}{{bold,#FF0000:b}}{{bold:c}}
+
+    The regex-based parser cannot handle nesting (``[^}]`` excludes the inner
+    ``}}``), which leaked raw tag text onto slides. This pre-pass rewrites
+    nested tags into the canonical comma-separated form. Merge order is
+    ``outer,inner`` — the parser applies attrs last-wins, so inner attributes
+    take priority naturally (boolean attrs like bold cannot be negated).
+
+    Guarantees:
+    - Non-nested input is returned byte-identical (tags copied verbatim).
+    - Tag starts trigger only on a ``{{`` two-char sequence; bare ``{`` / ``}``
+      (e.g. in highlight_code output) pass through untouched.
+    - link tags are opaque: never flattened, never merged.
+    - Unbalanced input falls back to the original text, so the parser behaves
+      exactly as it did before this pre-pass existed.
+    - Idempotent: flattened output contains no nested tags.
+    """
+    if '{{' not in text:
+        return text
+    out = []
+    i = 0
+    while i < len(text):
+        if text.startswith('{{', i):
+            scanned = _scan_styled_tag(text, i)
+            if scanned is not None:
+                end, attrs, parts, has_nest = scanned
+                out.append(_emit_flat_tag(attrs, parts) if has_nest else text[i:end])
+                i = end
+                continue
+        out.append(text[i])
+        i += 1
+    return ''.join(out)
+
+
+def _is_link_attrs(attrs):
+    return 'link' in (a.strip() for a in attrs.split(','))
+
+
+def _scan_styled_tag(text, start):
+    """Scan one ``{{attrs:body}}`` tag at ``start`` (must point at ``{{``).
+
+    Returns ``(end_index, attrs, parts, has_nest)`` where parts is a list of
+    ``('plain', str)`` / ``('tag', attrs, parts, has_nest)`` items, or None
+    if no well-formed tag starts here.
+    """
+    m = re.match(r'\{\{([^:}]+):', text[start:])
+    if not m:
+        return None
+    attrs = m.group(1)
+    j = start + m.end()
+    if _is_link_attrs(attrs):
+        # Link content cannot contain '}' (mirrors the link regex): opaque.
+        close = text.find('}}', j)
+        if close == -1:
+            return None
+        return (close + 2, attrs, [('plain', text[j:close])], False)
+    parts = []
+    buf = []
+    has_nest = False
+    while j < len(text):
+        if text.startswith('\\}', j):
+            buf.append('\\}')
+            j += 2
+        elif text.startswith('}}', j):
+            if buf:
+                parts.append(('plain', ''.join(buf)))
+            return (j + 2, attrs, parts, has_nest)
+        elif text[j] == '}':
+            return None  # unescaped single '}' — malformed, fall back
+        elif text.startswith('{{', j):
+            inner = _scan_styled_tag(text, j)
+            if inner is None:
+                buf.append(text[j])
+                j += 1
+                continue
+            in_end, in_attrs, in_parts, in_nest = inner
+            if _is_link_attrs(in_attrs):
+                buf.append(text[j:in_end])  # nested links stay verbatim
+            else:
+                if buf:
+                    parts.append(('plain', ''.join(buf)))
+                    buf = []
+                parts.append(('tag', in_attrs, in_parts, in_nest))
+                has_nest = True
+            j = in_end
+        else:
+            buf.append(text[j])
+            j += 1
+    return None  # ran out of text before '}}'
+
+
+def _emit_flat_tag(attrs, parts):
+    """Emit flattened tags for a scanned nested tag."""
+    out = []
+    for part in parts:
+        if part[0] == 'plain':
+            # Split on newlines so each line carries a complete tag (mirrors
+            # _expand_styled_newlines; avoids emitting an empty {{attrs:}}
+            # which the parser would leak as literal text).
+            lines = part[1].split('\n')
+            tagged = [f'{{{{{attrs}:{line}}}}}' if line else '' for line in lines]
+            out.append('\n'.join(tagged))
+        else:
+            _, in_attrs, in_parts, _ = part
+            out.append(_emit_flat_tag(attrs + ',' + in_attrs, in_parts))
+    return ''.join(out)
+
+
 def parse_styled_text(text, auto_spacing=True):
     """Parse {{attrs:text}} syntax into styled segments.
 
@@ -81,6 +195,7 @@ def parse_styled_text(text, auto_spacing=True):
             (typography for AI-authored decks). Pass False to preserve the
             source text verbatim (e.g. decks imported from existing PPTX).
     """
+    text = _flatten_nested_styles(text)
     link_pattern = r'\{\{(?:(\d+pt),)?link:([^}]+)\}\}'
     segments = []
     last_end = 0
@@ -209,6 +324,10 @@ def _parse_non_link_styles(text, auto_spacing=True):
 
 def _expand_styled_newlines(text):
     """Expand \\n inside styled tags so each line gets its own complete tag."""
+    # Flatten nesting first: builders call this before splitting on newlines,
+    # and the expand regex below (``[^}]``) cannot see through nested tags —
+    # without this, split("\n") would cut a nested tag in half (issue #123).
+    text = _flatten_nested_styles(text)
     def expand_match(m):
         attrs = m.group(1)
         content = m.group(2)

--- a/tests/test_styled_text_nesting.py
+++ b/tests/test_styled_text_nesting.py
@@ -1,0 +1,153 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+"""Nested styled-text notation support (issue #123).
+
+Agents sometimes nest styled-text tags ({{bold:{{#FF0000:X}}}}) instead of
+using the canonical comma form ({{bold,#FF0000:X}}). The regex parser cannot
+see through nesting, which leaked raw tag text onto slides. A flatten
+pre-pass (_flatten_nested_styles) rewrites nesting into the canonical form.
+"""
+
+from sdpm.utils.text import (
+    _expand_styled_newlines,
+    _flatten_nested_styles,
+    parse_styled_text,
+)
+
+
+def _all_text(segments):
+    return "".join(s["text"] for s in segments)
+
+
+class TestFlattenNestedStyles:
+    def test_full_nest(self):
+        assert _flatten_nested_styles("{{bold:{{#FF0000:重要}}}}") == "{{bold,#FF0000:重要}}"
+
+    def test_partial_nest_distributes_outer_attrs(self):
+        assert (
+            _flatten_nested_styles("{{bold:a{{#FF0000:b}}c}}")
+            == "{{bold:a}}{{bold,#FF0000:b}}{{bold:c}}"
+        )
+
+    def test_depth_three(self):
+        assert (
+            _flatten_nested_styles("{{bold:{{italic:{{#FF0000:x}}}}}}")
+            == "{{bold,italic,#FF0000:x}}"
+        )
+
+    def test_value_attrs_nest(self):
+        assert (
+            _flatten_nested_styles("{{baseline=-25000:{{#FF0000:x}}}}")
+            == "{{baseline=-25000,#FF0000:x}}"
+        )
+
+    def test_non_nested_input_is_byte_identical(self):
+        cases = [
+            "plain text",
+            "{{bold,#FF0000:x}}",
+            "{{bold:a\\}b}}",  # escaped brace
+            "a {{12pt:x}} b {{font=Menlo:code}}",
+            "{{link:https://example.com:text}}",
+            "{{14pt,link:https://example.com:text}}",
+            "{{bold:}}",  # empty body (parser treats as literal today)
+            "{{bold:通常}}\n{{italic:斜体}}",
+        ]
+        for s in cases:
+            assert _flatten_nested_styles(s) == s
+
+    def test_bare_braces_pass_through(self):
+        # highlight_code emits bare { } between tags; a single-char brace
+        # must never be mistaken for a tag boundary.
+        cases = [
+            "{{#d6deeb:dict}}{",
+            "{{#d6deeb:foo}}{{{#c792ea:bar}}",  # bare { adjacent to tag start
+            "{ }",
+            "{{#c792ea:f}}({{#d6deeb:x}})",
+        ]
+        for s in cases:
+            assert _flatten_nested_styles(s) == s
+
+    def test_unbalanced_falls_back_to_original(self):
+        cases = [
+            "{{bold:{{#FF0000:x}}",  # outer never closed
+            "{{bold:a}b}}",  # unescaped single }
+            "{{bold:unclosed",
+        ]
+        for s in cases:
+            assert _flatten_nested_styles(s) == s
+
+    def test_idempotent(self):
+        once = _flatten_nested_styles("{{bold:a{{#FF0000:b}}c}}")
+        assert _flatten_nested_styles(once) == once
+
+    def test_nested_link_stays_verbatim(self):
+        # Nested links are out of scope: kept as body text, not merged.
+        s = "{{bold:{{link:https://example.com:t}}}}"
+        assert _flatten_nested_styles(s) == s
+
+    def test_newline_in_plain_part_emits_complete_tags_per_line(self):
+        # Trailing newline must not produce an empty {{attrs:}} (would leak).
+        assert (
+            _flatten_nested_styles("{{bold:a\n{{#FF0000:b}}}}")
+            == "{{bold:a}}\n{{bold,#FF0000:b}}"
+        )
+
+
+class TestParseStyledTextNested:
+    def test_full_nest_segments(self):
+        segments = parse_styled_text("{{bold:{{#FF0000:重要}}}}")
+        assert segments == [{"text": "重要", "bold": True, "color": "#FF0000"}]
+
+    def test_partial_nest_segments(self):
+        segments = parse_styled_text("{{bold:通常と{{#FF0000:赤}}の混在}}")
+        assert [s["text"] for s in segments] == ["通常と", "赤", "の混在"]
+        assert all(s.get("bold") for s in segments)
+        assert [s.get("color") for s in segments] == [None, "#FF0000", None]
+
+    def test_inner_color_wins(self):
+        segments = parse_styled_text("{{#00FF00:{{#FF0000:x}}}}")
+        assert segments == [{"text": "x", "color": "#FF0000"}]
+
+    def test_no_tag_leakage(self):
+        for s in [
+            "{{bold:{{#FF0000:重要}}}}",
+            "{{bold:通常と{{#FF0000:赤}}の混在}}",
+            "{{bold:{{italic:{{#FF0000:x}}}}}}",
+        ]:
+            assert "{{" not in _all_text(parse_styled_text(s))
+
+    def test_auto_spacing_false_preserves_text(self):
+        segments = parse_styled_text("{{bold:漢字{{#FF0000:abc}}}}", auto_spacing=False)
+        assert _all_text(segments) == "漢字abc"  # no space inserted
+
+    def test_auto_spacing_true_inserts_boundary_space(self):
+        segments = parse_styled_text("{{bold:漢字{{#FF0000:abc}}}}")
+        assert _all_text(segments) == "漢字 abc"
+
+    def test_unbalanced_does_not_crash(self):
+        # Fallback: same (broken) output as before the flatten pre-pass.
+        segments = parse_styled_text("{{bold:{{#FF0000:x}}")
+        assert isinstance(segments, list)
+
+    def test_link_before_and_after_nest(self):
+        segments = parse_styled_text(
+            "{{link:https://example.com:site}} {{bold:{{#FF0000:x}}}}"
+        )
+        assert segments[0] == {"text": "site", "link": "https://example.com"}
+        assert {"text": "x", "bold": True, "color": "#FF0000"} in segments
+
+
+class TestExpandStyledNewlinesNested:
+    def test_nest_with_newline_expands_per_line(self):
+        # Builders split on \n after expand; without flatten-first the split
+        # would cut the nested tag in half.
+        assert (
+            _expand_styled_newlines("{{bold:a\n{{#FF0000:b}}}}")
+            == "{{bold:a}}\n{{bold,#FF0000:b}}"
+        )
+
+    def test_plain_expand_unchanged(self):
+        assert (
+            _expand_styled_newlines("{{bold:line1\nline2}}")
+            == "{{bold:line1}}\n{{bold:line2}}"
+        )

--- a/tests/test_styled_text_nesting.py
+++ b/tests/test_styled_text_nesting.py
@@ -63,9 +63,14 @@ class TestFlattenNestedStyles:
             "{{#d6deeb:foo}}{{{#c792ea:bar}}",  # bare { adjacent to tag start
             "{ }",
             "{{#c792ea:f}}({{#d6deeb:x}})",
+            "{{#d6deeb:func}}({{#c792ea:{}}})",  # bare brace inside tag body
         ]
         for s in cases:
             assert _flatten_nested_styles(s) == s
+
+    def test_pathological_depth_falls_back_without_crash(self):
+        deep = "{{bold:" * 2000 + "x" + "}}" * 2000
+        assert _flatten_nested_styles(deep) == deep  # RecursionError guard
 
     def test_unbalanced_falls_back_to_original(self):
         cases = [


### PR DESCRIPTION
## Summary

Agents sometimes emit nested styled text (`{{bold:{{#FF0000:X}}}}`) instead of the canonical comma form (`{{bold,#FF0000:X}}`). The regex-based parser cannot see through nesting, which leaked raw tag text onto slides.

This adds a flatten pre-pass (`_flatten_nested_styles`) that normalizes nested tags into the canonical comma-separated form, applied at the entry of both `parse_styled_text` and `_expand_styled_newlines` (builders call expand → split("\n") → parse, so both entries need it).

- Any depth, partial nesting included; inner attributes take priority (parser applies attrs last-wins)
- Non-nested input passes through byte-identical (tags copied verbatim)
- Bare `{` / `}` (highlight_code output) never mistaken for tag boundaries — only a `{{` two-char sequence triggers scanning
- `link` tags are opaque: never flattened or merged
- Unbalanced / pathologically deep input falls back to the original text

Also documents the canonical form in `slide-json-spec.md` (nesting is tolerated, comma form is canonical).

## Testing

- 21 new tests (`tests/test_styled_text_nesting.py`): flatten unit tests, parse integration, expand interplay, idempotence, byte-identical guarantee, bare braces, RecursionError guard
- Full suite: 872 passed, ruff clean
- ASH local scan: code scanners pass (remaining findings are pre-existing npm transitive-dep advisories, unrelated)

Closes #123