### PR TITLE
chore: widen infra typescript pin to >=6, bump @types/node to 26 (isolated)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,14 +36,15 @@ updates:
     cooldown:
       default-days: 7
     # Known-blocked majors (same policy as /web-ui above):
-    # - typescript >=7: TS 7 (native, Go-based) fails `tsc --noEmit` for the
-    #   CDK app — node globals/type resolution breaks repo-wide (TS2591
-    #   "Cannot find name 'process'/'fs'/'path'", TS2304 __dirname, even with
-    #   @types/node 26). Re-evaluate when the CDK toolchain and @types/node
-    #   support TS 7 (see PR #258 CI failure for the full log).
+    # - typescript >=6: TS 6/7 fail `tsc --noEmit` for the CDK app — node
+    #   globals/type resolution breaks repo-wide (TS2591 "Cannot find name
+    #   'process'/'fs'/'path'", TS2304 __dirname). Isolated locally: fails
+    #   with both @types/node 22 and 26, while TS 5.9 + @types/node 26 is
+    #   clean — so the blocker is the compiler, not the types. Re-evaluate
+    #   when the CDK toolchain supports TS >=6 (PR #258 / #298 CI logs).
     ignore:
       - dependency-name: "typescript"
-        versions: [">=7"]
+        versions: [">=6"]
     groups:
       infra-deps:
         patterns: ["*"]

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -16,7 +16,7 @@
         "infra": "bin/infra.js"
       },
       "devDependencies": {
-        "@types/node": "^22.20.1",
+        "@types/node": "^26.1.2",
         "aws-cdk": "^2.1133.0",
         "ts-node": "^10.9.0",
         "typescript": "~5.9.3"
@@ -140,13 +140,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/acorn": {
@@ -495,9 +495,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,16 +1,18 @@
 {
   "name": "sdpm-infra",
   "version": "0.1.0",
-  "bin": { "infra": "bin/infra.js" },
+  "bin": {
+    "infra": "bin/infra.js"
+  },
   "scripts": {
     "build": "tsc",
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@types/node": "^26.1.2",
     "aws-cdk": "^2.1133.0",
-    "typescript": "~5.9.3",
     "ts-node": "^10.9.0",
-    "@types/node": "^22.20.1"
+    "typescript": "~5.9.3"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.262.1",


### PR DESCRIPTION
Follow-up to #293. The re-delivered infra-majors PR (#298, TS 6.0.3 + @types/node 26) failed CI with the same repo-wide node type-resolution errors as TS 7 (#258).

Isolated locally on the #298 branch:

| Combination | tsc --noEmit |
|---|---|
| TS 6.0.3 + @types/node 26 | ❌ TS2591/TS2304 everywhere |
| TS 6.0.3 + @types/node 22 | ❌ same |
| TS 5.9.3 + @types/node 26 | ✅ clean |

The blocker is the TS 6/7 compiler, not the types.

- Widen the /infra dependabot ignore from `typescript >=7` to `>=6` (evidence + re-evaluation trigger in the comment)
- Manually bump @types/node 22 → 26 (the innocent half; dependabot re-delivery would wait out the 7-day cooldown). Lock regenerated with npm@10.8.2, `ci --dry-run` exit 0

Closes #298 rationale: upstream compiler blocker; @types/node half is delivered here.