### PR TITLE
fix: revert pydantic-core 2.47.0 (breaks container image resolution) + ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,11 @@ updates:
       # when aws-opentelemetry-distro is bumped, then run `make lock`.
       - dependency-name: cachetools
       - dependency-name: protobuf
+      # pydantic-core is hard-pinned by pydantic (mcp -> pydantic==X pins
+      # pydantic-core==Y exactly). Bumping it alone makes the container
+      # image unresolvable (PR #271 broke main; caught by container-deps).
+      # It moves automatically when pydantic itself is bumped via `make lock`.
+      - dependency-name: pydantic-core
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/servers/remote/constraints.txt
+++ b/servers/remote/constraints.txt
@@ -425,7 +425,7 @@ pydantic==2.13.4
     # via
     #   mcp
     #   pydantic-settings
-pydantic-core==2.47.0
+pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.2
     # via mcp


### PR DESCRIPTION
PR #271 broke `main`: `mcp==1.29.0` -> `pydantic==2.13.4` hard-pins `pydantic-core==2.46.4`, so bumping pydantic-core alone in `constraints.txt` makes the remote server image unresolvable. The `container-deps` check caught it (on the unrelated #272 run) but is not a required check, so the merge went through.

- Revert the constraints change (2.47.0 -> 2.46.4)
- Add `pydantic-core` to the /servers/remote dependabot `ignore` — same known pattern as cachetools/protobuf (transitive pins in the generated constraints.txt must not be bumped directly; it moves when pydantic itself is bumped via `make lock`)

Consider making `container-deps` a required check — it exists precisely to catch this class of failure before deploy time.