### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-05
+
 ### Fixed
 
 - **Nested styled-text notation no longer leaks raw tags onto slides** —
@@ -304,7 +306,8 @@ decks and cloud data keep working. See the
 - Initial release: spec-driven slide generation (Engine json ↔ pptx, CLI,
   local/remote MCP servers, Strands Agent, React Web UI, CDK stacks)
 
-[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/aws-samples/sample-spec-driven-presentation-maker/compare/v0.5.2...v0.5.3

--- a/sdpm/sdpm/__init__.py
+++ b/sdpm/sdpm/__init__.py
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT-0
 """sdpm - Generate PowerPoint from JSON using template."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
Release v0.7.1 — 10 user-facing fixes accumulated since v0.7.0 (aspect-ratio-agnostic canvas fixes, arch box calibration, builtin template download, grid tool %/repeat() + actionable errors, live-preview even-odd icon fix, nested styled-text, and more — see CHANGELOG).

- `__version__` 0.7.0 → 0.7.1
- CHANGELOG: Unreleased → [0.7.1] - 2026-08-05, compare links updated

Tag `v0.7.1` will be pushed after merge.