### PR TITLE
feat(kiro): generate a dedicated composer agent in legacy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ### Added
 
+- **`make install-kiro` generates a dedicated composer agent again** —
+  `<KIRO_HOME>/agents/sdpm-composer.json` gives parallel compose workers the
+  sdpm MCP server only, with pre-approved tools and a generous startup
+  timeout. Without it, workers fall back to a general-purpose agent that
+  cold-starts every MCP server in the profile per worker; on MCP-heavy
+  profiles this made some parallel composers miss the sdpm server
+  nondeterministically (observed with 30+ registered servers). The generated
+  config is a thin pointer — its prompt is a `file://` reference into
+  `personas/composer.md`, never inline behavior — and it is lifecycle-managed
+  by the same ownership audit as the rest of the wiring (own/stale are
+  regenerated, foreign/unknown are never touched; power mode still removes
+  it). v0.5.3 dropped generation because the old installer could not manage
+  the file safely across checkouts; the ownership audit removed that reason.
+
 - **Mode entry points are back, as thin dispatchers** — `skills/sdpm-vibe`,
   `skills/sdpm-spec` and `skills/sdpm-style` let users pick a mode explicitly
   (`/sdpm-vibe` and friends in clients that expose skills as slash commands).

--- a/clients/kiro/install.py
+++ b/clients/kiro/install.py
@@ -10,13 +10,14 @@ Kiro can consume sdpm two ways, and they must not both be active:
   Kiro IDE; this script never installs one. It only audits that no legacy
   wiring is left behind to shadow it.
 * **legacy** — Kiro v2 has no plugin mechanism, so the skills are symlinked
-  into ``<KIRO_HOME>/skills/`` and the MCP server is registered in
-  ``<KIRO_HOME>/settings/mcp.json``.
+  into ``<KIRO_HOME>/skills/``, a dedicated composer agent is generated at
+  ``<KIRO_HOME>/agents/sdpm-composer.json``, and the MCP server is registered
+  in ``<KIRO_HOME>/settings/mcp.json``.
 
 Everything this script writes is *owned*: it records nothing outside
 ``KIRO_HOME`` and it refuses to touch wiring that belongs to a different
 checkout. If another checkout owns the ``sdpm`` MCP registration, a skill
-symlink, or the legacy composer agent, the run fails with a report instead of
+symlink, or the composer agent, the run fails with a report instead of
 overwriting it — pass ``--replace-existing`` to take it over deliberately.
 
 Set ``KIRO_HOME`` (or pass ``--kiro-home``) to target a profile other than
@@ -25,8 +26,10 @@ from colliding, because Powers are global-scope only.
 
 The repository stays the single source of truth: mode behavior lives in
 ``personas/*.md`` and is served by the MCP server via
-``start_presentation(mode=...)``, and composer sub-agents are self-spawned by
-the orchestrating agent. ``git pull`` updates take effect without re-running
+``start_presentation(mode=...)``. The generated composer agent carries no
+behavior either — its prompt is a ``file://`` pointer into
+``personas/composer.md`` (self-spawn remains the documented fallback for
+environments without it). ``git pull`` updates take effect without re-running
 this script. Re-run only if you move the checkout.
 """
 
@@ -178,10 +181,20 @@ def audit_skill_link(link: Path, repo_root: Path = REPO_ROOT) -> Finding:
 
 
 def _expected_composer_config(checkout: Path) -> dict:
-    """The exact object the old installer (v0.5.0–v0.5.2) generated.
+    """The composer agent config this installer generates for ``checkout``.
 
-    This is the deleted ``sdpm-composer.json.tmpl`` with ``{{CHECKOUT}}``
-    resolved — kept here verbatim so cleanup can require FULL equality.
+    Same object the v0.5.0–v0.5.2 installers wrote (the deleted
+    ``sdpm-composer.json.tmpl`` with ``{{CHECKOUT}}`` resolved), kept verbatim
+    so ownership classification can require FULL equality across versions.
+
+    Why a dedicated agent: compose is a fan-out workload (up to 10 parallel
+    workers). The persona's self-spawn fallback works, but a general-purpose
+    worker inherits every MCP server in the profile — each worker cold-starts
+    all of them, and under parallel load the sdpm server can miss its init
+    timeout on some workers (observed in practice). This agent gives workers
+    the sdpm server only, with a generous timeout and pre-approved tools, and
+    carries no behavior text: the prompt is a ``file://`` pointer into
+    ``personas/composer.md``.
     """
     return {
         "name": "sdpm-composer",
@@ -234,12 +247,12 @@ def generated_composer_checkout(data: object) -> Path | None:
 
 
 def audit_composer(agents_dest: Path, repo_root: Path = REPO_ROOT) -> Finding:
-    """Classify the legacy generated ``sdpm-composer.json``.
+    """Classify the generated ``sdpm-composer.json``.
 
-    Composer sub-agents are self-spawned since v0.5.3, so this file is never
-    wanted. It is only removed when THIS checkout generated it: a config
-    belonging to another checkout is that checkout's business, even though it
-    matches a form we recognise.
+    Legacy mode (re)generates this file; power mode removes it. Either way the
+    decision is ownership-gated: a config belonging to another checkout is that
+    checkout's business, even though it matches a form we recognise, and a
+    user-edited one is never touched.
     """
     legacy = agents_dest / "sdpm-composer.json"
     if not legacy.exists():
@@ -323,18 +336,46 @@ def link_skills(kiro_home: Path, findings: list[Finding], repo_root: Path = REPO
 
 
 def remove_owned_composer_agent(findings: list[Finding]) -> None:
-    """Delete the legacy composer agent config, but only if we generated it."""
+    """Delete the composer agent config, but only if we generated it.
+
+    Used in power mode: the Power supersedes all legacy v2 wiring, including
+    the composer agent.
+    """
     for f in findings:
         if f.kind != "composer":
             continue
         if f.status in (OWN, STALE):
             f.target.unlink()
-            info(f"{f.target} (removed legacy composer agent — composers are now self-spawned)")
+            info(f"{f.target} (removed composer agent — the Power supersedes it)")
         elif f.status == UNKNOWN:
             warn(
                 f"{f.target} {f.detail} — left in place (it may be user-edited). "
-                "It is no longer needed for sdpm compose; remove it manually when convenient."
+                "Remove it manually when convenient."
             )
+
+
+def write_composer_agent(findings: list[Finding], repo_root: Path = REPO_ROOT) -> None:
+    """(Re)generate ``sdpm-composer.json`` for this checkout (idempotent).
+
+    A registered ``sdpm-composer`` agent is the persona's preferred worker for
+    parallel compose; without it, workers fall back to a general-purpose agent
+    that cold-starts every MCP server in the profile per worker (see
+    ``_expected_composer_config`` for the failure mode this avoids).
+    """
+    for f in findings:
+        if f.kind != "composer":
+            continue
+        if f.status == OWN:
+            info(f"{f.target} (already up to date)")
+            continue
+        if f.status in BLOCKING:
+            continue  # reported by the caller; never overwritten here
+        f.target.parent.mkdir(parents=True, exist_ok=True)
+        f.target.write_text(
+            json.dumps(_expected_composer_config(repo_root), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        info(f"{f.target} ({'regenerated' if f.status == STALE else 'generated'})")
 
 
 def _kiro_env(kiro_home: Path) -> dict[str, str]:
@@ -527,8 +568,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"[1/3] Linking skills into {kiro_home / 'skills'}")
     link_skills(kiro_home, findings, REPO_ROOT)
-    print("[2/3] Cleaning up superseded artifacts")
-    remove_owned_composer_agent(findings)
+    print(f"[2/3] Registering the composer agent in {kiro_home / 'agents'}")
+    write_composer_agent(findings, REPO_ROOT)
     print(f"[3/3] Registering MCP server '{MCP_SERVER_NAME}' in {mcp_finding.target}")
     register_mcp_server(kiro_cli, mcp_finding, opts.agent, kiro_home, REPO_ROOT)
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -38,8 +38,8 @@ directory into your agent's skills directory. The agent calls the engine through
 `scripts/pptx_builder.py` — no MCP server involved.
 
 > **Kiro CLI users:** you probably want [Layer 2](#layer-2-local-mcp-server) instead —
-> `make install-kiro` sets up the local MCP server (mode behavior included); composer
-> sub-agents for parallel slide generation are self-spawned, nothing extra to install.
+> `make install-kiro` sets up the local MCP server (mode behavior included) and a
+> dedicated composer agent for reliable parallel slide generation.
 
 ```bash
 # Install dependencies
@@ -65,8 +65,7 @@ Connect spec-driven-presentation-maker to any MCP-compatible client. No AWS acco
 ### Kiro CLI — one make target (recommended)
 
 Kiro CLI users get everything from a single target — the MCP server carries the mode
-behavior, and composer sub-agents are self-spawned at compose time (no agent files
-to install):
+behavior, and a dedicated `sdpm-composer` agent handles parallel slide generation:
 
 ```bash
 git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
@@ -76,16 +75,17 @@ kiro-cli chat   # then just ask: "make slides about ..."
 ```
 
 This registers the `sdpm` local MCP server in `<KIRO_HOME>/settings/mcp.json` (default
-`~/.kiro`) and symlinks the mode entry points into `<KIRO_HOME>/skills/`, so you can also
-run `/sdpm-vibe`, `/sdpm-spec` or `/sdpm-style` to pick a mode explicitly. The behavior
-itself is still served by the MCP server via `start_presentation(mode=...)`; the entry
-points only name the mode. Prerequisites: [`uv`](https://docs.astral.sh/uv/) on your
+`~/.kiro`), symlinks the mode entry points into `<KIRO_HOME>/skills/` (so you can also
+run `/sdpm-vibe`, `/sdpm-spec` or `/sdpm-style` to pick a mode explicitly), and generates
+a composer agent at `<KIRO_HOME>/agents/sdpm-composer.json` — a thin pointer that gives
+compose workers the sdpm server only, instead of cold-starting every MCP server in your
+profile per worker. The behavior itself is still served by the MCP server via
+`start_presentation(mode=...)`; the entry points and the composer agent only name it.
+Prerequisites: [`uv`](https://docs.astral.sh/uv/) on your
 `PATH`, plus **LibreOffice** and **poppler** for slide previews.
 
 Keep the checkout where it is — the MCP server runs from it. `git pull` is enough to
-update. Re-run `make install-kiro` only if you move the checkout (upgrading from
-v0.5.2 or earlier, re-run it once — it also removes the now-unneeded
-`~/.kiro/agents/sdpm-composer.json` that older installers generated).
+update. Re-run `make install-kiro` only if you move the checkout.
 
 Useful flags — call the script directly, since `make` does not forward arguments:
 

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -38,8 +38,8 @@ symlink します。エージェントは `scripts/pptx_builder.py` 経由でエ
 サーバーは不要です。
 
 > **Kiro CLI ユーザーの方:** [Layer 2](#layer-2-ローカル-mcp-サーバー) をご覧ください —
-> `make install-kiro` でローカル MCP サーバー（モードの振る舞い込み）が設定されます。
-> 並列スライド生成の composer サブエージェントは self-spawn されるため、追加のインストールは不要です。
+> `make install-kiro` でローカル MCP サーバー（モードの振る舞い込み）と、
+> 並列スライド生成用の専用 composer エージェントが設定されます。
 
 ```bash
 # 依存関係のインストール
@@ -65,8 +65,7 @@ spec-driven-presentation-maker を MCP 対応の任意のクライアントに�
 ### Kiro CLI — make ターゲット 1 つ（推奨）
 
 Kiro CLI では make ターゲット 1 つで完了します — モードの振る舞いは MCP サーバーが配信し、
-composer サブエージェントは compose 時にエージェント自身が self-spawn します
-（エージェントファイルのインストールは不要）。
+並列スライド生成は専用の `sdpm-composer` エージェントが担当します。
 
 ```bash
 git clone https://github.com/aws-samples/sample-spec-driven-presentation-maker.git
@@ -77,14 +76,17 @@ kiro-cli chat   # あとは「〜のスライドを作って」と頼むだけ
 
 `sdpm` ローカル MCP サーバーを `<KIRO_HOME>/settings/mcp.json`（既定は `~/.kiro`）に登録し、
 モードの入口を `<KIRO_HOME>/skills/` に symlink します。これにより `/sdpm-vibe` `/sdpm-spec`
-`/sdpm-style` でモードを明示的に選べます。振る舞いの実体は MCP サーバーが
-`start_presentation(mode=...)` で配信し、入口はモード名を指すだけです。
+`/sdpm-style` でモードを明示的に選べます。加えて composer エージェントを
+`<KIRO_HOME>/agents/sdpm-composer.json` に生成します — compose ワーカーに sdpm サーバー
+だけを持たせる薄いポインタで、ワーカーごとにプロファイル内の全 MCP サーバーを
+コールドスタートするのを防ぎます。振る舞いの実体は MCP サーバーが
+`start_presentation(mode=...)` で配信し、入口も composer エージェントもモード名を指すだけです。
 前提: [`uv`](https://docs.astral.sh/uv/) が `PATH` にあること、プレビュー用に
 **LibreOffice** と **poppler**。
 
 MCP サーバーはこの clone 先から起動するため、**ディレクトリはそのまま置いておいてください**。
 更新は `git pull` だけで十分です。
-別パスへ移動した場合のみ `make install-kiro` を再実行してください（v0.5.2 以前からのアップグレード時は一度再実行してください — 旧インストーラーが生成した不要な `~/.kiro/agents/sdpm-composer.json` も削除されます）。
+別パスへ移動した場合のみ `make install-kiro` を再実行してください。
 
 `make` は引数を渡さないので、オプションを使うときはスクリプトを直接呼びます:
 

--- a/tests/test_kiro_installer.py
+++ b/tests/test_kiro_installer.py
@@ -199,8 +199,8 @@ class TestAuditSkillLink:
 
 
 class TestAuditComposer:
-    """The legacy composer agent is superseded by self-spawn, but removing it
-    is still an ownership decision."""
+    """Legacy mode (re)generates the composer agent, power mode removes it —
+    both are ownership decisions driven by this classification."""
 
     def test_absent(self, kiro_home):
         assert kiro_install.audit_composer(kiro_home / "agents").status == ABSENT
@@ -336,12 +336,44 @@ class TestMainLegacyMode:
         assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 0
         assert link.resolve() == (REPO_ROOT / "skills" / "sdpm-vibe").resolve()
 
-    def test_removes_only_our_own_legacy_composer_agent(self, kiro_home, no_kiro_cli):
-        composer = _write_composer(
-            kiro_home / "agents", kiro_install._expected_composer_config(REPO_ROOT)
-        )
+    def test_generates_the_composer_agent(self, kiro_home, no_kiro_cli):
         assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 0
-        assert not composer.exists()
+        composer = kiro_home / "agents" / "sdpm-composer.json"
+        assert composer.exists()
+        data = json.loads(composer.read_text(encoding="utf-8"))
+        assert data == kiro_install._expected_composer_config(REPO_ROOT)
+        # The generated config is a thin pointer: sdpm MCP only, behavior
+        # served from personas/ — never inline.
+        assert set(data["mcpServers"]) == {"sdpm"}
+        assert data["prompt"].startswith("file://")
+        assert data["prompt"].endswith("/personas/composer.md")
+
+    def test_composer_generation_is_idempotent(self, kiro_home, no_kiro_cli):
+        assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 0
+        composer = kiro_home / "agents" / "sdpm-composer.json"
+        first = composer.read_text(encoding="utf-8")
+        assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 0
+        assert composer.read_text(encoding="utf-8") == first
+
+    def test_repairs_a_composer_agent_from_a_moved_checkout(
+        self, kiro_home, no_kiro_cli, tmp_path
+    ):
+        gone = tmp_path / "moved-away"
+        _write_composer(kiro_home / "agents", kiro_install._expected_composer_config(gone))
+
+        assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 0
+        data = json.loads(
+            (kiro_home / "agents" / "sdpm-composer.json").read_text(encoding="utf-8")
+        )
+        assert data == kiro_install._expected_composer_config(REPO_ROOT)
+
+    def test_never_overwrites_a_user_edited_composer_agent(self, kiro_home, no_kiro_cli):
+        cfg = kiro_install._expected_composer_config(REPO_ROOT)
+        cfg["tools"] = ["*"]  # user customisation -> unknown
+        composer = _write_composer(kiro_home / "agents", cfg)
+
+        assert kiro_install.main(["--kiro-home", str(kiro_home), "--mode", "legacy"]) == 1
+        assert json.loads(composer.read_text(encoding="utf-8")) == cfg
 
     def test_registers_mcp_with_this_checkouts_directory(self, kiro_home, monkeypatch):
         calls = []


### PR DESCRIPTION
## Summary

Follow-up to #307. Restores dedicated composer agent generation in `make install-kiro` (legacy mode) — the piece v0.5.3 removed — now that the ownership audit makes generated artifacts safe to manage.

### Why

Compose is a fan-out workload: the orchestrator dispatches up to 10 parallel workers. The persona's self-spawn fallback works, but a general-purpose worker inherits **every MCP server in the user's profile** and cold-starts all of them. Observed in practice on a profile with 30+ registered servers: some parallel workers nondeterministically missed the sdpm server's startup and stopped with "sdpm tools unavailable", while sibling workers in the same wave succeeded.

A dedicated `sdpm-composer` agent eliminates the failure mode structurally rather than by timeout tuning:

- **sdpm MCP server only** — no per-worker cold-start storm, no unrelated tool schemas in worker context
- **120s startup timeout and pre-approved tools** — no approval stalls in workers (the persona already warns about these)
- **No behavior text** — the prompt is a `file://` pointer into `personas/composer.md`, same single-source discipline as the skill entry points

The persona already prefers a registered `sdpm-composer` agent and only falls back to self-spawn when none exists; this PR just makes the preferred path exist by default on Kiro v2. Self-spawn remains the documented fallback for environments without an agent registry.

### Why it was removed, and why it is safe now

v0.5.3 dropped generation because the old installer could not manage the file safely across checkouts (`_is_generated_composer_config` deliberately matched other checkouts' files). #307 replaced that with the own/stale/foreign/unknown ownership audit — the reason for removal no longer holds. Lifecycle here is gated exactly like the MCP registration and skill symlinks:

| Existing file | Action |
|---|---|
| absent | generated |
| own (this checkout, exact generated form) | untouched — idempotent |
| stale (generated for a checkout that no longer exists) | regenerated |
| foreign (another live checkout) | conflict, non-zero exit unless `--replace-existing` |
| unknown (user-edited or unrecognized) | conflict, never overwritten |

Power mode still **removes** an owned config — the Power supersedes all legacy v2 wiring.

### Per-client picture

Kiro v2 was the only client without a dedicated composer:

- **Claude Code**: plugin already bundles one (`clients/claude-code/agents/sdpm-composer.md`) — unchanged
- **Codex / Agent Plugins portable package**: manifests have no `agents` component, so the fallback chain is their path by design — unchanged
- **Kiro v2**: this PR

## Testing

- `uv run ruff check ...` — clean
- `uv run python -m pytest tests/ -q` — **1003 passed, 8 skipped** (main baseline: 1000/8)
- New installer tests: generation on absent, idempotency (byte-identical on re-run), repair from a moved checkout, refusal to overwrite a user-edited config (exit 1); existing foreign-composer conflict and power-mode removal tests still pass
- Generated config asserted to be a thin pointer: `mcpServers == {sdpm}` only, `prompt` is a `file://…/personas/composer.md` reference
- The exact generated form was validated manually on a live MCP-heavy profile: with it, parallel compose workers stopped losing the sdpm server
