### PR TITLE
feat: add scaffold pass to the compose workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Entries before v0.5.0 were written retroactively as summaries.
 
 ### Added
 
+- **Scaffold pass in the compose workflow** — before the parallel content
+  composers fan out, the orchestrator now dispatches one composer with
+  `task_instruction: "Scaffold pass."` (a new composer mode alongside
+  `"Consistency review."`). It writes the shared, content-free decoration
+  (chrome: accent bars, footer, page-number chip, title band) into every
+  `slides/*.json` in a single programmatic `run_python` loop; content
+  composers then read-modify-append instead of rewriting whole files.
+  Cross-slide decoration consistency is guaranteed by construction and
+  identical chrome JSON is no longer re-emitted per slide (token savings).
+  Persona-only change (`personas/composer.md`, `vibe.md`, `spec.md`).
 - **Per-user usage measurement** (#326) — Bedrock usage logs (`bedrock_usage`)
   now carry `user_id` / `session_id` / `deck_id` (composer invocations
   included), and new structured events count slides per user:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ Entries before v0.5.0 were written retroactively as summaries.
 - **Scaffold pass in the compose workflow** — before the parallel content
   composers fan out, the orchestrator now dispatches one composer with
   `task_instruction: "Scaffold pass."` (a new composer mode alongside
-  `"Consistency review."`). It writes the shared, content-free decoration
-  (chrome: accent bars, footer, page-number chip, title band) into every
-  `slides/*.json` in a single programmatic `run_python` loop; content
-  composers then read-modify-append instead of rewriting whole files.
-  Cross-slide decoration consistency is guaranteed by construction and
-  identical chrome JSON is no longer re-emitted per slide (token savings).
+  `"Consistency review."`). It writes the deck's shared visual frame into
+  every `slides/*.json` in a single programmatic `run_python` loop — every
+  element whose structure repeats across slides, identical (accent bars,
+  footer, title band) or parameterized per slide (titles/subtitles drafted
+  from the outline, section labels). Page numbers are explicitly forbidden
+  as elements — they come from the template's native slide-number
+  placeholder. Content composers then read the existing JSON and build on
+  the frame instead of rewriting whole files. Cross-slide decoration
+  consistency moves from post-hoc review fixes to by-construction, and
+  near-identical JSON is no longer re-emitted per slide (token savings).
   Persona-only change (`personas/composer.md`, `vibe.md`, `spec.md`).
 - **Per-user usage measurement** (#326) — Bedrock usage logs (`bedrock_usage`)
   now carry `user_id` / `session_id` / `deck_id` (composer invocations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,20 @@ Entries before v0.5.0 were written retroactively as summaries.
 - **Scaffold pass in the compose workflow** — before the parallel content
   composers fan out, the orchestrator now dispatches one composer with
   `task_instruction: "Scaffold pass."` (a new composer mode alongside
-  `"Consistency review."`). It writes the deck's shared visual frame into
-  every `slides/*.json` in a single programmatic `run_python` loop — every
-  element whose structure repeats across slides, identical (accent bars,
-  footer, title band) or parameterized per slide (titles/subtitles drafted
-  from the outline, section labels). Page numbers are explicitly forbidden
-  as elements — they come from the template's native slide-number
-  placeholder. Content composers then read the existing JSON and build on
-  the frame instead of rewriting whole files. Cross-slide decoration
-  consistency moves from post-hoc review fixes to by-construction, and
-  near-identical JSON is no longer re-emitted per slide (token savings).
-  Persona-only change (`personas/composer.md`, `vibe.md`, `spec.md`).
+  `"Consistency review."`). It batch-writes the style- and role-derived
+  elements every slide shares — decoration from the art direction (accent
+  bars, footer, title band) and role elements with per-slide parameters
+  (titles/subtitles drafted from the outline, section labels) — into every
+  `slides/*.json` via a single programmatic `run_python` for-loop (no
+  individual slide edits in this mode). Elements that require imagining a
+  slide's content stay with the content composers. Page numbers are
+  explicitly forbidden as elements — they come from the template's native
+  slide-number placeholder. Content composers then read the existing JSON
+  and build on the frame instead of rewriting whole files. Cross-slide
+  decoration consistency moves from post-hoc review fixes to
+  by-construction, and near-identical JSON is no longer re-emitted per
+  slide (token savings). Persona-only change (`personas/composer.md`,
+  `vibe.md`, `spec.md`).
 - **Per-user usage measurement** (#326) — Bedrock usage logs (`bedrock_usage`)
   now carry `user_id` / `session_id` / `deck_id` (composer invocations
   included), and new structured events count slides per user:

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -185,18 +185,28 @@ and `ptPerPx` (the pt-to-px conversion rate used for text width budgeting and
 ## Scaffold Pass Mode
 
 If the instruction is `"Scaffold pass."`, you run BEFORE the content composers: you own
-**every** slide in the deck and create the initial `slides/*.json` files containing only
-the shared, content-free decoration ("chrome") — accent bars, footer, page-number chip,
-title band, background accents. Content composers build on top of what you write, so
+**every** slide in the deck and create the initial `slides/*.json` files carrying the
+deck's shared visual frame ("chrome"). This is a **design task, not placeholder
+filling**: you translate the art direction's decoration language into concrete,
+consistently placed elements — accent bars, footer, page-number chip, title band,
+background accents — and the layout foundation they imply (where the title sits, where
+the content area begins). Content composers build on top of what you write, so
 cross-slide decoration stays consistent by construction (deviations are deliberate,
 per-slide decisions on their side).
 
+**Steps 1 and 2 apply in full.** You need the slide JSON schema, the grid math, and
+the component/pattern vocabulary just like a content composer — without them your
+chrome cannot express the style. Read `specs/art-direction.html` especially closely:
+its decoration guidance (shapes, weights, placement principles — not just the `:root`
+tokens) is what you are realizing. Read `specs/brief.md` and `specs/outline.md` for
+tone and slide roles, and `deck.json` for `slideSize`.
+
 Procedure:
 
-1. Read `specs/outline.md`, `specs/art-direction.html` (design tokens + decoration
-   language), and `deck.json` (`slideSize`).
-2. Decide the chrome per slide role (e.g. title / section divider / content). Slides
-   with the same role get IDENTICAL chrome — same element types, coordinates, tokens.
+1. Complete Step 1 (references) and Step 2 (context) as usual.
+2. Design the chrome per slide role (e.g. title / section divider / content), derived
+   from the style's decoration language. Slides with the same role get IDENTICAL
+   chrome — same element types, coordinates, tokens.
 3. **Override groups**: slugs sharing a prefix (e.g. `demo-1`, `demo-2`) are built with
    override inheritance by their composer — write chrome ONLY to the first slug of the
    group and do NOT create files for the derived slugs (they inherit the base's
@@ -224,9 +234,9 @@ Procedure:
    )
    ```
 
-5. Check the returned previews for the representative slugs — chrome must stay out of
-   the content area (y = title bottom + margin to H−130) and match the style's
-   decoration language.
+5. Check the returned previews for the representative slugs — judge them as designs:
+   does the chrome express the style's decoration language? Does it stay out of the
+   content area (y = title bottom + margin to H−130)? Iterate until it does.
 
 Constraints:
 - Chrome only — do NOT write content elements (body text, diagrams, charts, images).

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -189,10 +189,9 @@ and `ptPerPx` (the pt-to-px conversion rate used for text width budgeting and
 
 If the instruction is `"Scaffold pass."`, you run BEFORE the content composers: you own
 **every** slide in the deck and MUST create an initial `slides/{slug}.json` for **every
-assigned slug** (sole exception: derived slugs of override groups — see Procedure 3),
-each carrying the deck's shared visual frame ("chrome"). This is a **design task, not
-placeholder filling**: you translate the art direction's decoration language into
-concrete,
+assigned slug**, each carrying the deck's shared visual frame ("chrome"). This is a
+**design task, not placeholder filling**: you translate the art direction's decoration
+language into concrete,
 consistently placed elements — accent bars, footer, title band,
 background accents — and the layout foundation they imply (where the title sits, where
 the content area begins). Content composers build on top of what you write, so
@@ -227,11 +226,7 @@ Procedure:
    - **Page numbers are PROHIBITED as elements** — never draw them as
      textbox/shape objects. Slide numbering is a native PowerPoint feature and
      comes from the template's slide-number placeholder.
-3. **Override groups**: slugs sharing a prefix (e.g. `demo-1`, `demo-2`) are built with
-   override inheritance by their composer — write chrome ONLY to the first slug of the
-   group and do NOT create files for the derived slugs (they inherit the base's
-   elements; writing chrome to them would draw it twice).
-4. Write all target slides in ONE `run_python` call using a Python loop — this is the
+3. Write all target slides in ONE `run_python` call using a Python loop — this is the
    explicit exception to the per-slide write rule (the loop code is small, so there is
    no output-truncation risk; emitting near-identical JSON once per slide is exactly
    the waste this mode exists to avoid):
@@ -260,23 +255,22 @@ Procedure:
 
    Titles may also go through the template's `layout` + `placeholders` instead of
    explicit elements — follow whichever the style/template calls for.
-   The `plan` list MUST cover every assigned slug (minus skipped override-derived
-   slugs). A slide whose role has little shared structure still gets its file —
-   with whatever minimal frame its role defines.
+   The `plan` list MUST cover every assigned slug. A slide whose role has little
+   shared structure still gets its file — with whatever minimal frame its role
+   defines.
 
-5. **Completeness check (MANDATORY)**: run `list_files("slides")` and verify a
-   `{slug}.json` exists for every assigned slug (minus skipped override-derived
-   slugs). If any are missing, write them before proceeding.
+4. **Completeness check (MANDATORY)**: run `list_files("slides")` and verify a
+   `{slug}.json` exists for every assigned slug. If any are missing, write them
+   before proceeding.
 
-6. Check the returned previews for the representative slugs — judge them as designs:
+5. Check the returned previews for the representative slugs — judge them as designs:
    does the frame express the style's decoration language? Do the longest titles fit?
    Does it stay out of the content area (y = title bottom + margin to H−130)?
    Iterate until it does.
 
 Constraints:
-- Create a file for EVERY assigned slug (sole exception: derived slugs of override
-  groups). Scaffolding only "the slides with common elements" is a failure mode —
-  content composers rely on every file existing.
+- Create a file for EVERY assigned slug. Scaffolding only "the slides with common
+  elements" is a failure mode — content composers rely on every file existing.
 - Shared frame only — do NOT write slide-specific body content (body text, diagrams,
   charts, images unique to one slide). Anything whose structure repeats across slides
   is fair game, identical or parameterized.
@@ -286,8 +280,8 @@ Constraints:
   style's `:root`.
 - Do NOT continue into content composition — scaffold, verify, return.
 
-Return: which slugs you scaffolded (element count each), which derived slugs you
-skipped and why, and anything content composers must know (e.g. reserved regions).
+Return: which slugs you scaffolded (element count each) and anything content
+composers must know (e.g. reserved regions).
 
 ## Consistency Review Mode
 

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -100,8 +100,11 @@ sandbox use `read_json` / `read_text` / `list_files`; `open()` is blocked.
 
 If `slides/{slug}.json` ALREADY EXISTS when you start (a scaffold pass ran before you),
 read it before writing — never write a fresh object blind. Its elements are the deck's
-shared chrome (decoration written identically across slides). In the common case, keep
-them as-is and append your content:
+shared frame: everything whose structure repeats across slides — decoration placed
+consistently, plus parameterized common elements (a drafted title, a section label,
+etc.). In the common case, keep them as-is and append your content (refining drafted
+text such as title wording to match your composed content is fine — keep the structure
+and style):
 
 ```
 run_python(
@@ -188,7 +191,7 @@ If the instruction is `"Scaffold pass."`, you run BEFORE the content composers: 
 **every** slide in the deck and create the initial `slides/*.json` files carrying the
 deck's shared visual frame ("chrome"). This is a **design task, not placeholder
 filling**: you translate the art direction's decoration language into concrete,
-consistently placed elements — accent bars, footer, page-number chip, title band,
+consistently placed elements — accent bars, footer, title band,
 background accents — and the layout foundation they imply (where the title sits, where
 the content area begins). Content composers build on top of what you write, so
 cross-slide decoration stays consistent by construction (deviations are deliberate,
@@ -204,42 +207,67 @@ tone and slide roles, and `deck.json` for `slideSize`.
 Procedure:
 
 1. Complete Step 1 (references) and Step 2 (context) as usual.
-2. Design the chrome per slide role (e.g. title / section divider / content), derived
-   from the style's decoration language. Slides with the same role get IDENTICAL
-   chrome — same element types, coordinates, tokens.
+2. Design the shared frame per slide role (e.g. title / section divider / content),
+   derived from the style's decoration language. **The test for what belongs in the
+   scaffold is commonality, not element kind**: if the same structure repeats across
+   slides, the scaffold places it — decoration, layout framework, or text alike.
+   Two degrees of commonality:
+   - **Identical** — same element, same coordinates, same tokens on every slide of
+     the role (e.g. accent bars, footer, background accents).
+   - **Parameterized** — same structure, style, and coordinates with per-slide
+     values (e.g. a title/subtitle drafted from the outline's message, a section
+     label, a recurring decorative motif that varies by section color). Content
+     differing while structure repeats is not a reason to leave it to the content
+     composers — placing it once programmatically is faster and more consistent
+     than letting each composer re-derive it.
+   - **Page numbers are PROHIBITED as elements** — never draw them as
+     textbox/shape objects. Slide numbering is a native PowerPoint feature and
+     comes from the template's slide-number placeholder.
 3. **Override groups**: slugs sharing a prefix (e.g. `demo-1`, `demo-2`) are built with
    override inheritance by their composer — write chrome ONLY to the first slug of the
    group and do NOT create files for the derived slugs (they inherit the base's
    elements; writing chrome to them would draw it twice).
 4. Write all target slides in ONE `run_python` call using a Python loop — this is the
    explicit exception to the per-slide write rule (the loop code is small, so there is
-   no output-truncation risk; emitting identical JSON once per slide is exactly the
-   waste this mode exists to avoid):
+   no output-truncation risk; emitting near-identical JSON once per slide is exactly
+   the waste this mode exists to avoid):
 
    ```
    run_python(
-     purpose="scaffold chrome across all slides",
+     purpose="scaffold chrome and common elements across all slides",
      code='''
    chrome = {
      "title":   [ ...elements... ],
      "section": [ ...elements... ],
      "content": [ ...elements... ],
    }
-   roles = [("intro", "title"), ("agenda", "content"), ...]  # per outline
-   for slug, role in roles:
-       write_json(f"slides/{slug}.json", {"notes": "", "elements": list(chrome[role])})
+   def common(title, subtitle):
+       return [ ...same structure, parameterized text... ]
+   # per outline: (slug, role, title, subtitle)
+   plan = [("intro", "title", "...", "..."), ("agenda", "content", "...", "..."), ...]
+   for slug, role, title, subtitle in plan:
+       write_json(f"slides/{slug}.json",
+                  {"notes": "", "elements": list(chrome[role]) + common(title, subtitle)})
    ''',
      deck_id="<absolute deck path>",
      measure_slides=["<one representative slug per role>"],
    )
    ```
 
+   Titles may also go through the template's `layout` + `placeholders` instead of
+   explicit elements — follow whichever the style/template calls for.
+
 5. Check the returned previews for the representative slugs — judge them as designs:
-   does the chrome express the style's decoration language? Does it stay out of the
-   content area (y = title bottom + margin to H−130)? Iterate until it does.
+   does the frame express the style's decoration language? Do the longest titles fit?
+   Does it stay out of the content area (y = title bottom + margin to H−130)?
+   Iterate until it does.
 
 Constraints:
-- Chrome only — do NOT write content elements (body text, diagrams, charts, images).
+- Shared frame only — do NOT write slide-specific body content (body text, diagrams,
+  charts, images unique to one slide). Anything whose structure repeats across slides
+  is fair game, identical or parameterized.
+- Never draw page numbers as elements — they come from the template's native
+  slide-number placeholder.
 - Token discipline applies as always — every fontSize / hex color from the active
   style's `:root`.
 - Do NOT continue into content composition — scaffold, verify, return.

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -209,25 +209,26 @@ Procedure:
 
 1. Complete Step 1 (references) and Step 2 (context) as usual.
 2. Design the shared frame per slide role (e.g. title / section divider / content),
-   derived from the style's decoration language. **The test for what belongs in the
-   scaffold is commonality, not element kind**: if the same structure repeats across
-   slides, the scaffold places it — decoration, layout framework, or text alike.
-   Commonality decides which ELEMENTS the scaffold owns — NEVER which slides get a
-   file: every slide gets one, even if its role's frame is minimal.
-   Two degrees of commonality:
+   derived from the style's decoration language. **The scaffold owns exactly the
+   elements derivable from the STYLE and the slide's ROLE alone**: decoration from
+   the art direction, and role elements every slide necessarily has (title band,
+   subtitle, section label). The test: if you must imagine a slide's CONTENT to
+   decide an element's structure or placement, it is NOT scaffold material — leave
+   it to the content composers.
+   Scaffold elements come in two degrees:
    - **Identical** — same element, same coordinates, same tokens on every slide of
      the role (e.g. accent bars, footer, background accents).
    - **Parameterized** — same structure, style, and coordinates with per-slide
      values (e.g. a title/subtitle drafted from the outline's message, a section
-     label, a recurring decorative motif that varies by section color). Content
-     differing while structure repeats is not a reason to leave it to the content
-     composers — placing it once programmatically is faster and more consistent
-     than letting each composer re-derive it.
-   - **Page numbers are PROHIBITED as elements** — never draw them as
-     textbox/shape objects. Slide numbering is a native PowerPoint feature and
-     comes from the template's slide-number placeholder.
-3. Write all target slides in ONE `run_python` call using a Python loop — this is the
-   explicit exception to the per-slide write rule (the loop code is small, so there is
+     label, a motif colored per section).
+   Either way, this decides which ELEMENTS the scaffold owns — NEVER which slides
+   get a file: every slide gets one, even if its role's frame is minimal.
+   **Page numbers are PROHIBITED as elements** — never draw them as
+   textbox/shape objects. Slide numbering is a native PowerPoint feature and
+   comes from the template's slide-number placeholder.
+3. Write ALL slides in ONE `run_python` call using a **Python for loop — always**.
+   Never write or edit slides individually in this mode. This is the explicit
+   exception to the per-slide write rule (the loop code is small, so there is
    no output-truncation risk; emitting near-identical JSON once per slide is exactly
    the waste this mode exists to avoid):
 
@@ -266,14 +267,17 @@ Procedure:
 5. Check the returned previews for the representative slugs — judge them as designs:
    does the frame express the style's decoration language? Do the longest titles fit?
    Does it stay out of the content area (y = title bottom + margin to H−130)?
-   Iterate until it does.
+   If not, fix the `chrome` / `plan` definitions and **re-run the batch loop** —
+   never patch individual slides.
 
 Constraints:
 - Create a file for EVERY assigned slug. Scaffolding only "the slides with common
   elements" is a failure mode — content composers rely on every file existing.
+- Batch only — every write goes through the Python for loop over the full plan.
+  Individual slide edits do not exist in this mode.
 - Shared frame only — do NOT write slide-specific body content (body text, diagrams,
-  charts, images unique to one slide). Anything whose structure repeats across slides
-  is fair game, identical or parameterized.
+  charts, images unique to one slide). If deciding an element requires imagining a
+  slide's content, it belongs to the content composers, not you.
 - Never draw page numbers as elements — they come from the template's native
   slide-number placeholder.
 - Token discipline applies as always — every fontSize / hex color from the active

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -18,7 +18,8 @@ Do NOT advance to Phase 3 (review). Do NOT ask the user anything.
 The orchestrator passes you:
 - **deck_id**: absolute path to the deck directory (contains `deck.json`, `specs/`, `slides/`)
 - **assigned slide slugs**: exactly which slides you own and must build
-- **task_instruction**: what to do with them — initial compose, `"Consistency review."`
+- **task_instruction**: what to do with them — initial compose, `"Scaffold pass."`
+  (see Scaffold Pass Mode below), `"Consistency review."`
   (see Consistency Review Mode below), or a targeted fix request
 
 You write ONLY your assigned slugs. Other slugs belong to sibling composers running in
@@ -95,10 +96,38 @@ the slugs you measured. Do not write deck files through any other mechanism (no
 client-native Write/Edit) — `run_python` must stay the single writer. Inside the
 sandbox use `read_json` / `read_text` / `list_files`; `open()` is blocked.
 
+### Scaffolded slides — read first, build on the chrome
+
+If `slides/{slug}.json` ALREADY EXISTS when you start (a scaffold pass ran before you),
+read it before writing — never write a fresh object blind. Its elements are the deck's
+shared chrome (decoration written identically across slides). In the common case, keep
+them as-is and append your content:
+
+```
+run_python(
+  purpose="append content to scaffolded slide '{slug}'",
+  code='''
+data = read_json("slides/{slug}.json")
+data["notes"] = "..."
+data["elements"] += [ ... ]   # your content elements, per slide-json-spec
+write_json("slides/{slug}.json", data)
+''',
+  deck_id="<absolute deck path>",
+  measure_slides=["{slug}"],
+)
+```
+
+Consistency is the chrome's whole point — keep it by default and lay your content out
+around it (it already occupies space — check the preview). If this slide's design
+genuinely requires deviating (e.g. a full-bleed visual the chrome would break), you may
+adjust or drop individual chrome elements — do it deliberately, and note the deviation
+in your summary so the consistency review can weigh it.
+
 ### Per-slide write loop (MANDATORY)
 
 Write **one slide at a time** — never batch-write multiple `slides/*.json` in a
-single call (risks output truncation). Per slug:
+single call (risks output truncation). The only exception is Scaffold Pass Mode
+(see below), which writes identical chrome via a small programmatic loop. Per slug:
 
 **write → `run_python(measure_slides=["{slug}"])` → inspect returned
 `preview_files` + `warnings` → fix if needed → next slug.**
@@ -152,6 +181,61 @@ and `ptPerPx` (the pt-to-px conversion rate used for text width budgeting and
 - For 16:9 (H=1080, ptPerPx=0.5): y=173–950. For 4:3 (H=1440, ptPerPx=0.375): y=173–1310
 - Never assume H=1080 — derive from `slideSize`
 - Pass `slideSize.ptPerPx` to `arch_diagram` as `pt_per_px` for correct box sizing
+
+## Scaffold Pass Mode
+
+If the instruction is `"Scaffold pass."`, you run BEFORE the content composers: you own
+**every** slide in the deck and create the initial `slides/*.json` files containing only
+the shared, content-free decoration ("chrome") — accent bars, footer, page-number chip,
+title band, background accents. Content composers build on top of what you write, so
+cross-slide decoration stays consistent by construction (deviations are deliberate,
+per-slide decisions on their side).
+
+Procedure:
+
+1. Read `specs/outline.md`, `specs/art-direction.html` (design tokens + decoration
+   language), and `deck.json` (`slideSize`).
+2. Decide the chrome per slide role (e.g. title / section divider / content). Slides
+   with the same role get IDENTICAL chrome — same element types, coordinates, tokens.
+3. **Override groups**: slugs sharing a prefix (e.g. `demo-1`, `demo-2`) are built with
+   override inheritance by their composer — write chrome ONLY to the first slug of the
+   group and do NOT create files for the derived slugs (they inherit the base's
+   elements; writing chrome to them would draw it twice).
+4. Write all target slides in ONE `run_python` call using a Python loop — this is the
+   explicit exception to the per-slide write rule (the loop code is small, so there is
+   no output-truncation risk; emitting identical JSON once per slide is exactly the
+   waste this mode exists to avoid):
+
+   ```
+   run_python(
+     purpose="scaffold chrome across all slides",
+     code='''
+   chrome = {
+     "title":   [ ...elements... ],
+     "section": [ ...elements... ],
+     "content": [ ...elements... ],
+   }
+   roles = [("intro", "title"), ("agenda", "content"), ...]  # per outline
+   for slug, role in roles:
+       write_json(f"slides/{slug}.json", {"notes": "", "elements": list(chrome[role])})
+   ''',
+     deck_id="<absolute deck path>",
+     measure_slides=["<one representative slug per role>"],
+   )
+   ```
+
+5. Check the returned previews for the representative slugs — chrome must stay out of
+   the content area (y = title bottom + margin to H−130) and match the style's
+   decoration language.
+
+Constraints:
+- Chrome only — do NOT write content elements (body text, diagrams, charts, images).
+- Token discipline applies as always — every fontSize / hex color from the active
+  style's `:root`.
+- Do NOT continue into content composition — scaffold, verify, return.
+
+Return: which slugs you scaffolded (element count each), which derived slugs you
+skipped and why, and anything content composers must know (e.g. reserved regions).
 
 ## Consistency Review Mode
 

--- a/personas/composer.md
+++ b/personas/composer.md
@@ -188,9 +188,11 @@ and `ptPerPx` (the pt-to-px conversion rate used for text width budgeting and
 ## Scaffold Pass Mode
 
 If the instruction is `"Scaffold pass."`, you run BEFORE the content composers: you own
-**every** slide in the deck and create the initial `slides/*.json` files carrying the
-deck's shared visual frame ("chrome"). This is a **design task, not placeholder
-filling**: you translate the art direction's decoration language into concrete,
+**every** slide in the deck and MUST create an initial `slides/{slug}.json` for **every
+assigned slug** (sole exception: derived slugs of override groups — see Procedure 3),
+each carrying the deck's shared visual frame ("chrome"). This is a **design task, not
+placeholder filling**: you translate the art direction's decoration language into
+concrete,
 consistently placed elements — accent bars, footer, title band,
 background accents — and the layout foundation they imply (where the title sits, where
 the content area begins). Content composers build on top of what you write, so
@@ -211,6 +213,8 @@ Procedure:
    derived from the style's decoration language. **The test for what belongs in the
    scaffold is commonality, not element kind**: if the same structure repeats across
    slides, the scaffold places it — decoration, layout framework, or text alike.
+   Commonality decides which ELEMENTS the scaffold owns — NEVER which slides get a
+   file: every slide gets one, even if its role's frame is minimal.
    Two degrees of commonality:
    - **Identical** — same element, same coordinates, same tokens on every slide of
      the role (e.g. accent bars, footer, background accents).
@@ -256,13 +260,23 @@ Procedure:
 
    Titles may also go through the template's `layout` + `placeholders` instead of
    explicit elements — follow whichever the style/template calls for.
+   The `plan` list MUST cover every assigned slug (minus skipped override-derived
+   slugs). A slide whose role has little shared structure still gets its file —
+   with whatever minimal frame its role defines.
 
-5. Check the returned previews for the representative slugs — judge them as designs:
+5. **Completeness check (MANDATORY)**: run `list_files("slides")` and verify a
+   `{slug}.json` exists for every assigned slug (minus skipped override-derived
+   slugs). If any are missing, write them before proceeding.
+
+6. Check the returned previews for the representative slugs — judge them as designs:
    does the frame express the style's decoration language? Do the longest titles fit?
    Does it stay out of the content area (y = title bottom + margin to H−130)?
    Iterate until it does.
 
 Constraints:
+- Create a file for EVERY assigned slug (sole exception: derived slugs of override
+  groups). Scaffolding only "the slides with common elements" is a failure mode —
+  content composers rely on every file existing.
 - Shared frame only — do NOT write slide-specific body content (body text, diagrams,
   charts, images unique to one slide). Anything whose structure repeats across slides
   is fair game, identical or parameterized.

--- a/personas/spec.md
+++ b/personas/spec.md
@@ -129,10 +129,10 @@ When all 3 spec files are approved (new-deck flow) OR when the guide's Step 5 co
 (edit branch), delegate in two steps:
 
 **First — Scaffold pass (serial):** dispatch ONE composer with ALL slugs and
-task_instruction exactly `Scaffold pass.` — it writes the deck's shared visual frame
-(every element whose structure repeats across slides — decoration, drafted titles,
-etc.) into the initial `slides/*.json` so parallel composers start from a consistent
-base and focus on content. Use the same dispatch mechanism as below.
+task_instruction exactly `Scaffold pass.` — it batch-writes the style- and
+role-derived elements every slide shares (decoration, title bands, etc.) into the
+initial `slides/*.json` so parallel composers start from a consistent base and focus
+on content. Use the same dispatch mechanism as below.
 Wait for it to finish before dispatching content composers.
 
 **Then — Content compose (parallel):** split slides into groups (see **Slide Group

--- a/personas/spec.md
+++ b/personas/spec.md
@@ -126,8 +126,16 @@ For PPTX files specifically:
 ## Delegation to Composer
 
 When all 3 spec files are approved (new-deck flow) OR when the guide's Step 5 completes
-(edit branch), split slides into groups (see **Slide Group Assignment**) and dispatch,
-checking your tool list in this order:
+(edit branch), delegate in two steps:
+
+**First — Scaffold pass (serial):** dispatch ONE composer with ALL slugs and
+task_instruction exactly `Scaffold pass.` — it writes the shared, content-free
+decoration (chrome) into the initial `slides/*.json` so parallel composers start from a
+consistent base and only append content. Use the same dispatch mechanism as below.
+Wait for it to finish before dispatching content composers.
+
+**Then — Content compose (parallel):** split slides into groups (see **Slide Group
+Assignment**) and dispatch, checking your tool list in this order:
 
 1. **A `compose_slides` tool exists** → call
    `compose_slides(deck_id=..., slide_groups=[...])` and let the backend parallelize.
@@ -164,6 +172,8 @@ STEP") and load the composer behavior with `mode="composer"`; dedicated
 composer agents already carry it. Do not add instructions to the template.
 
 `{deck_id}` is the absolute deck path. `{task_instruction}` values:
+- Scaffold pass (assign ALL slugs, before content compose): `Scaffold pass.` — exactly
+  this string; it switches the composer's mode.
 - Initial compose: `Compose the assigned slides from the approved specs.`
 - Consistency review (assign ALL slugs): `Consistency review.` — exactly this string;
   it switches the composer's mode.

--- a/personas/spec.md
+++ b/personas/spec.md
@@ -129,9 +129,10 @@ When all 3 spec files are approved (new-deck flow) OR when the guide's Step 5 co
 (edit branch), delegate in two steps:
 
 **First — Scaffold pass (serial):** dispatch ONE composer with ALL slugs and
-task_instruction exactly `Scaffold pass.` — it writes the shared, content-free
-decoration (chrome) into the initial `slides/*.json` so parallel composers start from a
-consistent base and only append content. Use the same dispatch mechanism as below.
+task_instruction exactly `Scaffold pass.` — it writes the deck's shared visual frame
+(every element whose structure repeats across slides — decoration, drafted titles,
+etc.) into the initial `slides/*.json` so parallel composers start from a consistent
+base and focus on content. Use the same dispatch mechanism as below.
 Wait for it to finish before dispatching content composers.
 
 **Then — Content compose (parallel):** split slides into groups (see **Slide Group

--- a/personas/vibe.md
+++ b/personas/vibe.md
@@ -117,8 +117,16 @@ After Step 5, **`specs/art-direction.html` and `deck.json` are FROZEN.**
 
 Prerequisite: Steps 2–5 complete.
 
-Split slides into groups (see **Slide Group Assignment**), then dispatch depending on
-what your environment provides — check your tool list in this order:
+**Step 6a — Scaffold pass (serial, run first):** dispatch ONE composer with ALL slugs
+and task_instruction exactly `Scaffold pass.` — it writes the shared, content-free
+decoration (chrome) into the initial `slides/*.json` so parallel composers start from a
+consistent base and only append content. Use the same dispatch mechanism as Step 6b
+below (whichever your environment provides). Wait for it to finish before dispatching
+content composers.
+
+**Step 6b — Content compose (parallel):** split slides into groups (see **Slide Group
+Assignment**), then dispatch depending on what your environment provides — check your
+tool list in this order:
 
 1. **A `compose_slides` tool exists** → call
    `compose_slides(deck_id=..., slide_groups=[...])` and let the backend parallelize.
@@ -156,6 +164,8 @@ STEP") and load the composer behavior with `mode="composer"`; dedicated
 composer agents already carry it. Do not add instructions to the template.
 
 `{deck_id}` is the absolute deck path. `{task_instruction}` values:
+- Scaffold pass (assign ALL slugs, before content compose): `Scaffold pass.` — exactly
+  this string; it switches the composer's mode.
 - Initial compose: `Compose the assigned slides from the approved specs.`
 - Consistency review (assign ALL slugs): `Consistency review.` — exactly this string;
   it switches the composer's mode.

--- a/personas/vibe.md
+++ b/personas/vibe.md
@@ -118,10 +118,10 @@ After Step 5, **`specs/art-direction.html` and `deck.json` are FROZEN.**
 Prerequisite: Steps 2–5 complete.
 
 **Step 6a — Scaffold pass (serial, run first):** dispatch ONE composer with ALL slugs
-and task_instruction exactly `Scaffold pass.` — it writes the deck's shared visual
-frame (every element whose structure repeats across slides — decoration, drafted
-titles, etc.) into the initial `slides/*.json` so parallel composers start from a
-consistent base and focus on content. Use the same dispatch mechanism as Step 6b
+and task_instruction exactly `Scaffold pass.` — it batch-writes the style- and
+role-derived elements every slide shares (decoration, title bands, etc.) into the
+initial `slides/*.json` so parallel composers start from a consistent base and focus
+on content. Use the same dispatch mechanism as Step 6b
 below (whichever your environment provides). Wait for it to finish before dispatching
 content composers.
 

--- a/personas/vibe.md
+++ b/personas/vibe.md
@@ -118,9 +118,10 @@ After Step 5, **`specs/art-direction.html` and `deck.json` are FROZEN.**
 Prerequisite: Steps 2–5 complete.
 
 **Step 6a — Scaffold pass (serial, run first):** dispatch ONE composer with ALL slugs
-and task_instruction exactly `Scaffold pass.` — it writes the shared, content-free
-decoration (chrome) into the initial `slides/*.json` so parallel composers start from a
-consistent base and only append content. Use the same dispatch mechanism as Step 6b
+and task_instruction exactly `Scaffold pass.` — it writes the deck's shared visual
+frame (every element whose structure repeats across slides — decoration, drafted
+titles, etc.) into the initial `slides/*.json` so parallel composers start from a
+consistent base and focus on content. Use the same dispatch mechanism as Step 6b
 below (whichever your environment provides). Wait for it to finish before dispatching
 content composers.
 


### PR DESCRIPTION
## Summary

Adds a **scaffold pass** to the compose workflow: before the parallel content composers fan out, the orchestrator dispatches one composer with `task_instruction: "Scaffold pass."` — a new composer mode alongside `"Consistency review."` (same fixed-string switch mechanism, no new persona file, no client wiring).

The scaffold composer owns every slide and **batch-writes the style- and role-derived elements every slide shares** into the initial `slides/*.json` via a single programmatic `run_python` for-loop:

- **Style-derived** (identical per role): decoration realizing the art direction — accent bars, footer, background accents
- **Role-derived** (parameterized per slide): title band / subtitle drafted from the outline, section labels

The decision test is deliberately narrow: **if deciding an element requires imagining a slide's content, it is not scaffold material** — content-derived shared structures stay with the content composers (already covered by slide group assignment). Content composers then read the existing JSON and build on the frame (keep + append by default; deliberate deviations reported for the consistency review).

## Why

- **Consistency by construction**: style-dependent decoration used to drift between parallel composers (no information sharing) and was fixed post-hoc by the consistency review. The scaffold makes it consistent at creation time.
- **Token savings**: near-identical chrome JSON is no longer re-emitted per slide by each composer; the scaffold writes it once via a Python loop, and composers append instead of rewriting whole files.

## Design points

- Scaffolding is a **design task, not placeholder filling** — Steps 1–2 (references + context) apply in full; the composer realizes the art direction's decoration language
- **Completeness invariant**: a file for EVERY assigned slug + mandatory `list_files` check (a field test caught a run that scaffolded only 2 slides)
- **Batch only**: all writes go through the for-loop; individual slide edits do not exist in this mode — preview issues are fixed by adjusting the chrome/plan definitions and re-running the loop
- **Page numbers are prohibited as elements** — they come from the template's native slide-number placeholder
- Persona-only change: `personas/composer.md`, `vibe.md`, `spec.md` (+ CHANGELOG). No engine/server/client changes — `compose_slides` passes `task_instruction` through

## Tested

- `make all` (ruff + 1022 unit tests) green on every commit
- Deployed to the dev stack (SdpmRuntime) and exercised end-to-end via the Web UI; the completeness invariant and the narrowed style/role scope both came out of field-test iterations