### PR TITLE
fix: resync web-ui package-lock to npm-10 format (deploy CodeBuild compatibility)

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -10015,6 +10015,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13274,6 +13275,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {


### PR DESCRIPTION
The four dependabot merges (#272 / #277 / #278 / #280) regenerated the web-ui lock in npm-11 format, which fails `npm ci` on the deploy CodeBuild (npm 10) — same known pattern as #250 / #254 (documented in steering).

Regenerated with `npx npm@10.8.2 install --package-lock-only`; `npm@10.8.2 ci --dry-run` exits 0. Lockfile-only change, nothing else run in between per the steering rule.