### PR TITLE
chore(dependabot): ignore mcp >=2 until FastMCP migration (#301)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,12 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    ignore:
+      # mcp 2.0 removes mcp.server.fastmcp (FastMCP) — the server fails at
+      # import. Requires migration to mcp.server.mcpserver.MCPServer,
+      # tracked in #301. Remove this once migrated.
+      - dependency-name: mcp
+        versions: [">=2"]
   - package-ecosystem: pip
     directory: /servers/remote
     schedule:
@@ -84,6 +90,10 @@ updates:
       # image unresolvable (PR #271 broke main; caught by container-deps).
       # It moves automatically when pydantic itself is bumped via `make lock`.
       - dependency-name: pydantic-core
+      # mcp 2.0 removes mcp.server.fastmcp (FastMCP) — see /servers/local
+      # entry above. Migration tracked in #301.
+      - dependency-name: mcp
+        versions: [">=2"]
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
mcp 2.0.0 removes `mcp.server.fastmcp` — both servers fail at import time (verified locally with the 2.0 wheel; see #295 / #297 close comments). Migration to `mcp.server.mcpserver.MCPServer` is tracked in #301.

This stops dependabot from re-delivering the 2.0 bump every week until the migration lands. Remove both ignores in #301.